### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/ETFA/ETFA-ai-review.html
+++ b/genes/human/ETFA/ETFA-ai-review.html
@@ -1,0 +1,5651 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ETFA - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ETFA</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P13804" target="_blank" class="term-link">
+                        P13804
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ETFA";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P13804" data-a="DESCRIPTION: ETFA is the alpha subunit of the electron-transfer..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ETFA is the alpha subunit of the electron-transfer flavoprotein (ETF), a soluble FAD-containing heterodimer of ETFA and ETFB that resides in the mitochondrial matrix (on the matrix face of the inner membrane). ETF is the common electron acceptor for at least a dozen mitochondrial FAD-dependent primary dehydrogenases, including the chain-length-specific acyl-CoA dehydrogenases of fatty-acid beta-oxidation (e.g. ACADM/MCAD, ACADVL) and dehydrogenases of amino-acid catabolism (IVD, glutaryl-CoA dehydrogenase GCDH) as well as sarcosine/dimethylglycine dehydrogenases of choline degradation. ETF accepts reducing equivalents from these dehydrogenases, storing them transiently on its single bound FAD, and passes the electrons to ETF-ubiquinone oxidoreductase (ETFDH / ETF-QO), which reduces the ubiquinone pool and thereby funnels the electrons into the mitochondrial respiratory chain. The heterodimer binds one FAD and one AMP per dimer; most of the FAD is coordinated by the C-terminal domain of the alpha subunit. ETF is thus the third major electron feeder to the respiratory chain after complexes I and II, and is required for normal mitochondrial fatty acid oxidation and amino acid metabolism. Biallelic loss-of-function of ETFA (or ETFB or ETFDH) causes multiple acyl-CoA dehydrogenase deficiency (MADD) / glutaric acidemia type II.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) localization of ETFA to the mitochondrion. Correct but general; ETF acts specifically in the mitochondrial matrix, which is separately and more precisely annotated (GO:0005759).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The compartment is correct, but &#34;mitochondrion&#34; is the broad parent of the more specific and better-supported &#34;mitochondrial matrix&#34; location. Retained as non-core context; the matrix annotation is preferred as the core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8617498" target="_blank" class="term-link">
+                                        PMID:8617498
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">obligatory electron acceptor for several dehydrogenases and is located in the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0009055" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of electron transfer activity, the core molecular function of ETF: it accepts electrons from primary flavoprotein dehydrogenases and passes them to ETFDH. Well supported experimentally and by the phylogeny of the ETF alpha/FixB family.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the central, defining molecular function of the ETF alpha subunit and is concordant with the direct experimental annotations (PMID:9334218, PMID:10423253) and the UniProt FUNCTION statement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10423253" target="_blank" class="term-link">
+                                        PMID:10423253
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">serves as an intermediate electron carrier</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033539" target="_blank" class="term-link">
+                                    GO:0033539
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid beta-oxidation using acyl-CoA dehydrogenase</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0033539" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment linking ETF to fatty-acid beta-oxidation. ETF is the obligate electron acceptor for the chain-length-specific acyl-CoA dehydrogenases of the beta-oxidation spiral, so its activity is required for flux through this pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strongly supported: ETF accepts electrons from the beta-oxidation acyl-CoA dehydrogenases, and this term is also directly annotated (IDA, PMID:25416781). Loss of ETFA causes a functional block in fatty-acid beta-oxidation (MADD).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9334218" target="_blank" class="term-link">
+                                        PMID:9334218
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Among these dehydrogenases are the four chain</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Some of these dehydrogenases, e.g. medium chain acyl-CoA dehydrogenase (MCAD), are involved in β-oxidation of fatty acids</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050660" target="_blank" class="term-link">
+                                    GO:0050660
+                                </a>
+                            </span>
+                            <span class="term-label">flavin adenine dinucleotide binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0050660" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of FAD binding. ETF carries a single FAD per heterodimer, most of which is coordinated by the alpha subunit; FAD is the redox cofactor that transiently stores the transferred electrons.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cofactor-binding function of ETFA, corroborated by direct experimental annotations (IDA, PMID:9334218, PMID:10423253) and by the crystallographically defined FAD-binding residues on the alpha subunit in UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link">
+                                        PMID:8962055
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">most of the FAD molecule residing in the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005739" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) localization to the mitochondrion. Correct but general relative to the experimentally supported mitochondrial matrix location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Compartment is correct; broader than the specific matrix annotation. Retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (UniProt Subcellular Location keyword mapping) placing ETFA in the mitochondrial matrix, the compartment where ETF operates.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimentally determined subcellular location (IDA, PMID:3760196; NAS, PMID:8504797) and with the biology of ETF as a matrix electron shuttle.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8617498" target="_blank" class="term-link">
+                                        PMID:8617498
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">obligatory electron acceptor for several dehydrogenases and is located in the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0009055" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro2GO, IPR001308 ETF alpha/FixB) assignment of electron transfer activity, the core molecular function of the ETF alpha subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro family (ETF alpha/FixB) maps correctly to electron transfer activity, in agreement with the direct experimental and phylogenetic annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10423253" target="_blank" class="term-link">
+                                        PMID:10423253
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">serves as an intermediate electron carrier</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050660" target="_blank" class="term-link">
+                                    GO:0050660
+                                </a>
+                            </span>
+                            <span class="term-label">flavin adenine dinucleotide binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0050660" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro2GO, IPR001308) assignment of FAD binding, the redox cofactor carried by the alpha subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct InterPro-to-GO mapping for the ETF alpha/FixB family; concordant with direct experimental FAD-binding annotations and the crystallographic FAD-binding residues.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link">
+                                        PMID:8962055
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">most of the FAD molecule residing in the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24606901" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24606901
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cochaperone binding to LYR motifs confers specificity of iro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005515" data-r="PMID:24606901" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated binary interaction (with HSCB, Q8IWL3) captured as the uninformative term &#34;protein binding&#34;. Derived from a study of the Fe-S cluster cochaperone HSC20/HSCB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;protein binding&#34; (GO:0005515) is not an informative molecular function and does not document ETFA&#39;s role. The interaction is not further pursued in this HSC20-focused study; per curation policy this bare IPI is marked as over-annotated rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24606901" target="_blank" class="term-link">
+                                        PMID:24606901
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LYR motifs</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26618866" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26618866
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    ∆F508 CFTR interactome remodelling promotes rescue of cystic...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005515" data-r="PMID:26618866" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated binary interaction (with CFTR, P13569) from a large-scale CFTR-interactome remodelling study, captured as the uninformative term &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; from a high-throughput interactome dataset; not an informative molecular function for ETFA and no dedicated functional follow-up. Marked as over-annotated per policy.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27499296" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27499296
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial Protein Interaction Mapping Identifies Regulat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005515" data-r="PMID:27499296" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction (with ETFB, P38117) from the mitochondrial protein interaction map that identified LYRM5/ETFRF1 as a &#34;deflavinase&#34; directly regulating ETF. Captured only as the generic term &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The underlying interaction is biologically real and meaningful (ETF is directly regulated by LYRM5/ETFRF1, and ETFA obligately partners ETFB), but the GO term &#34;protein binding&#34; is uninformative. The functional relationships are better captured by the ETF-complex (GO:0045251) and electron-transfer annotations; the bare IPI is over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27499296" target="_blank" class="term-link">
+                                        PMID:27499296
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We also establish LYRM5 as a “deflavinase” that directly regulates the electron transferring flavoprotein (ETF)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28380382" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28380382
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A Single Adaptable Cochaperone-Scaffold Complex Delivers Nas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005515" data-r="PMID:28380382" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction (with HSCB, Q8IWL3) from a study of the HSC20 cochaperone- scaffold Fe-S delivery complex; captured as the generic term &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; from a study centred on respiratory-chain Fe-S cluster delivery, not on ETFA function. Uninformative molecular function; marked over-annotated per policy.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction (with ETFB, P38117) from a proteome-scale (BioPlex) interactome network, captured as the uninformative term &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; from a high-throughput interactome; the ETFA-ETFB partnership is informatively captured by the ETF complex annotation (GO:0045251). Marked over-annotated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35156780" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35156780
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CFTR interactome mapping using the mammalian membrane two-hy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005515" data-r="PMID:35156780" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction (with CFTR, P13569) from a CFTR mammalian membrane two-hybrid screen, captured as the uninformative term &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; from a high-throughput CFTR screen; not an informative ETFA molecular function. Marked over-annotated per policy.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36012204" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36012204
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Differential CFTR-Interactome Proximity Labeling Procedures ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005515" data-r="PMID:36012204" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction (with CFTR, P13569) from a CFTR proximity-labeling interactome study, captured as the uninformative term &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; from a high-throughput proximity-labeling dataset; uninformative for ETFA function. Marked over-annotated per policy.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction (with ETFB, P38117) from a multimodal cell-map / structural and functional genomics study, captured as the uninformative term &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; from a large-scale cell-mapping dataset; the ETFA-ETFB relationship is better captured by the ETF complex annotation. Marked over-annotated per policy.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3760196" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3760196
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Biosynthesis of electron transfer flavoprotein in a cell-fre...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005759" data-r="PMID:3760196" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) evidence that alpha-ETF is synthesized in the cytosol as a larger precursor, imported into mitochondria, and processed to the mature form in the matrix. This is the core, experimentally defined localization of ETFA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biosynthesis/import study demonstrating mitochondrial (matrix) localization of the processed alpha subunit; it is the basis for the UniProt Subcellular Location and matches the biology of ETF as a matrix electron shuttle.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3760196" target="_blank" class="term-link">
+                                        PMID:3760196
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">translocated into the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9334218" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9334218
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression and characterization of two pathogenic mutations ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0009055" data-r="PMID:9334218" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) demonstration of ETF electron transfer activity: recombinant wild-type and pathogenic-mutant ETF were assayed for electron transfer from primary dehydrogenases and onward to ETF-QO, with mutations impairing this activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct biochemical characterization of the core electron-transfer function of ETF, including the effect of GA2A mutations on activity. This is a defining core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9334218" target="_blank" class="term-link">
+                                        PMID:9334218
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">electron transfer from nine primary flavoprotein dehydrogenases to the main</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8504797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    cDNA cloning and mitochondrial import of the beta-subunit of...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005759" data-r="PMID:8504797" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable author statement (ComplexPortal) supporting mitochondrial matrix localization; the cited work shows the ETF beta subunit is imported to the mitochondrial matrix, consistent with the matrix location of the ETF heterodimer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with the direct experimental IDA matrix annotation (PMID:3760196) and the established matrix location of ETF. Retained as supporting the core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009063" target="_blank" class="term-link">
+                                    GO:0009063
+                                </a>
+                            </span>
+                            <span class="term-label">amino acid catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human METTL20 is a mitochondrial lysine methyltransferase th...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0009063" data-r="PMID:25416781" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA, ComplexPortal) evidence that ETF participates in amino-acid catabolism: the ETF alpha/beta heterodimer receives electrons from amino-acid-oxidation dehydrogenases such as glutaryl-CoA dehydrogenase (GCDH) and isovaleryl-CoA dehydrogenase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ETF is the obligate electron acceptor for amino-acid catabolic dehydrogenases; loss of ETFA impairs amino-acid metabolism (a component of the MADD phenotype). Supported by the cited study characterizing ETF electron transfer from GCDH.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">others, including glutaryl-CoA dehydrogenase (GCDH) and isovaleryl-CoA dehydrogenase, are involved in the oxidation of amino acids</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022904" target="_blank" class="term-link">
+                                    GO:0022904
+                                </a>
+                            </span>
+                            <span class="term-label">respiratory electron transport chain</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human METTL20 is a mitochondrial lysine methyltransferase th...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0022904" data-r="PMID:25416781" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA, ComplexPortal) evidence linking ETF to the respiratory electron transport chain: ETF shuttles electrons from matrix dehydrogenases to ETF:quinone oxidoreductase and thence to the ubiquinone pool, acting as the third major electron provider to the respiratory chain after complexes I and II.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ETF feeds electrons into the respiratory chain via ETFDH/ubiquinone; this is a core physiological role of ETFA, well documented in the cited study.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">it is the third major provider of electrons to the ubiquinone</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033539" target="_blank" class="term-link">
+                                    GO:0033539
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid beta-oxidation using acyl-CoA dehydrogenase</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human METTL20 is a mitochondrial lysine methyltransferase th...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0033539" data-r="PMID:25416781" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA, ComplexPortal) evidence that ETF participates in acyl-CoA- dehydrogenase-dependent fatty-acid beta-oxidation: the heterodimer receives electrons from dehydrogenases such as medium-chain acyl-CoA dehydrogenase (MCAD) involved in beta-oxidation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core physiological role: ETF is the obligate electron acceptor for the beta-oxidation acyl-CoA dehydrogenases. Duplicate of the IBA annotation to the same term; both accepted.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Some of these dehydrogenases, e.g. medium chain acyl-CoA dehydrogenase (MCAD), are involved in β-oxidation of fatty acids</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045251" target="_blank" class="term-link">
+                                    GO:0045251
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer flavoprotein complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8962055
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Three-dimensional structure of human electron transfer flavo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0045251" data-r="PMID:8962055" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETFA is a subunit of the electron transfer flavoprotein complex, the FAD-containing alpha/beta heterodimer whose crystal structure was solved to 2.1 A. ETFA contributes two of the three structural domains and coordinates most of the FAD.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly demonstrated by the X-ray structure of the human ETF heterodimer (also captured as ComplexPortal CPX-2731). This is the defining cellular complex for ETFA and a core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link">
+                                        PMID:8962055
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mammalian electron transfer flavoproteins (ETF) are heterodimers containing a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Immunofluorescence-based (HPA, IDA) localization of ETFA to the mitochondrion. Correct but general relative to the specific matrix location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Compartment is correct and independently corroborated (HPA imaging); broader than the specific mitochondrial matrix annotation. Retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35362222" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35362222
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    S1P defects cause a new entity of cataract, alopecia, oral m...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005515" data-r="PMID:35362222" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction (with MBTPS1/S1P, Q14703, and ETFB, P38117) demonstrated by Co-IP and GST pull-down; S1P forms a trimeric complex with ETFA/ETFB, stabilizing the heterodimer and promoting FAD incorporation. Captured only as the generic term &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The interaction is biologically meaningful and ETFA-specific (direct GST-ETFA pull-down, docking of specific ETFA residues), but &#34;protein binding&#34; is an uninformative molecular function. The functional consequence (heterodimer stabilization / FAD binding) is better captured by the FAD-binding and ETF-complex annotations; the bare IPI is over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35362222" target="_blank" class="term-link">
+                                        PMID:35362222
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">S1P forms a trimeric complex with ETFA and ETFB proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005739" data-r="PMID:34800366" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput (HTP) mitochondrial-proteome localization of ETFA to the mitochondrion, consistent with its established matrix location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment from a high-confidence mitochondrial proteome; broader than the specific matrix annotation. Retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human METTL20 is a mitochondrial lysine methyltransferase th...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0009055" data-r="PMID:25416781" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA, ComplexPortal) evidence of ETF electron transfer activity: the ETF alpha/beta heterodimer mediates electron transfer from acyl-CoA dehydrogenases (MCAD, GCDH) to an electron acceptor, an activity modulated by ETFB methylation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct assay of the core electron-transfer function of the ETF heterodimer. Duplicate of other electron-transfer-activity annotations; accepted as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ETF acts as a mobile electron carrier that shuttles electrons between several FAD-containing dehydrogenases</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20833797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphoproteome analysis of functional mitochondria isolated...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005739" data-r="PMID:20833797" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput direct assay (HDA) placing ETFA in the mitochondrion, from a phosphoproteome of mitochondria isolated from human muscle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment from isolated-mitochondria mass spectrometry; broader than the specific matrix annotation. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link">
+                                        PMID:20833797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mitochondria isolated from human muscle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-169260
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005759" data-r="Reactome:R-HSA-169260" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement (Reactome) placing ETF in the mitochondrial matrix, where it accepts reducing equivalents from fatty-acyl-CoA beta-oxidation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with the experimentally supported matrix localization and the reaction context (ETF residing on the matrix face of the inner membrane).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-169270
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005759" data-r="Reactome:R-HSA-169270" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement (Reactome) placing ETF in the mitochondrial matrix in the reaction where ETFDH re-oxidizes reduced ETF and reduces CoQ.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with the experimentally supported matrix localization and the ETF -&gt; ETFDH -&gt; ubiquinone electron-transfer reaction.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10423253" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10423253
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The intraflavin hydrogen bond in human electron transfer fla...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0009055" data-r="PMID:10423253" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) study of ETF as an intermediate electron carrier: substitution of the FAD analog 4&#39;-deoxy-FAD altered redox potentials and abolished electron transfer to and from ETF-QO, dissecting the electron-transfer mechanism of ETF.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly probes the core electron-transfer function of ETF and its dependence on the FAD cofactor. Duplicate of other electron-transfer-activity annotations; accepted as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10423253" target="_blank" class="term-link">
+                                        PMID:10423253
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">serves as an intermediate electron carrier</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050660" target="_blank" class="term-link">
+                                    GO:0050660
+                                </a>
+                            </span>
+                            <span class="term-label">flavin adenine dinucleotide binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10423253" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10423253
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The intraflavin hydrogen bond in human electron transfer fla...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0050660" data-r="PMID:10423253" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) evidence of FAD binding: binding constants for FAD (and the 4&#39;-deoxy-FAD analog) with the ETF apoprotein were measured, and the intra-cofactor 4&#39;-hydroxyl-N1 hydrogen bond of the bound FAD was characterized.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct biochemical characterization of the FAD-binding function of ETF, a core cofactor- binding function of the alpha subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10423253" target="_blank" class="term-link">
+                                        PMID:10423253
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the 4&#39;-hydroxyl of the ribityl side chain of FAD is hydrogen bonded to N(1)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050660" target="_blank" class="term-link">
+                                    GO:0050660
+                                </a>
+                            </span>
+                            <span class="term-label">flavin adenine dinucleotide binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9334218" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9334218
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression and characterization of two pathogenic mutations ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0050660" data-r="PMID:9334218" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) evidence of FAD binding: the flavin environment and kinetics of flavin release from oxidized and reduced ETF were characterized for wild-type and the pathogenic alphaT266M mutant, which perturbs the FAD-binding site.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct biochemical characterization of ETFA FAD binding, including the effect of a GA2A mutation on the flavin environment. Core cofactor-binding function. Duplicate of the other FAD-binding annotations; accepted.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9334218" target="_blank" class="term-link">
+                                        PMID:9334218
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Among these dehydrogenases are the four chain</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3170610" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3170610
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning and nucleotide sequence of cDNAs encoding ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005739" data-r="PMID:3170610" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement (PINC) placing alpha-ETF in the mitochondrion, from the molecular cloning of the alpha subunit precursor, whose identity was confirmed by mitochondrial processing of the translated protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment; broader than the specific matrix annotation. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3170610" target="_blank" class="term-link">
+                                        PMID:3170610
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mitochondrial processing of the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8617498" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8617498
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Assignment of Etfdh, Etfb, and Etfa to chromosomes 3, 7, and...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13804" data-a="GO:0005759" data-r="PMID:8617498" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement (PINC) placing ETF in the mitochondrial matrix, from the chromosomal-assignment study which states ETF is an obligatory electron acceptor located in the mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with the direct experimental matrix localization; supports the core location of ETFA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8617498" target="_blank" class="term-link">
+                                        PMID:8617498
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">obligatory electron acceptor for several dehydrogenases and is located in the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Electron transfer (electron-carrier) activity: the ETFA/ETFB heterodimer accepts electrons from multiple mitochondrial matrix FAD-dependent primary dehydrogenases and passes them to ETF-ubiquinone oxidoreductase (ETFDH), feeding the respiratory chain.</h3>
+                <span class="vote-buttons" data-g="P13804" data-a="FUNCTION: Electron transfer (electron-carrier) activity: the..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                            electron transfer activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022904" target="_blank" class="term-link">
+                                respiratory electron transport chain
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045251" target="_blank" class="term-link">
+                            electron transfer flavoprotein complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9334218" target="_blank" class="term-link">
+                                PMID:9334218
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">electron transfer from nine primary flavoprotein dehydrogenases to the main</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10423253" target="_blank" class="term-link">
+                                PMID:10423253
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">serves as an intermediate electron carrier</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>FAD binding: ETFA coordinates most of the single FAD cofactor of the ETF heterodimer, which transiently stores the electrons transferred between dehydrogenases and ETFDH.</h3>
+                <span class="vote-buttons" data-g="P13804" data-a="FUNCTION: FAD binding: ETFA coordinates most of the single F..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050660" target="_blank" class="term-link">
+                            flavin adenine dinucleotide binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045251" target="_blank" class="term-link">
+                            electron transfer flavoprotein complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link">
+                                PMID:8962055
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">most of the FAD molecule residing in the</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10423253" target="_blank" class="term-link">
+                                PMID:10423253
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the 4&#39;-hydroxyl of the ribityl side chain of FAD is hydrogen bonded to N(1)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As the common electron acceptor for the beta-oxidation acyl-CoA dehydrogenases, ETF is required for mitochondrial fatty-acid beta-oxidation flux; its loss produces a functional block in this pathway (MADD).</h3>
+                <span class="vote-buttons" data-g="P13804" data-a="FUNCTION: As the common electron acceptor for the beta-oxida..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                            electron transfer activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033539" target="_blank" class="term-link">
+                                fatty acid beta-oxidation using acyl-CoA dehydrogenase
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                PMID:25416781
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Some of these dehydrogenases, e.g. medium chain acyl-CoA dehydrogenase (MCAD), are involved in β-oxidation of fatty acids</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9334218" target="_blank" class="term-link">
+                                PMID:9334218
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Among these dehydrogenases are the four chain</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As the electron acceptor for amino-acid-catabolic dehydrogenases (e.g. glutaryl-CoA and isovaleryl-CoA dehydrogenases), ETF is required for normal amino-acid catabolism.</h3>
+                <span class="vote-buttons" data-g="P13804" data-a="FUNCTION: As the electron acceptor for amino-acid-catabolic ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                            electron transfer activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009063" target="_blank" class="term-link">
+                                amino acid catabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                PMID:25416781
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">others, including glutaryl-CoA dehydrogenase (GCDH) and isovaleryl-CoA dehydrogenase, are involved in the oxidation of amino acids</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10423253" target="_blank" class="term-link">
+                            PMID:10423253
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The intraflavin hydrogen bond in human electron transfer flavoprotein modulates redox potentials and may participate in electron transfer.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link">
+                            PMID:20833797
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phosphoproteome analysis of functional mitochondria isolated from resting human muscle reveals extensive phosphorylation of inner membrane protein complexes and enzymes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24606901" target="_blank" class="term-link">
+                            PMID:24606901
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cochaperone binding to LYR motifs confers specificity of iron sulfur cluster delivery.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                            PMID:25416781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human METTL20 is a mitochondrial lysine methyltransferase that targets the β subunit of electron transfer flavoprotein (ETFβ) and modulates its activity.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26618866" target="_blank" class="term-link">
+                            PMID:26618866
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">∆F508 CFTR interactome remodelling promotes rescue of cystic fibrosis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27499296" target="_blank" class="term-link">
+                            PMID:27499296
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial Protein Interaction Mapping Identifies Regulators of Respiratory Chain Function.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28380382" target="_blank" class="term-link">
+                            PMID:28380382
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A Single Adaptable Cochaperone-Scaffold Complex Delivers Nascent Iron-Sulfur Clusters to Mammalian Respiratory Chain Complexes I-III.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/3170610" target="_blank" class="term-link">
+                            PMID:3170610
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular cloning and nucleotide sequence of cDNAs encoding the alpha-subunit of human electron transfer flavoprotein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35156780" target="_blank" class="term-link">
+                            PMID:35156780
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CFTR interactome mapping using the mammalian membrane two-hybrid high-throughput screening system.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35362222" target="_blank" class="term-link">
+                            PMID:35362222
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">S1P defects cause a new entity of cataract, alopecia, oral mucosal disorder, and psoriasis-like syndrome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36012204" target="_blank" class="term-link">
+                            PMID:36012204
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Differential CFTR-Interactome Proximity Labeling Procedures Identify Enrichment in Multiple SLC Transporters.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/3760196" target="_blank" class="term-link">
+                            PMID:3760196
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis of electron transfer flavoprotein in a cell-free system and in cultured human fibroblasts. Defect in the alpha subunit synthesis is a primary lesion in glutaric aciduria type II.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                            PMID:8504797
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">cDNA cloning and mitochondrial import of the beta-subunit of the human electron-transfer flavoprotein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8617498" target="_blank" class="term-link">
+                            PMID:8617498
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Assignment of Etfdh, Etfb, and Etfa to chromosomes 3, 7, and 13: the mouse homologs of genes responsible for glutaric acidemia type II in human.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link">
+                            PMID:8962055
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Three-dimensional structure of human electron transfer flavoprotein to 2.1-A resolution.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9334218" target="_blank" class="term-link">
+                            PMID:9334218
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Expression and characterization of two pathogenic mutations in human electron transfer flavoprotein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-169260
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Reducing equivalents from beta-oxidation of fatty acids transfer to ETF</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-169270
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ETFDH oxidises ETF (reduced) to ETF, reduces CoQ to CoQH2</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Beyond serving all the acyl-CoA and amino-acid-catabolic dehydrogenases, how is electron flux through ETF regulated in vivo (e.g. by ETFRF1/LYRM5 deflavination or MBTPS1/S1P-mediated stabilization), and does this constitute a physiological control point for substrate selection?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P13804" data-a="Q: Beyond serving all the acyl-CoA and amino-acid-cat..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantitative flux analysis (e.g. stable-isotope tracing of fatty-acid and branched-chain amino-acid oxidation) in ETFA-null versus rescued cells to measure the contribution of ETF to each catabolic pathway and to respiratory-chain electron input.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P13804" data-a="EXPERIMENT: Quantitative flux analysis (e.g. stable-isotope tr..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ETFA-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P13804" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="etfa-human-review-notes">ETFA (human) review notes</h1>
+<p>UniProtKB:P13804 — Electron transfer flavoprotein subunit alpha, mitochondrial (Alpha-ETF).<br />
+HGNC:3481. Gene MIM 608053; disease MIM 231680 (Glutaric aciduria 2A). 333 aa precursor;<br />
+transit peptide 1..19; mature chain 20..333.</p>
+<h2 id="verified-biology-from-uniprottxt-and-cached-publications">Verified biology (from -uniprot.txt and cached publications)</h2>
+<ul>
+<li>ETF is a soluble mitochondrial-matrix FAD-containing <strong>heterodimer</strong> of ETFA (alpha) +<br />
+  ETFB (beta), binding one FAD and one AMP per dimer<br />
+  [Reactome R-HSA-169260 "63kDa heterodimer composed of alpha and beta subunits and binds<br />
+  one FAD and one AMP per dimer"; PMID:8962055 "Mammalian electron transfer flavoproteins<br />
+  (ETF) are heterodimers containing a single equivalent of flavin adenine dinucleotide (FAD)"].</li>
+<li>Most of the FAD binds in the C-terminal (Domain II) portion of the alpha subunit<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8962055" title="most of the FAD molecule residing in the C-terminal portion of the alpha   subunit">PMID:8962055</a>. UniProt lists ~16 FAD BINDING residues on ETFA (223..319).</li>
+<li>ETF is the common electron acceptor for at least a dozen mitochondrial matrix FAD-dependent<br />
+  acyl-CoA dehydrogenases of fatty-acid beta-oxidation (ACADM/MCAD, ACADVL, etc.) and of<br />
+  amino-acid catabolism (IVD, GCDH), plus choline-pathway dehydrogenases (DMGDH, SARDH); it<br />
+  passes electrons to ETF-ubiquinone oxidoreductase (ETFDH / ETF-QO), funneling them to the<br />
+  respiratory-chain ubiquinone pool<br />
+  [PMID:25416781 full text "ETF acts as a mobile electron carrier that shuttles electrons<br />
+  between several FAD-containing dehydrogenases present in the mitochondrial matrix and the<br />
+  membrane-bound ETF:quinone oxidoreductase ... Altogether, there are 13 human dehydrogenases<br />
+  that interact with ETF ... it is the third major provider of electrons to the ubiquinone<br />
+  pool of the mitochondrial respiratory chain"].</li>
+<li>UniProt FUNCTION: "Heterodimeric electron transfer flavoprotein that accepts electrons from<br />
+  several mitochondrial dehydrogenases, including acyl-CoA dehydrogenases, glutaryl-CoA and<br />
+  sarcosine dehydrogenase ... transfers the electrons to the main mitochondrial respiratory<br />
+  chain via ETF-ubiquinone oxidoreductase (ETF dehydrogenase) ... Required for normal<br />
+  mitochondrial fatty acid oxidation and normal amino acid metabolism."</li>
+<li>SUBCELLULAR LOCATION: Mitochondrion matrix <a href="https://pubmed.ncbi.nlm.nih.gov/3760196">PMID:3760196</a>. ETF resides on the matrix face<br />
+  of the inner membrane [Reactome].</li>
+<li>Deficiency (ETFA/ETFB/ETFDH) =&gt; multiple acyl-CoA dehydrogenase deficiency (MADD) /<br />
+  glutaric acidemia type II [MONDO:0009282; dismech MADD KB].</li>
+</ul>
+<h2 id="annotation-decisions-summary">Annotation decisions summary</h2>
+<p>Core (ACCEPT): GO:0009055 electron transfer activity (IDA/IBA/IEA); GO:0050660 FAD binding<br />
+(IDA/IBA/IEA); GO:0033539 fatty acid beta-oxidation using acyl-CoA dehydrogenase (IDA/IBA);<br />
+GO:0009063 amino acid catabolic process (IDA); GO:0022904 respiratory electron transport<br />
+chain (IDA); GO:0045251 electron transfer flavoprotein complex (IPI); GO:0005759<br />
+mitochondrial matrix (IDA/NAS/TAS). Mitochondrion terms (GO:0005739) KEEP_AS_NON_CORE or<br />
+ACCEPT (broader parent of matrix; HPA/HTP/HDA localization support).</p>
+<p>protein binding (GO:0005515) IPIs: bare, uninformative. Most are high-throughput<br />
+interactome/CFTR proximity screens =&gt; MARK_AS_OVER_ANNOTATED (policy: not REMOVE). The<br />
+ETFRF1 (PMID:27499296) and MBTPS1 (PMID:35362222) interactions are functionally meaningful<br />
+(ETFRF1 promotes FAD dissociation; MBTPS1/S1P stabilizes the ETFA/ETFB heterodimer and<br />
+promotes FAD binding) but the GO term itself is still bare "protein binding" =&gt;<br />
+MARK_AS_OVER_ANNOTATED with notes pointing to informative partners; better captured by<br />
+proposed complex/regulation terms rather than protein binding.</p>
+<h2 id="deep-research">Deep research</h2>
+<p>Falcon DR file did NOT arrive within the 8-min poll window (timed out, no file). Review is<br />
+grounded in UniProt (P13804), GOA, cached publications (PMID:8962055, 9334218, 10423253,<br />
+25416781, 3760196, 8504797, 3170610, 8617498, 27499296, 35362222, 34800366, 20833797),<br />
+Reactome R-HSA-169260/169270, and the dismech MADD KB.</p>
+<h2 id="final-result">Final result</h2>
+<p>Validation clean (<code>just validate human ETFA</code> =&gt; Valid) on first run. 35 existing annotations<br />
+reviewed: 20 ACCEPT, 6 KEEP_AS_NON_CORE, 9 MARK_AS_OVER_ANNOTATED (all bare protein-binding<br />
+IPIs). 4 core_functions (electron transfer activity x3 contexts: respiratory ETC / fatty-acid<br />
+beta-ox / amino-acid catabolism; + FAD binding), all in mitochondrial matrix / ETF complex.<br />
+19 reference_review blocks added.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P13804
+gene_symbol: ETFA
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  ETFA is the alpha subunit of the electron-transfer flavoprotein (ETF), a soluble
+  FAD-containing heterodimer of ETFA and ETFB that resides in the mitochondrial matrix (on
+  the matrix face of the inner membrane). ETF is the common electron acceptor for at least a
+  dozen mitochondrial FAD-dependent primary dehydrogenases, including the chain-length-specific
+  acyl-CoA dehydrogenases of fatty-acid beta-oxidation (e.g. ACADM/MCAD, ACADVL) and
+  dehydrogenases of amino-acid catabolism (IVD, glutaryl-CoA dehydrogenase GCDH) as well as
+  sarcosine/dimethylglycine dehydrogenases of choline degradation. ETF accepts reducing
+  equivalents from these dehydrogenases, storing them transiently on its single bound FAD, and
+  passes the electrons to ETF-ubiquinone oxidoreductase (ETFDH / ETF-QO), which reduces the
+  ubiquinone pool and thereby funnels the electrons into the mitochondrial respiratory chain.
+  The heterodimer binds one FAD and one AMP per dimer; most of the FAD is coordinated by the
+  C-terminal domain of the alpha subunit. ETF is thus the third major electron feeder to the
+  respiratory chain after complexes I and II, and is required for normal mitochondrial fatty
+  acid oxidation and amino acid metabolism. Biallelic loss-of-function of ETFA (or ETFB or
+  ETFDH) causes multiple acyl-CoA dehydrogenase deficiency (MADD) / glutaric acidemia type II.
+alternative_products:
+- name: &#39;1&#39;
+  id: P13804-1
+- name: &#39;2&#39;
+  id: P13804-2
+  sequence_note: VSP_043246
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) localization of ETFA to the mitochondrion. Correct but general; ETF
+      acts specifically in the mitochondrial matrix, which is separately and more precisely
+      annotated (GO:0005759).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The compartment is correct, but &#34;mitochondrion&#34; is the broad parent of the more specific
+      and better-supported &#34;mitochondrial matrix&#34; location. Retained as non-core context; the
+      matrix annotation is preferred as the core localization.
+    supported_by:
+    - reference_id: PMID:8617498
+      supporting_text: &gt;-
+        obligatory electron acceptor for several dehydrogenases and is located in the
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of electron transfer activity, the core molecular function
+      of ETF: it accepts electrons from primary flavoprotein dehydrogenases and passes them to
+      ETFDH. Well supported experimentally and by the phylogeny of the ETF alpha/FixB family.
+    action: ACCEPT
+    reason: &gt;-
+      This is the central, defining molecular function of the ETF alpha subunit and is
+      concordant with the direct experimental annotations (PMID:9334218, PMID:10423253) and the
+      UniProt FUNCTION statement.
+    supported_by:
+    - reference_id: PMID:10423253
+      supporting_text: &gt;-
+        serves as an intermediate electron carrier
+- term:
+    id: GO:0033539
+    label: fatty acid beta-oxidation using acyl-CoA dehydrogenase
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment linking ETF to fatty-acid beta-oxidation. ETF is the
+      obligate electron acceptor for the chain-length-specific acyl-CoA dehydrogenases of the
+      beta-oxidation spiral, so its activity is required for flux through this pathway.
+    action: ACCEPT
+    reason: &gt;-
+      Strongly supported: ETF accepts electrons from the beta-oxidation acyl-CoA dehydrogenases,
+      and this term is also directly annotated (IDA, PMID:25416781). Loss of ETFA causes a
+      functional block in fatty-acid beta-oxidation (MADD).
+    supported_by:
+    - reference_id: PMID:9334218
+      supporting_text: &gt;-
+        Among these dehydrogenases are the four chain
+    - reference_id: PMID:25416781
+      supporting_text: &gt;-
+        Some of these dehydrogenases, e.g. medium chain acyl-CoA dehydrogenase (MCAD), are
+        involved in β-oxidation of fatty acids
+- term:
+    id: GO:0050660
+    label: flavin adenine dinucleotide binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of FAD binding. ETF carries a single FAD per heterodimer,
+      most of which is coordinated by the alpha subunit; FAD is the redox cofactor that
+      transiently stores the transferred electrons.
+    action: ACCEPT
+    reason: &gt;-
+      Core cofactor-binding function of ETFA, corroborated by direct experimental annotations
+      (IDA, PMID:9334218, PMID:10423253) and by the crystallographically defined FAD-binding
+      residues on the alpha subunit in UniProt.
+    supported_by:
+    - reference_id: PMID:8962055
+      supporting_text: &gt;-
+        most of the FAD molecule residing in the
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) localization to the mitochondrion. Correct but general relative to the
+      experimentally supported mitochondrial matrix location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Compartment is correct; broader than the specific matrix annotation. Retained as
+      non-core.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation (UniProt Subcellular Location keyword mapping) placing ETFA in the
+      mitochondrial matrix, the compartment where ETF operates.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the experimentally determined subcellular location (IDA, PMID:3760196;
+      NAS, PMID:8504797) and with the biology of ETF as a matrix electron shuttle.
+    supported_by:
+    - reference_id: PMID:8617498
+      supporting_text: &gt;-
+        obligatory electron acceptor for several dehydrogenases and is located in the
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (InterPro2GO, IPR001308 ETF alpha/FixB) assignment of electron transfer
+      activity, the core molecular function of the ETF alpha subunit.
+    action: ACCEPT
+    reason: &gt;-
+      The InterPro family (ETF alpha/FixB) maps correctly to electron transfer activity, in
+      agreement with the direct experimental and phylogenetic annotations.
+    supported_by:
+    - reference_id: PMID:10423253
+      supporting_text: &gt;-
+        serves as an intermediate electron carrier
+- term:
+    id: GO:0050660
+    label: flavin adenine dinucleotide binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (InterPro2GO, IPR001308) assignment of FAD binding, the redox cofactor carried
+      by the alpha subunit.
+    action: ACCEPT
+    reason: &gt;-
+      Correct InterPro-to-GO mapping for the ETF alpha/FixB family; concordant with direct
+      experimental FAD-binding annotations and the crystallographic FAD-binding residues.
+    supported_by:
+    - reference_id: PMID:8962055
+      supporting_text: &gt;-
+        most of the FAD molecule residing in the
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:24606901
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated binary interaction (with HSCB, Q8IWL3) captured as the uninformative term
+      &#34;protein binding&#34;. Derived from a study of the Fe-S cluster cochaperone HSC20/HSCB.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;protein binding&#34; (GO:0005515) is not an informative molecular function and does not
+      document ETFA&#39;s role. The interaction is not further pursued in this HSC20-focused study;
+      per curation policy this bare IPI is marked as over-annotated rather than removed.
+    supported_by:
+    - reference_id: PMID:24606901
+      supporting_text: &gt;-
+        LYR motifs
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26618866
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated binary interaction (with CFTR, P13569) from a large-scale CFTR-interactome
+      remodelling study, captured as the uninformative term &#34;protein binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare &#34;protein binding&#34; from a high-throughput interactome dataset; not an informative
+      molecular function for ETFA and no dedicated functional follow-up. Marked as
+      over-annotated per policy.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:27499296
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction (with ETFB, P38117) from the mitochondrial protein interaction
+      map that identified LYRM5/ETFRF1 as a &#34;deflavinase&#34; directly regulating ETF. Captured only
+      as the generic term &#34;protein binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The underlying interaction is biologically real and meaningful (ETF is directly regulated
+      by LYRM5/ETFRF1, and ETFA obligately partners ETFB), but the GO term &#34;protein binding&#34; is
+      uninformative. The functional relationships are better captured by the ETF-complex
+      (GO:0045251) and electron-transfer annotations; the bare IPI is over-annotated.
+    supported_by:
+    - reference_id: PMID:27499296
+      supporting_text: &gt;-
+        We also establish LYRM5 as a “deflavinase” that directly regulates the electron
+        transferring flavoprotein (ETF)
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28380382
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction (with HSCB, Q8IWL3) from a study of the HSC20 cochaperone-
+      scaffold Fe-S delivery complex; captured as the generic term &#34;protein binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare &#34;protein binding&#34; from a study centred on respiratory-chain Fe-S cluster delivery,
+      not on ETFA function. Uninformative molecular function; marked over-annotated per policy.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction (with ETFB, P38117) from a proteome-scale (BioPlex) interactome
+      network, captured as the uninformative term &#34;protein binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare &#34;protein binding&#34; from a high-throughput interactome; the ETFA-ETFB partnership is
+      informatively captured by the ETF complex annotation (GO:0045251). Marked over-annotated.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35156780
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction (with CFTR, P13569) from a CFTR mammalian membrane two-hybrid
+      screen, captured as the uninformative term &#34;protein binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare &#34;protein binding&#34; from a high-throughput CFTR screen; not an informative ETFA
+      molecular function. Marked over-annotated per policy.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:36012204
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction (with CFTR, P13569) from a CFTR proximity-labeling interactome
+      study, captured as the uninformative term &#34;protein binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare &#34;protein binding&#34; from a high-throughput proximity-labeling dataset; uninformative
+      for ETFA function. Marked over-annotated per policy.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction (with ETFB, P38117) from a multimodal cell-map / structural and
+      functional genomics study, captured as the uninformative term &#34;protein binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare &#34;protein binding&#34; from a large-scale cell-mapping dataset; the ETFA-ETFB relationship
+      is better captured by the ETF complex annotation. Marked over-annotated per policy.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:3760196
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) evidence that alpha-ETF is synthesized in the cytosol as a
+      larger precursor, imported into mitochondria, and processed to the mature form in the
+      matrix. This is the core, experimentally defined localization of ETFA.
+    action: ACCEPT
+    reason: &gt;-
+      Biosynthesis/import study demonstrating mitochondrial (matrix) localization of the
+      processed alpha subunit; it is the basis for the UniProt Subcellular Location and matches
+      the biology of ETF as a matrix electron shuttle.
+    supported_by:
+    - reference_id: PMID:3760196
+      supporting_text: &gt;-
+        translocated into the
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IDA
+  original_reference_id: PMID:9334218
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) demonstration of ETF electron transfer activity: recombinant
+      wild-type and pathogenic-mutant ETF were assayed for electron transfer from primary
+      dehydrogenases and onward to ETF-QO, with mutations impairing this activity.
+    action: ACCEPT
+    reason: &gt;-
+      Direct biochemical characterization of the core electron-transfer function of ETF,
+      including the effect of GA2A mutations on activity. This is a defining core function.
+    supported_by:
+    - reference_id: PMID:9334218
+      supporting_text: &gt;-
+        electron transfer from nine primary flavoprotein dehydrogenases to the main
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: NAS
+  original_reference_id: PMID:8504797
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Non-traceable author statement (ComplexPortal) supporting mitochondrial matrix
+      localization; the cited work shows the ETF beta subunit is imported to the mitochondrial
+      matrix, consistent with the matrix location of the ETF heterodimer.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with the direct experimental IDA matrix annotation (PMID:3760196) and the
+      established matrix location of ETF. Retained as supporting the core localization.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: &gt;-
+        reach the mitochondrial matrix
+- term:
+    id: GO:0009063
+    label: amino acid catabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:25416781
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA, ComplexPortal) evidence that ETF participates in amino-acid
+      catabolism: the ETF alpha/beta heterodimer receives electrons from amino-acid-oxidation
+      dehydrogenases such as glutaryl-CoA dehydrogenase (GCDH) and isovaleryl-CoA dehydrogenase.
+    action: ACCEPT
+    reason: &gt;-
+      ETF is the obligate electron acceptor for amino-acid catabolic dehydrogenases; loss of
+      ETFA impairs amino-acid metabolism (a component of the MADD phenotype). Supported by the
+      cited study characterizing ETF electron transfer from GCDH.
+    supported_by:
+    - reference_id: PMID:25416781
+      supporting_text: &gt;-
+        others, including glutaryl-CoA dehydrogenase (GCDH) and isovaleryl-CoA dehydrogenase,
+        are involved in the oxidation of amino acids
+- term:
+    id: GO:0022904
+    label: respiratory electron transport chain
+  evidence_type: IDA
+  original_reference_id: PMID:25416781
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA, ComplexPortal) evidence linking ETF to the respiratory electron
+      transport chain: ETF shuttles electrons from matrix dehydrogenases to ETF:quinone
+      oxidoreductase and thence to the ubiquinone pool, acting as the third major electron
+      provider to the respiratory chain after complexes I and II.
+    action: ACCEPT
+    reason: &gt;-
+      ETF feeds electrons into the respiratory chain via ETFDH/ubiquinone; this is a core
+      physiological role of ETFA, well documented in the cited study.
+    supported_by:
+    - reference_id: PMID:25416781
+      supporting_text: &gt;-
+        it is the third major provider of electrons to the ubiquinone
+- term:
+    id: GO:0033539
+    label: fatty acid beta-oxidation using acyl-CoA dehydrogenase
+  evidence_type: IDA
+  original_reference_id: PMID:25416781
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA, ComplexPortal) evidence that ETF participates in acyl-CoA-
+      dehydrogenase-dependent fatty-acid beta-oxidation: the heterodimer receives electrons from
+      dehydrogenases such as medium-chain acyl-CoA dehydrogenase (MCAD) involved in beta-oxidation.
+    action: ACCEPT
+    reason: &gt;-
+      Core physiological role: ETF is the obligate electron acceptor for the beta-oxidation
+      acyl-CoA dehydrogenases. Duplicate of the IBA annotation to the same term; both accepted.
+    supported_by:
+    - reference_id: PMID:25416781
+      supporting_text: &gt;-
+        Some of these dehydrogenases, e.g. medium chain acyl-CoA dehydrogenase (MCAD), are
+        involved in β-oxidation of fatty acids
+- term:
+    id: GO:0045251
+    label: electron transfer flavoprotein complex
+  evidence_type: IPI
+  original_reference_id: PMID:8962055
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ETFA is a subunit of the electron transfer flavoprotein complex, the FAD-containing
+      alpha/beta heterodimer whose crystal structure was solved to 2.1 A. ETFA contributes two
+      of the three structural domains and coordinates most of the FAD.
+    action: ACCEPT
+    reason: &gt;-
+      Directly demonstrated by the X-ray structure of the human ETF heterodimer (also captured
+      as ComplexPortal CPX-2731). This is the defining cellular complex for ETFA and a core
+      annotation.
+    supported_by:
+    - reference_id: PMID:8962055
+      supporting_text: &gt;-
+        Mammalian electron transfer flavoproteins (ETF) are heterodimers containing a
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Immunofluorescence-based (HPA, IDA) localization of ETFA to the mitochondrion. Correct but
+      general relative to the specific matrix location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Compartment is correct and independently corroborated (HPA imaging); broader than the
+      specific mitochondrial matrix annotation. Retained as non-core.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35362222
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated interaction (with MBTPS1/S1P, Q14703, and ETFB, P38117) demonstrated by
+      Co-IP and GST pull-down; S1P forms a trimeric complex with ETFA/ETFB, stabilizing the
+      heterodimer and promoting FAD incorporation. Captured only as the generic term &#34;protein
+      binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The interaction is biologically meaningful and ETFA-specific (direct GST-ETFA pull-down,
+      docking of specific ETFA residues), but &#34;protein binding&#34; is an uninformative molecular
+      function. The functional consequence (heterodimer stabilization / FAD binding) is better
+      captured by the FAD-binding and ETF-complex annotations; the bare IPI is over-annotated.
+    supported_by:
+    - reference_id: PMID:35362222
+      supporting_text: &gt;-
+        S1P forms a trimeric complex with ETFA and ETFB proteins
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput (HTP) mitochondrial-proteome localization of ETFA to the mitochondrion,
+      consistent with its established matrix location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct compartment from a high-confidence mitochondrial proteome; broader than the
+      specific matrix annotation. Retained as non-core.
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IDA
+  original_reference_id: PMID:25416781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (IDA, ComplexPortal) evidence of ETF electron transfer activity: the
+      ETF alpha/beta heterodimer mediates electron transfer from acyl-CoA dehydrogenases (MCAD,
+      GCDH) to an electron acceptor, an activity modulated by ETFB methylation.
+    action: ACCEPT
+    reason: &gt;-
+      Direct assay of the core electron-transfer function of the ETF heterodimer. Duplicate of
+      other electron-transfer-activity annotations; accepted as core.
+    supported_by:
+    - reference_id: PMID:25416781
+      supporting_text: &gt;-
+        ETF acts as a mobile electron carrier that shuttles electrons between several
+        FAD-containing dehydrogenases
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HDA
+  original_reference_id: PMID:20833797
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput direct assay (HDA) placing ETFA in the mitochondrion, from a
+      phosphoproteome of mitochondria isolated from human muscle.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct compartment from isolated-mitochondria mass spectrometry; broader than the
+      specific matrix annotation. Retained as non-core.
+    supported_by:
+    - reference_id: PMID:20833797
+      supporting_text: &gt;-
+        mitochondria isolated from human muscle
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-169260
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Traceable author statement (Reactome) placing ETF in the mitochondrial matrix, where it
+      accepts reducing equivalents from fatty-acyl-CoA beta-oxidation.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with the experimentally supported matrix localization and the reaction context
+      (ETF residing on the matrix face of the inner membrane).
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-169270
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Traceable author statement (Reactome) placing ETF in the mitochondrial matrix in the
+      reaction where ETFDH re-oxidizes reduced ETF and reduces CoQ.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with the experimentally supported matrix localization and the ETF -&gt; ETFDH -&gt;
+      ubiquinone electron-transfer reaction.
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IDA
+  original_reference_id: PMID:10423253
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) study of ETF as an intermediate electron carrier: substitution
+      of the FAD analog 4&#39;-deoxy-FAD altered redox potentials and abolished electron transfer to
+      and from ETF-QO, dissecting the electron-transfer mechanism of ETF.
+    action: ACCEPT
+    reason: &gt;-
+      Directly probes the core electron-transfer function of ETF and its dependence on the FAD
+      cofactor. Duplicate of other electron-transfer-activity annotations; accepted as core.
+    supported_by:
+    - reference_id: PMID:10423253
+      supporting_text: &gt;-
+        serves as an intermediate electron carrier
+- term:
+    id: GO:0050660
+    label: flavin adenine dinucleotide binding
+  evidence_type: IDA
+  original_reference_id: PMID:10423253
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) evidence of FAD binding: binding constants for FAD (and the
+      4&#39;-deoxy-FAD analog) with the ETF apoprotein were measured, and the intra-cofactor
+      4&#39;-hydroxyl-N1 hydrogen bond of the bound FAD was characterized.
+    action: ACCEPT
+    reason: &gt;-
+      Direct biochemical characterization of the FAD-binding function of ETF, a core cofactor-
+      binding function of the alpha subunit.
+    supported_by:
+    - reference_id: PMID:10423253
+      supporting_text: &gt;-
+        the 4&#39;-hydroxyl of the ribityl side chain of FAD is hydrogen bonded to N(1)
+- term:
+    id: GO:0050660
+    label: flavin adenine dinucleotide binding
+  evidence_type: IDA
+  original_reference_id: PMID:9334218
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) evidence of FAD binding: the flavin environment and kinetics of
+      flavin release from oxidized and reduced ETF were characterized for wild-type and the
+      pathogenic alphaT266M mutant, which perturbs the FAD-binding site.
+    action: ACCEPT
+    reason: &gt;-
+      Direct biochemical characterization of ETFA FAD binding, including the effect of a GA2A
+      mutation on the flavin environment. Core cofactor-binding function. Duplicate of the other
+      FAD-binding annotations; accepted.
+    supported_by:
+    - reference_id: PMID:9334218
+      supporting_text: &gt;-
+        Among these dehydrogenases are the four chain
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: TAS
+  original_reference_id: PMID:3170610
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Traceable author statement (PINC) placing alpha-ETF in the mitochondrion, from the
+      molecular cloning of the alpha subunit precursor, whose identity was confirmed by
+      mitochondrial processing of the translated protein.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct compartment; broader than the specific matrix annotation. Retained as non-core.
+    supported_by:
+    - reference_id: PMID:3170610
+      supporting_text: &gt;-
+        mitochondrial processing of the
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: PMID:8617498
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Traceable author statement (PINC) placing ETF in the mitochondrial matrix, from the
+      chromosomal-assignment study which states ETF is an obligatory electron acceptor located
+      in the mitochondrial matrix.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with the direct experimental matrix localization; supports the core location of
+      ETFA.
+    supported_by:
+    - reference_id: PMID:8617498
+      supporting_text: &gt;-
+        obligatory electron acceptor for several dehydrogenases and is located in the
+core_functions:
+- description: &gt;-
+    Electron transfer (electron-carrier) activity: the ETFA/ETFB heterodimer accepts electrons
+    from multiple mitochondrial matrix FAD-dependent primary dehydrogenases and passes them to
+    ETF-ubiquinone oxidoreductase (ETFDH), feeding the respiratory chain.
+  molecular_function:
+    id: GO:0009055
+    label: electron transfer activity
+  directly_involved_in:
+  - id: GO:0022904
+    label: respiratory electron transport chain
+  in_complex:
+    id: GO:0045251
+    label: electron transfer flavoprotein complex
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:9334218
+    supporting_text: &gt;-
+      electron transfer from nine primary flavoprotein dehydrogenases to the main
+  - reference_id: PMID:10423253
+    supporting_text: &gt;-
+      serves as an intermediate electron carrier
+- description: &gt;-
+    FAD binding: ETFA coordinates most of the single FAD cofactor of the ETF heterodimer, which
+    transiently stores the electrons transferred between dehydrogenases and ETFDH.
+  molecular_function:
+    id: GO:0050660
+    label: flavin adenine dinucleotide binding
+  in_complex:
+    id: GO:0045251
+    label: electron transfer flavoprotein complex
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:8962055
+    supporting_text: &gt;-
+      most of the FAD molecule residing in the
+  - reference_id: PMID:10423253
+    supporting_text: &gt;-
+      the 4&#39;-hydroxyl of the ribityl side chain of FAD is hydrogen bonded to N(1)
+- description: &gt;-
+    As the common electron acceptor for the beta-oxidation acyl-CoA dehydrogenases, ETF is
+    required for mitochondrial fatty-acid beta-oxidation flux; its loss produces a functional
+    block in this pathway (MADD).
+  molecular_function:
+    id: GO:0009055
+    label: electron transfer activity
+  directly_involved_in:
+  - id: GO:0033539
+    label: fatty acid beta-oxidation using acyl-CoA dehydrogenase
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:25416781
+    supporting_text: &gt;-
+      Some of these dehydrogenases, e.g. medium chain acyl-CoA dehydrogenase (MCAD), are
+      involved in β-oxidation of fatty acids
+  - reference_id: PMID:9334218
+    supporting_text: &gt;-
+      Among these dehydrogenases are the four chain
+- description: &gt;-
+    As the electron acceptor for amino-acid-catabolic dehydrogenases (e.g. glutaryl-CoA and
+    isovaleryl-CoA dehydrogenases), ETF is required for normal amino-acid catabolism.
+  molecular_function:
+    id: GO:0009055
+    label: electron transfer activity
+  directly_involved_in:
+  - id: GO:0009063
+    label: amino acid catabolic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:25416781
+    supporting_text: &gt;-
+      others, including glutaryl-CoA dehydrogenase (GCDH) and isovaleryl-CoA dehydrogenase, are
+      involved in the oxidation of amino acids
+suggested_questions:
+- question: &gt;-
+    Beyond serving all the acyl-CoA and amino-acid-catabolic dehydrogenases, how is electron
+    flux through ETF regulated in vivo (e.g. by ETFRF1/LYRM5 deflavination or MBTPS1/S1P-mediated
+    stabilization), and does this constitute a physiological control point for substrate
+    selection?
+suggested_experiments:
+- description: &gt;-
+    Quantitative flux analysis (e.g. stable-isotope tracing of fatty-acid and branched-chain
+    amino-acid oxidation) in ETFA-null versus rescued cells to measure the contribution of ETF
+    to each catabolic pathway and to respiratory-chain electron input.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:10423253
+  title: The intraflavin hydrogen bond in human electron transfer flavoprotein modulates
+    redox potentials and may participate in electron transfer.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Directly characterizes ETF as an intermediate electron carrier and the
+      role of the FAD cofactor in electron transfer; supports the electron-transfer-activity and
+      FAD-binding core functions.
+- id: PMID:20833797
+  title: Phosphoproteome analysis of functional mitochondria isolated from resting
+    human muscle reveals extensive phosphorylation of inner membrane protein complexes
+    and enzymes.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Mitochondrial phosphoproteome from human muscle; corroborates mitochondrial localization
+      of ETFA (HDA) but not informative on molecular function.
+- id: PMID:24606901
+  title: Cochaperone binding to LYR motifs confers specificity of iron sulfur cluster
+    delivery.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      HSC20/HSCB Fe-S cochaperone study; ETFA appears only as an IntAct interaction partner
+      captured as bare &#34;protein binding&#34;. Not informative for ETFA function.
+- id: PMID:25416781
+  title: Human METTL20 is a mitochondrial lysine methyltransferase that targets the
+    β subunit of electron transfer flavoprotein (ETFβ) and modulates its activity.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text available; describes ETF alpha/beta heterodimer function (electron shuttle from
+      ~13 dehydrogenases to ETF:QO; third major electron provider to the ubiquinone pool) and is
+      the basis for the ComplexPortal IDA annotations. Directly supports the fatty-acid
+      beta-oxidation, amino-acid catabolism, respiratory-electron-transport, and
+      electron-transfer annotations.
+- id: PMID:26618866
+  title: ∆F508 CFTR interactome remodelling promotes rescue of cystic fibrosis.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale CFTR-interactome study; ETFA appears only as an IntAct interaction partner
+      captured as bare &#34;protein binding&#34;. Not informative for ETFA function.
+- id: PMID:27499296
+  title: Mitochondrial Protein Interaction Mapping Identifies Regulators of Respiratory
+    Chain Function.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes LYRM5/ETFRF1 as a deflavinase that directly regulates ETF; the ETFA IntAct
+      annotation is only bare &#34;protein binding&#34; but the study is biologically relevant to ETF
+      regulation.
+- id: PMID:28380382
+  title: A Single Adaptable Cochaperone-Scaffold Complex Delivers Nascent Iron-Sulfur
+    Clusters to Mammalian Respiratory Chain Complexes I-III.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      HSC20 Fe-S delivery study focused on respiratory-chain complexes; ETFA appears only as an
+      IntAct partner captured as bare &#34;protein binding&#34;.
+- id: PMID:3170610
+  title: Molecular cloning and nucleotide sequence of cDNAs encoding the alpha-subunit
+    of human electron transfer flavoprotein.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Original cloning of the human alpha-ETF precursor (333 aa); establishes the mitochondrially
+      processed alpha subunit. Supports mitochondrial localization.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale (BioPlex) interactome; ETFA-ETFB captured as bare &#34;protein binding&#34;. The
+      partnership is better represented by the ETF complex annotation.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-confidence mitochondrial proteome; corroborates mitochondrial localization of ETFA
+      (HTP).
+- id: PMID:35156780
+  title: CFTR interactome mapping using the mammalian membrane two-hybrid high-throughput
+    screening system.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput CFTR two-hybrid screen; ETFA appears only as an IntAct partner captured as
+      bare &#34;protein binding&#34;.
+- id: PMID:35362222
+  title: S1P defects cause a new entity of cataract, alopecia, oral mucosal disorder,
+    and psoriasis-like syndrome.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Demonstrates a direct, ETFA-specific interaction of MBTPS1/S1P with the ETFA/ETFB
+      heterodimer (Co-IP, GST-ETFA pull-down) that stabilizes the complex and promotes FAD
+      incorporation. Biologically meaningful, though the GO annotation is only bare &#34;protein
+      binding&#34;.
+- id: PMID:36012204
+  title: Differential CFTR-Interactome Proximity Labeling Procedures Identify Enrichment
+    in Multiple SLC Transporters.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      CFTR proximity-labeling interactome study; ETFA captured only as bare &#34;protein binding&#34;.
+- id: PMID:3760196
+  title: Biosynthesis of electron transfer flavoprotein in a cell-free system and
+    in cultured human fibroblasts. Defect in the alpha subunit synthesis is a primary
+    lesion in glutaric aciduria type II.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Shows alpha-ETF is synthesized in the cytosol as a precursor, imported into mitochondria,
+      and processed to the mature matrix form; defective alpha-ETF synthesis is a primary lesion
+      in glutaric aciduria type II. Supports matrix localization and disease relevance.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale multimodal cell-mapping study; ETFA-ETFB captured as bare &#34;protein binding&#34;.
+- id: PMID:8504797
+  title: cDNA cloning and mitochondrial import of the beta-subunit of the human electron-transfer
+    flavoprotein.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Cloning/import of the ETF beta subunit, showing it reaches the mitochondrial matrix;
+      supports the matrix localization of the ETF heterodimer.
+- id: PMID:8617498
+  title: &#39;Assignment of Etfdh, Etfb, and Etfa to chromosomes 3, 7, and 13: the mouse
+    homologs of genes responsible for glutaric acidemia type II in human.&#39;
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      States ETF is an obligatory electron acceptor for several dehydrogenases located in the
+      mitochondrial matrix, with electrons transferred to the respiratory chain via ETFDH;
+      supports matrix localization and the electron-shuttle role.
+- id: PMID:8962055
+  title: Three-dimensional structure of human electron transfer flavoprotein to 2.1-A
+    resolution.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Crystal structure of the human ETF heterodimer; establishes the alpha/beta complex, the
+      single FAD (most coordinated by the alpha C-terminal domain), and the electron-shuttle
+      role. Supports the ETF-complex and FAD-binding core functions.
+- id: PMID:9334218
+  title: Expression and characterization of two pathogenic mutations in human electron
+    transfer flavoprotein.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Biochemical characterization of ETF electron transfer from nine primary dehydrogenases to
+      the respiratory chain and the effect of GA2A alpha-subunit mutations on activity and FAD
+      binding. Supports the electron-transfer-activity and FAD-binding core functions.
+- id: Reactome:R-HSA-169260
+  title: Reducing equivalents from beta-oxidation of fatty acids transfer to ETF
+  findings: []
+- id: Reactome:R-HSA-169270
+  title: ETFDH oxidises ETF (reduced) to ETF, reduces CoQ to CoQH2
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/ETFB/ETFB-ai-review.html
+++ b/genes/human/ETFB/ETFB-ai-review.html
@@ -1,0 +1,4539 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ETFB - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ETFB</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P38117" target="_blank" class="term-link">
+                        P38117
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ETFB";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P38117" data-a="DESCRIPTION: ETFB is the beta subunit of the electron-transfer ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ETFB is the beta subunit of the electron-transfer flavoprotein (ETF), a soluble mitochondrial-matrix heterodimer (ETFA + ETFB) that carries a single FAD and one AMP. ETF is the common electron acceptor for a family of matrix FAD-dependent dehydrogenases acting in fatty-acid beta-oxidation, amino-acid catabolism, and choline degradation (including the acyl-CoA dehydrogenases, glutaryl-CoA dehydrogenase, and sarcosine dehydrogenase). Electrons abstracted from these dehydrogenases reduce the ETF-bound FAD, and ETF relays them to the inner-membrane ETF-ubiquinone oxidoreductase (ETFDH) and thence to the respiratory-chain ubiquinone pool, making ETF a third major electron entry point to ubiquinone alongside complexes I and II. The beta subunit provides the AMP-binding site (structural) and a solvent-exposed recognition loop that docks the partner dehydrogenases, positioning them for interprotein electron transfer. Biallelic loss-of-function variants in ETFB (like those in ETFA and ETFDH) cause multiple acyl-CoA dehydrogenase deficiency (MADD) / glutaric acidemia type II.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0009055" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (PAN-GO) inference that ETFB enables electron transfer activity. This is the core molecular function of the ETF heterodimer, in which the beta subunit is an integral partner. Well supported by structural, biochemical, and disease evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Electron transfer activity is the defining, experimentally established molecular function of the ETF complex (accepting electrons from matrix dehydrogenases and relaying them to ETFDH), and ETFB is an obligate structural/recognition component of the electron-transferring heterodimer. The IBA is consistent with the human IDA/TAS annotations below.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link">
+                                        PMID:8962055
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">electron shuttles between primary flavoprotein dehydrogenases involved in</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ETF acts as a mobile electron carrier that shuttles electrons between several FAD-containing dehydrogenases present in the mitochondrial matrix and the membrane-bound ETF:quinone oxidoreductase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference that ETFB is active in the mitochondrion. Correct but less precise than the mitochondrial matrix localization directly demonstrated for the human protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ETFB is a bona fide mitochondrial protein, but the specific and experimentally supported location is the mitochondrial matrix (GO:0005759, IDA below). Retain the broader mitochondrion term as non-core; the matrix term captures the precise location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contains the information necessary to reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033539" target="_blank" class="term-link">
+                                    GO:0033539
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid beta-oxidation using acyl-CoA dehydrogenase</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0033539" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference that ETFB is involved in fatty-acid beta-oxidation via acyl-CoA dehydrogenases. ETF is the obligatory electron acceptor for the matrix acyl-CoA dehydrogenases of fatty-acid beta-oxidation, so this is a core biological process for the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Fatty-acid beta-oxidation via acyl-CoA dehydrogenases depends on ETF accepting electrons from those dehydrogenases; loss of ETFB blocks this flux and causes MADD. Consistent with the human IDA annotation (PMID:25416781) and disease evidence (PMID:7912128).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">e.g. medium chain acyl-CoA dehydrogenase (MCAD), are involved in β-oxidation of fatty acids</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7912128" target="_blank" class="term-link">
+                                        PMID:7912128
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cDNA complements the genetic defect and restores the beta-oxidation flux to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005739" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA machine-learning electronic annotation to mitochondrion. Correct but superseded in precision by the mitochondrial-matrix annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimentally supported mitochondrial-matrix localization; retain as a broader, non-core location term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contains the information necessary to reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation mapping the UniProt subcellular-location term (Mitochondrion matrix) to GO:0005759. Matches the experimentally demonstrated matrix localization of ETFB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ETFB is imported into and resides in the mitochondrial matrix; this is the precise, core cellular location, directly supported by import assays (PMID:8504797) and UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contains the information necessary to reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0009055" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation of electron transfer activity based on the ETF beta-subunit domain signatures (IPR000049, IPR012255). Consistent with the core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro-to-GO mapping correctly assigns the ETF electron transfer activity to ETFB via its family domains; redundant with, and supported by, the IDA/TAS/IBA annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link">
+                                        PMID:8962055
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">electron shuttles between primary flavoprotein dehydrogenases involved in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27499296" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27499296
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial Protein Interaction Mapping Identifies Regulat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005515" data-r="PMID:27499296" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated physical interaction (IPI) of ETFB with ETFA (P13804) and ETFRF1/LYRM5 (Q6IPR1), from a mitochondrial interaction-mapping study. These are real, biologically meaningful interactions (ETFA is the partner subunit; ETFRF1 is the ETF deflavinase), but the GO term itself is the uninformative generic &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The underlying interactions are genuine and important, but bare protein binding (GO:0005515) conveys no specific molecular function. Per curation policy the experimental IPI is retained rather than removed; the informative content (partner-subunit assembly, ETFRF1-mediated deflavination) is captured in core_functions and the ETF-complex annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27499296" target="_blank" class="term-link">
+                                        PMID:27499296
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LYRM5 interacts with and deflavinates</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interactions of ETFB with ETFA (P13804) and ETFRF1 (Q6IPR1) from the proteome-scale BioPlex AP-MS interactome. Uninformative generic protein-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput AP-MS interactome data; the ETFA and ETFRF1 interactions are consistent with the known ETF complex biology, but the generic protein binding term adds no specific functional information. Retained as an experimental IPI per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">BioPlex 3.0, results from affinity purification</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction of ETFB with ETFA (P13804) from a multimodal (AP-MS + immunofluorescence) cell-map study. Generic protein-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ETFA interaction reflects the constitutive ETF heterodimer, but the bare protein binding term is uninformative. Retained as an experimental IPI per policy; specific content is captured by the ETF-complex annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                                        PMID:40205054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">interacting partners were identified by tandem MS (AP–MS)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033539" target="_blank" class="term-link">
+                                    GO:0033539
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid beta-oxidation using acyl-CoA dehydrogenase</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0033539" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Combined multi-method electronic annotation (with mouse ortholog Q9DCW4) to fatty-acid beta-oxidation using acyl-CoA dehydrogenase. Consistent with the curated IDA/IBA annotations of the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant electronic support for a core biological process that is independently established experimentally (PMID:25416781) and by disease complementation (PMID:7912128).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">e.g. medium chain acyl-CoA dehydrogenase (MCAD), are involved in β-oxidation of fatty acids</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8504797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    cDNA cloning and mitochondrial import of the beta-subunit of...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005759" data-r="PMID:8504797" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-2731) non-traceable-author-statement assignment of the matrix location, citing the ETFB cloning/import study. Correct core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited study demonstrated that beta-ETF is imported into the mitochondrial matrix; the matrix is the established core location of the ETF complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contains the information necessary to reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009063" target="_blank" class="term-link">
+                                    GO:0009063
+                                </a>
+                            </span>
+                            <span class="term-label">amino acid catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human METTL20 is a mitochondrial lysine methyltransferase th...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0009063" data-r="PMID:25416781" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IDA assigning ETFB to amino-acid catabolism, reflecting that several ETF-partner dehydrogenases (e.g. glutaryl-CoA and isovaleryl-CoA dehydrogenases) act in amino-acid oxidation. ETF is their obligatory electron acceptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ETF accepts electrons from dehydrogenases involved in amino-acid catabolism (glutaryl-CoA, isovaleryl-CoA dehydrogenases), and ETFB methylation reduces electron uptake from GCDH; loss of ETFB disrupts amino-acid catabolic flux (part of the MADD phenotype). A core biological process, though broader than the fatty-acid term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">glutaryl-CoA dehydrogenase (GCDH) and isovaleryl-CoA dehydrogenase, are involved in the oxidation of amino acids</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022904" target="_blank" class="term-link">
+                                    GO:0022904
+                                </a>
+                            </span>
+                            <span class="term-label">respiratory electron transport chain</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human METTL20 is a mitochondrial lysine methyltransferase th...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0022904" data-r="PMID:25416781" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IDA linking ETFB to the respiratory electron transport chain. ETF relays electrons from matrix dehydrogenases into the ubiquinone pool via ETFDH, acting as a third major electron entry point after complexes I and II.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ETF feeds electrons into the respiratory-chain ubiquinone pool through ETFDH; the cited study explicitly frames ETF as the third major provider of electrons to the ubiquinone pool of the respiratory chain. Core process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">it is the third major provider of electrons to the ubiquinone pool of the mitochondrial respiratory chain</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033539" target="_blank" class="term-link">
+                                    GO:0033539
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid beta-oxidation using acyl-CoA dehydrogenase</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human METTL20 is a mitochondrial lysine methyltransferase th...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0033539" data-r="PMID:25416781" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IDA for fatty-acid beta-oxidation using acyl-CoA dehydrogenase. The cited study shows ETFB receives electrons from medium-chain acyl-CoA dehydrogenase (MCAD), a core beta-oxidation enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental annotation for a core beta-oxidation process. ETF is the electron acceptor for the acyl-CoA dehydrogenases of fatty-acid beta-oxidation, and ETFB methylation modulates electron uptake from MCAD.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reduced its ability to receive electrons from the medium chain acyl-CoA dehydrogenase and the glutaryl-CoA dehydrogenase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045251" target="_blank" class="term-link">
+                                    GO:0045251
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer flavoprotein complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8962055
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Three-dimensional structure of human electron transfer flavo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0045251" data-r="PMID:8962055" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal part_of annotation to the electron transfer flavoprotein complex, based on the human ETF crystal structure showing the alpha/beta heterodimer. This is the specific, core complex for ETFB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The 2.1-A crystal structure defines ETF as a heterodimer in which the beta subunit contributes the third structural domain and the AMP site; ETFB is an obligate part of the ETF complex (ComplexPortal CPX-2731). Precise and correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link">
+                                        PMID:8962055
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">third domain is made up entirely by the beta subunit</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HPA immunofluorescence-based IDA placing ETFB in the mitochondrion. Consistent with the established mitochondrial-matrix localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct mitochondrial localization at organelle resolution; the more precise matrix term is the core location. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contains the information necessary to reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35362222" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35362222
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    S1P defects cause a new entity of cataract, alopecia, oral m...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005515" data-r="PMID:35362222" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt/IntAct IPI recording interaction of ETFB with ETFA (P13804) and MBTPS1/S1P (Q14703). MBTPS1 forms a trimeric complex with ETFA/ETFB that promotes FAD incorporation and stabilizes the heterodimer. Real interactions, but the GO term is generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The MBTPS1 and ETFA interactions are genuine and functionally meaningful (MBTPS1 stabilizes and flavinates the ETF heterodimer), but the bare protein binding term is uninformative. Retained as an experimental IPI per policy; the regulatory content is noted in the notes and core functions rather than as protein binding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35362222" target="_blank" class="term-link">
+                                        PMID:35362222
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">protein that forms a trimeric complex with ETFA/ETFB. S1P enhances ETFA/ETFB</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005739" data-r="PMID:34800366" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput assignment of ETFB to the mitochondrion from a high-confidence quantitative mitochondrial-proteome study. Consistent with the established localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborates mitochondrial localization at organelle resolution; the matrix term is the precise core location. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contains the information necessary to reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-8931858
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005759" data-r="Reactome:R-HSA-8931858" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement (ETFBKMT/METTL20 methylation reaction) placing ETFB in the mitochondrial matrix. Correct core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimentally established matrix localization; the Reactome reaction annotation correctly reflects the matrix compartment where ETFB is methylated and functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contains the information necessary to reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8504797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    cDNA cloning and mitochondrial import of the beta-subunit of...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005759" data-r="PMID:8504797" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt IDA for mitochondrial matrix, from the beta-ETF cloning study demonstrating energy-dependent import of the polypeptide into the matrix. Directly supports the core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited import experiments show that the cDNA-encoded beta-ETF reaches the mitochondrial matrix; this is the primary experimental evidence for the core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contains the information necessary to reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human METTL20 is a mitochondrial lysine methyltransferase th...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0009055" data-r="PMID:25416781" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt IDA for electron transfer activity, from the METTL20/ETFB study that measured ETF-mediated electron transfer from acyl-CoA dehydrogenases to an artificial acceptor and showed methylation of ETFB reduces this activity. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct assay evidence that ETFB participates in electron transfer (accepting electrons from MCAD and GCDH), and that modification of the ETFB recognition loop modulates the rate. This is the defining molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                        PMID:25416781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reduced its ability to receive electrons from the medium chain acyl-CoA dehydrogenase and the glutaryl-CoA dehydrogenase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-169260
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005759" data-r="Reactome:R-HSA-169260" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS (electron transfer from fatty-acid beta-oxidation to ETF) placing ETFB in the matrix compartment. Correct core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with experimentally established matrix localization; Reactome correctly situates the ETF electron-uptake reaction in the mitochondrial matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contains the information necessary to reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-169270
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005759" data-r="Reactome:R-HSA-169270" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS (ETFDH re-oxidizes reduced ETF, reducing CoQ) placing ETFB in the matrix. Correct core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the established matrix localization of ETF; correctly reflects the compartment of the ETF/ETFDH electron-relay reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                                        PMID:8504797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">contains the information necessary to reach the mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7912128" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7912128
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations and polymorphisms of the gene encoding the beta-su...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0009055" data-r="PMID:7912128" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS for electron transfer activity, citing the ETFB glutaric-acidemia-II mutation study. The GA2B mutation R164Q reduces ETF electron transfer activity, supporting the core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Disease-mutation evidence corroborates that ETFB is required for ETF electron transfer activity; complementation with wild-type beta-ETF cDNA restores beta-oxidation flux. Consistent with the IDA/IBA annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7912128" target="_blank" class="term-link">
+                                        PMID:7912128
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cDNA complements the genetic defect and restores the beta-oxidation flux to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8617498" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8617498
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Assignment of Etfdh, Etfb, and Etfa to chromosomes 3, 7, and...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P38117" data-a="GO:0005759" data-r="PMID:8617498" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS for mitochondrial matrix, citing the mouse Etf/Etfdh chromosomal mapping paper, which states ETF is located in the mitochondrial matrix and is an obligatory electron acceptor for several dehydrogenases. Correct core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited review-style statement correctly places ETF in the mitochondrial matrix, consistent with human experimental import data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8617498" target="_blank" class="term-link">
+                                        PMID:8617498
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">obligatory electron acceptor for several dehydrogenases</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Beta subunit of the electron-transfer flavoprotein (ETF) heterodimer; together with ETFA it accepts electrons from matrix FAD-dependent dehydrogenases and relays them to ETF-ubiquinone oxidoreductase, functioning as a mobile electron carrier.</h3>
+                <span class="vote-buttons" data-g="P38117" data-a="FUNCTION: Beta subunit of the electron-transfer flavoprotein..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                            electron transfer activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022904" target="_blank" class="term-link">
+                                respiratory electron transport chain
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045251" target="_blank" class="term-link">
+                            electron transfer flavoprotein complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                PMID:25416781
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">it is the third major provider of electrons to the ubiquinone pool of the mitochondrial respiratory chain</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link">
+                                PMID:8962055
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">electron shuttles between primary flavoprotein dehydrogenases involved in</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As part of ETF, accepts electrons from acyl-CoA dehydrogenases of mitochondrial fatty-acid beta-oxidation (e.g. medium-chain acyl-CoA dehydrogenase), coupling beta-oxidation to the respiratory chain; the ETFB recognition loop docks these dehydrogenases.</h3>
+                <span class="vote-buttons" data-g="P38117" data-a="FUNCTION: As part of ETF, accepts electrons from acyl-CoA de..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                            electron transfer activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033539" target="_blank" class="term-link">
+                                fatty acid beta-oxidation using acyl-CoA dehydrogenase
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045251" target="_blank" class="term-link">
+                            electron transfer flavoprotein complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                                PMID:25416781
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">reduced its ability to receive electrons from the medium chain acyl-CoA dehydrogenase and the glutaryl-CoA dehydrogenase</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7912128" target="_blank" class="term-link">
+                                PMID:7912128
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">cDNA complements the genetic defect and restores the beta-oxidation flux to</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" target="_blank" class="term-link">
+                            PMID:25416781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human METTL20 is a mitochondrial lysine methyltransferase that targets the β subunit of electron transfer flavoprotein (ETFβ) and modulates its activity.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ETF is a mobile electron carrier that shuttles electrons from matrix FAD-containing dehydrogenases to the membrane-bound ETF quinone oxidoreductase, and is the third major provider of electrons to the respiratory-chain ubiquinone pool after complexes I and II. METTL20/ETFBKMT trimethylates ETFB Lys-200/Lys-203 near the recognition loop, reducing electron uptake from MCAD and GCDH.</div>
+
+                        <div class="finding-text">"it is the third major provider of electrons to the ubiquinone pool of the mitochondrial respiratory chain"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27499296" target="_blank" class="term-link">
+                            PMID:27499296
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial Protein Interaction Mapping Identifies Regulators of Respiratory Chain Function.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ETFB interacts with ETFA and ETFRF1/LYRM5; LYRM5 acts as an ETF deflavinase, removing FAD from the electron-transferring flavoprotein that shuttles electrons to coenzyme Q.</div>
+
+                        <div class="finding-text">"LYRM5 interacts with and deflavinates"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Proteome-scale BioPlex AP-MS interactome; source of the IntAct-curated ETFB interactions with ETFA and ETFRF1.</div>
+
+                        <div class="finding-text">"BioPlex 3.0, results from affinity purification"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">High-confidence quantitative human mitochondrial proteome; supports mitochondrial localization of ETFB (HTP).</div>
+
+                        <div class="finding-text">"Quantitative high-confidence human mitochondrial proteome"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35362222" target="_blank" class="term-link">
+                            PMID:35362222
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">S1P defects cause a new entity of cataract, alopecia, oral mucosal disorder, and psoriasis-like syndrome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MBTPS1/S1P is a mitochondrial protein that forms a trimeric complex with ETFA/ETFB, enhancing ETF flavination (FAD incorporation) and stabilizing the heterodimer; loss impairs mitochondrial respiration and fatty-acid beta-oxidation.</div>
+
+                        <div class="finding-text">"protein that forms a trimeric complex with ETFA/ETFB. S1P enhances ETFA/ETFB"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Multimodal (AP-MS + immunofluorescence) cell map; source of the IntAct-curated ETFB-ETFA interaction.</div>
+
+                        <div class="finding-text">"interacting partners were identified by tandem MS (AP–MS)"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7912128" target="_blank" class="term-link">
+                            PMID:7912128
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations and polymorphisms of the gene encoding the beta-subunit of the electron transfer flavoprotein in three patients with glutaric acidemia type II.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Beta-ETF (ETFB) mutations cause glutaric acidemia type II; the R164Q mutation reduces electron transfer activity, and wild-type beta-ETF cDNA restores beta-oxidation flux in patient fibroblasts.</div>
+
+                        <div class="finding-text">"cDNA complements the genetic defect and restores the beta-oxidation flux to"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8504797" target="_blank" class="term-link">
+                            PMID:8504797
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">cDNA cloning and mitochondrial import of the beta-subunit of the human electron-transfer flavoprotein.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The cloned beta-ETF (255 aa) polypeptide contains the information necessary to reach the mitochondrial matrix via energy-dependent import, and lacks a cleavable leader peptide; the mRNA is abundant in liver, heart, and skeletal muscle.</div>
+
+                        <div class="finding-text">"contains the information necessary to reach the mitochondrial matrix"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8617498" target="_blank" class="term-link">
+                            PMID:8617498
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Assignment of Etfdh, Etfb, and Etfa to chromosomes 3, 7, and 13: the mouse homologs of genes responsible for glutaric acidemia type II in human.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ETF (alpha/beta) is an obligatory electron acceptor for several dehydrogenases and is located in the mitochondrial matrix; electrons are transferred to the respiratory chain via ETFDH, and deficiency causes glutaric acidemia type II.</div>
+
+                        <div class="finding-text">"obligatory electron acceptor for several dehydrogenases"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8962055" target="_blank" class="term-link">
+                            PMID:8962055
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Three-dimensional structure of human electron transfer flavoprotein to 2.1-A resolution.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The 2.1-A crystal structure of human ETF shows a heterodimer of three domains, the third contributed entirely by the beta subunit, with FAD in a cleft between subunits; ETF functions as an electron shuttle between primary flavoprotein dehydrogenases and ETF-ubiquinone oxidoreductase.</div>
+
+                        <div class="finding-text">"third domain is made up entirely by the beta subunit"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-169260
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Reducing equivalents from beta-oxidation of fatty acids transfer to ETF</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-169270
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ETFDH oxidises ETF (reduced) to ETF, reduces CoQ to CoQH2</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-8931858
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ETFBKMT transfers 3xCH3 from 3xAdoMet to ETFB</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ETFB-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38117" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="etfb-p38117-review-notes">ETFB (P38117) review notes</h1>
+<h2 id="identity-core-biology">Identity / core biology</h2>
+<p>ETFB is the <strong>beta subunit of the electron-transfer flavoprotein (ETF)</strong>, a soluble<br />
+mitochondrial-matrix FAD-containing heterodimer (ETFA + ETFB). ETF is the common<br />
+electron acceptor for the matrix FAD-dependent acyl-CoA dehydrogenases (fatty-acid<br />
+beta-oxidation and amino-acid catabolism), relaying electrons to ETF-ubiquinone<br />
+oxidoreductase (ETFDH) and thence to the respiratory-chain ubiquinone pool.</p>
+<p>Supporting text:<br />
+- [file:UniProt P38117 FUNCTION "Heterodimeric electron transfer flavoprotein that accepts electrons from several mitochondrial dehydrogenases, including acyl-CoA dehydrogenases, glutaryl-CoA and sarcosine dehydrogenase"]<br />
+- [file:UniProt P38117 FUNCTION "It transfers the electrons to the main mitochondrial respiratory chain via ETF-ubiquinone oxidoreductase"]<br />
+- [PMID:8962055 abstract "They function as electron shuttles between primary flavoprotein dehydrogenases involved in mitochondrial fatty acid and amino acid catabolism and the membrane-bound electron transfer flavoprotein ubiquinone oxidoreductase."]<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" title="ETF acts as a mobile electron carrier that shuttles electrons between several FAD-containing dehydrogenases present in the mitochondrial matrix and the membrane-bound ETF:quinone oxidoreductase">PMID:25416781</a><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/25416781" title="in addition to complexes I and II, it is the third major provider of electrons to the ubiquinone pool of the mitochondrial respiratory chain">PMID:25416781</a></p>
+<h2 id="structure-domain-role-of-beta-subunit">Structure / domain / role of beta subunit</h2>
+<ul>
+<li>Heterodimer: two domains from alpha, third domain entirely from beta; FAD lies in a cleft<br />
+  between subunits, mostly in the C-terminal portion of alpha <a href="https://pubmed.ncbi.nlm.nih.gov/8962055">PMID:8962055</a>.</li>
+<li>ETFB binds an AMP molecule that probably has a purely structural role<br />
+  [file:UniProt FUNCTION].</li>
+<li><strong>Recognition loop</strong> (residues 183-205; ~191-200 in older numbering) at the surface of ETFB<br />
+  recognizes a hydrophobic patch on interacting dehydrogenases and acts as a static anchor<br />
+  [file:UniProt DOMAIN "The recognition loop recognizes a hydrophobic patch at the surface of interacting dehydrogenases and acts as a static anchor at the interface."].</li>
+<li>L195A severely impairs complex formation with ACADM (MCAD) [file:UniProt MUTAGEN 195].</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>Mitochondrial matrix. UniProt SUBCELLULAR LOCATION: "Mitochondrion matrix".</li>
+<li>Imported into matrix; unusual in lacking a cleavable leader peptide; energy-dependent import<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8504797" title="the cDNA-encoded beta-ETF polypeptide contains the information necessary to reach the mitochondrial matrix">PMID:8504797</a>.</li>
+<li>Reactome notes ETF resides on the matrix face of the mitochondrial inner membrane [R-HSA-169260].</li>
+<li>HPA IDA (GO_REF:0000052) and HTP mito proteome (PMID:34800366) both mitochondrion.</li>
+</ul>
+<h2 id="complex">Complex</h2>
+<ul>
+<li>Part of the mitochondrial electron transfer flavoprotein complex (ETFA/ETFB heterodimer;<br />
+  ComplexPortal CPX-2731); GO:0045251 IPI from PMID:8962055 crystal structure.</li>
+</ul>
+<h2 id="regulation-ptm">Regulation / PTM</h2>
+<ul>
+<li>ETFBKMT (METTL20) trimethylates Lys-200 and Lys-203, adjacent to the recognition loop,<br />
+  reducing ETFB's ability to receive electrons from MCAD and GCDH <a href="https://pubmed.ncbi.nlm.nih.gov/25416781">PMID:25416781</a>.</li>
+<li>MBTPS1/S1P forms a trimeric complex with ETFA/ETFB, stabilizing the heterodimer and<br />
+  promoting FAD binding (flavination) <a href="https://pubmed.ncbi.nlm.nih.gov/35362222" title="S1P forms a trimeric complex with ETFA/ETFB. S1P enhances ETFA/ETFB flavination and maintains its stability.">PMID:35362222</a>.</li>
+<li>ETFRF1 (LYRM5) is a "deflavinase" that removes FAD from ETF <a href="https://pubmed.ncbi.nlm.nih.gov/27499296">PMID:27499296</a>.</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>Biallelic ETFB variants cause <strong>multiple acyl-CoA dehydrogenase deficiency (MADD) /<br />
+  glutaric acidemia type II (GA2B, MIM:231680)</strong> [file:UniProt DISEASE; PMID:7912128;<br />
+  PMID:12815589]. GA2B variants D128N (decreased stability) and R164Q (reduced electron<br />
+  transfer activity).</li>
+</ul>
+<h2 id="annotation-review-decisions-summary">Annotation review decisions summary</h2>
+<ul>
+<li>MF electron transfer activity (GO:0009055): CORE. Multiple IDA/TAS/IBA/IEA -&gt; ACCEPT (one core, rest accept).</li>
+<li>BP fatty acid beta-oxidation using acyl-CoA dehydrogenase (GO:0033539): CORE (IDA/IBA/IEA) -&gt; ACCEPT.</li>
+<li>BP amino acid catabolic process (GO:0009063): supported (dehydrogenases in aa catabolism) -&gt; ACCEPT.</li>
+<li>BP respiratory electron transport chain (GO:0022904): supported (feeds ubiquinone pool) -&gt; ACCEPT.</li>
+<li>CC mitochondrial matrix (GO:0005759): CORE location -&gt; ACCEPT.</li>
+<li>CC mitochondrion (GO:0005739): broader; ACCEPT / KEEP_AS_NON_CORE (matrix is more precise).</li>
+<li>CC electron transfer flavoprotein complex (GO:0045251): CORE complex -&gt; ACCEPT.</li>
+<li>protein binding (GO:0005515) IPIs x5: bare protein binding, uninformative -&gt; MARK_AS_OVER_ANNOTATED<br />
+  (do NOT REMOVE experimental IPIs per policy). WITH/FROM: ETFA (P13804), ETFRF1 (Q6IPR1),<br />
+  MBTPS1 via PMID:35362222 (P13804|Q14703). These are real interactions but the GO term itself<br />
+  is uninformative.</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<p>falcon DR file not present within poll window; grounded in UniProt, cached PMIDs, Reactome,<br />
+and the MADD disorder KB.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P38117
+gene_symbol: ETFB
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: ETFB is the beta subunit of the electron-transfer flavoprotein (ETF),
+  a soluble mitochondrial-matrix heterodimer (ETFA + ETFB) that carries a single FAD
+  and one AMP. ETF is the common electron acceptor for a family of matrix FAD-dependent
+  dehydrogenases acting in fatty-acid beta-oxidation, amino-acid catabolism, and choline
+  degradation (including the acyl-CoA dehydrogenases, glutaryl-CoA dehydrogenase, and
+  sarcosine dehydrogenase). Electrons abstracted from these dehydrogenases reduce the
+  ETF-bound FAD, and ETF relays them to the inner-membrane ETF-ubiquinone oxidoreductase
+  (ETFDH) and thence to the respiratory-chain ubiquinone pool, making ETF a third major
+  electron entry point to ubiquinone alongside complexes I and II. The beta subunit
+  provides the AMP-binding site (structural) and a solvent-exposed recognition loop that
+  docks the partner dehydrogenases, positioning them for interprotein electron transfer.
+  Biallelic loss-of-function variants in ETFB (like those in ETFA and ETFDH) cause multiple
+  acyl-CoA dehydrogenase deficiency (MADD) / glutaric acidemia type II.
+alternative_products:
+- name: &#39;1&#39;
+  id: P38117-1
+- name: &#39;2&#39;
+  id: P38117-2
+  sequence_note: VSP_017850
+existing_annotations:
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (PAN-GO) inference that ETFB enables electron transfer activity.
+      This is the core molecular function of the ETF heterodimer, in which the beta
+      subunit is an integral partner. Well supported by structural, biochemical, and
+      disease evidence.
+    action: ACCEPT
+    reason: Electron transfer activity is the defining, experimentally established molecular
+      function of the ETF complex (accepting electrons from matrix dehydrogenases and
+      relaying them to ETFDH), and ETFB is an obligate structural/recognition component
+      of the electron-transferring heterodimer. The IBA is consistent with the human
+      IDA/TAS annotations below.
+    supported_by:
+    - reference_id: PMID:8962055
+      supporting_text: electron shuttles between primary flavoprotein dehydrogenases involved in
+    - reference_id: PMID:25416781
+      supporting_text: &#34;ETF acts as a mobile electron carrier that shuttles electrons between several FAD-containing dehydrogenases present in the mitochondrial matrix and the membrane-bound ETF:quinone oxidoreductase&#34;
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic inference that ETFB is active in the mitochondrion. Correct
+      but less precise than the mitochondrial matrix localization directly demonstrated
+      for the human protein.
+    action: KEEP_AS_NON_CORE
+    reason: ETFB is a bona fide mitochondrial protein, but the specific and experimentally
+      supported location is the mitochondrial matrix (GO:0005759, IDA below). Retain
+      the broader mitochondrion term as non-core; the matrix term captures the precise
+      location.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: contains the information necessary to reach the mitochondrial matrix
+- term:
+    id: GO:0033539
+    label: fatty acid beta-oxidation using acyl-CoA dehydrogenase
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic inference that ETFB is involved in fatty-acid beta-oxidation
+      via acyl-CoA dehydrogenases. ETF is the obligatory electron acceptor for the
+      matrix acyl-CoA dehydrogenases of fatty-acid beta-oxidation, so this is a core
+      biological process for the gene.
+    action: ACCEPT
+    reason: Fatty-acid beta-oxidation via acyl-CoA dehydrogenases depends on ETF accepting
+      electrons from those dehydrogenases; loss of ETFB blocks this flux and causes MADD.
+      Consistent with the human IDA annotation (PMID:25416781) and disease evidence
+      (PMID:7912128).
+    supported_by:
+    - reference_id: PMID:25416781
+      supporting_text: &#34;e.g. medium chain acyl-CoA dehydrogenase (MCAD), are involved in β-oxidation of fatty acids&#34;
+    - reference_id: PMID:7912128
+      supporting_text: cDNA complements the genetic defect and restores the beta-oxidation flux to
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: ARBA machine-learning electronic annotation to mitochondrion. Correct but
+      superseded in precision by the mitochondrial-matrix annotations.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with the experimentally supported mitochondrial-matrix localization;
+      retain as a broader, non-core location term.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: contains the information necessary to reach the mitochondrial matrix
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic annotation mapping the UniProt subcellular-location term
+      (Mitochondrion matrix) to GO:0005759. Matches the experimentally demonstrated
+      matrix localization of ETFB.
+    action: ACCEPT
+    reason: ETFB is imported into and resides in the mitochondrial matrix; this is the
+      precise, core cellular location, directly supported by import assays (PMID:8504797)
+      and UniProt.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: contains the information necessary to reach the mitochondrial matrix
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic annotation of electron transfer activity based on
+      the ETF beta-subunit domain signatures (IPR000049, IPR012255). Consistent with
+      the core molecular function.
+    action: ACCEPT
+    reason: The InterPro-to-GO mapping correctly assigns the ETF electron transfer
+      activity to ETFB via its family domains; redundant with, and supported by, the
+      IDA/TAS/IBA annotations.
+    supported_by:
+    - reference_id: PMID:8962055
+      supporting_text: electron shuttles between primary flavoprotein dehydrogenases involved in
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:27499296
+  qualifier: enables
+  review:
+    summary: IntAct-curated physical interaction (IPI) of ETFB with ETFA (P13804) and
+      ETFRF1/LYRM5 (Q6IPR1), from a mitochondrial interaction-mapping study. These are
+      real, biologically meaningful interactions (ETFA is the partner subunit; ETFRF1
+      is the ETF deflavinase), but the GO term itself is the uninformative generic
+      &#34;protein binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The underlying interactions are genuine and important, but bare protein
+      binding (GO:0005515) conveys no specific molecular function. Per curation policy
+      the experimental IPI is retained rather than removed; the informative content
+      (partner-subunit assembly, ETFRF1-mediated deflavination) is captured in
+      core_functions and the ETF-complex annotation.
+    supported_by:
+    - reference_id: PMID:27499296
+      supporting_text: LYRM5 interacts with and deflavinates
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: IntAct-curated interactions of ETFB with ETFA (P13804) and ETFRF1 (Q6IPR1)
+      from the proteome-scale BioPlex AP-MS interactome. Uninformative generic
+      protein-binding term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: High-throughput AP-MS interactome data; the ETFA and ETFRF1 interactions
+      are consistent with the known ETF complex biology, but the generic protein binding
+      term adds no specific functional information. Retained as an experimental IPI per
+      policy.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: BioPlex 3.0, results from affinity purification
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: IntAct-curated interaction of ETFB with ETFA (P13804) from a multimodal
+      (AP-MS + immunofluorescence) cell-map study. Generic protein-binding term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The ETFA interaction reflects the constitutive ETF heterodimer, but the
+      bare protein binding term is uninformative. Retained as an experimental IPI per
+      policy; specific content is captured by the ETF-complex annotation.
+    supported_by:
+    - reference_id: PMID:40205054
+      supporting_text: &#34;interacting partners were identified by tandem MS (AP–MS)&#34;
+- term:
+    id: GO:0033539
+    label: fatty acid beta-oxidation using acyl-CoA dehydrogenase
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Combined multi-method electronic annotation (with mouse ortholog Q9DCW4)
+      to fatty-acid beta-oxidation using acyl-CoA dehydrogenase. Consistent with the
+      curated IDA/IBA annotations of the same term.
+    action: ACCEPT
+    reason: Redundant electronic support for a core biological process that is
+      independently established experimentally (PMID:25416781) and by disease
+      complementation (PMID:7912128).
+    supported_by:
+    - reference_id: PMID:25416781
+      supporting_text: &#34;e.g. medium chain acyl-CoA dehydrogenase (MCAD), are involved in β-oxidation of fatty acids&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: NAS
+  original_reference_id: PMID:8504797
+  qualifier: located_in
+  review:
+    summary: ComplexPortal (CPX-2731) non-traceable-author-statement assignment of the
+      matrix location, citing the ETFB cloning/import study. Correct core location.
+    action: ACCEPT
+    reason: The cited study demonstrated that beta-ETF is imported into the mitochondrial
+      matrix; the matrix is the established core location of the ETF complex.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: contains the information necessary to reach the mitochondrial matrix
+- term:
+    id: GO:0009063
+    label: amino acid catabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:25416781
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal IDA assigning ETFB to amino-acid catabolism, reflecting that
+      several ETF-partner dehydrogenases (e.g. glutaryl-CoA and isovaleryl-CoA
+      dehydrogenases) act in amino-acid oxidation. ETF is their obligatory electron
+      acceptor.
+    action: ACCEPT
+    reason: ETF accepts electrons from dehydrogenases involved in amino-acid catabolism
+      (glutaryl-CoA, isovaleryl-CoA dehydrogenases), and ETFB methylation reduces
+      electron uptake from GCDH; loss of ETFB disrupts amino-acid catabolic flux (part
+      of the MADD phenotype). A core biological process, though broader than the
+      fatty-acid term.
+    supported_by:
+    - reference_id: PMID:25416781
+      supporting_text: &#34;glutaryl-CoA dehydrogenase (GCDH) and isovaleryl-CoA dehydrogenase, are involved in the oxidation of amino acids&#34;
+- term:
+    id: GO:0022904
+    label: respiratory electron transport chain
+  evidence_type: IDA
+  original_reference_id: PMID:25416781
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal IDA linking ETFB to the respiratory electron transport chain.
+      ETF relays electrons from matrix dehydrogenases into the ubiquinone pool via ETFDH,
+      acting as a third major electron entry point after complexes I and II.
+    action: ACCEPT
+    reason: ETF feeds electrons into the respiratory-chain ubiquinone pool through ETFDH;
+      the cited study explicitly frames ETF as the third major provider of electrons to
+      the ubiquinone pool of the respiratory chain. Core process.
+    supported_by:
+    - reference_id: PMID:25416781
+      supporting_text: it is the third major provider of electrons to the ubiquinone pool of the mitochondrial respiratory chain
+- term:
+    id: GO:0033539
+    label: fatty acid beta-oxidation using acyl-CoA dehydrogenase
+  evidence_type: IDA
+  original_reference_id: PMID:25416781
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal IDA for fatty-acid beta-oxidation using acyl-CoA dehydrogenase.
+      The cited study shows ETFB receives electrons from medium-chain acyl-CoA
+      dehydrogenase (MCAD), a core beta-oxidation enzyme.
+    action: ACCEPT
+    reason: Directly supported experimental annotation for a core beta-oxidation process.
+      ETF is the electron acceptor for the acyl-CoA dehydrogenases of fatty-acid
+      beta-oxidation, and ETFB methylation modulates electron uptake from MCAD.
+    supported_by:
+    - reference_id: PMID:25416781
+      supporting_text: reduced its ability to receive electrons from the medium chain acyl-CoA dehydrogenase and the glutaryl-CoA dehydrogenase
+- term:
+    id: GO:0045251
+    label: electron transfer flavoprotein complex
+  evidence_type: IPI
+  original_reference_id: PMID:8962055
+  qualifier: part_of
+  review:
+    summary: ComplexPortal part_of annotation to the electron transfer flavoprotein
+      complex, based on the human ETF crystal structure showing the alpha/beta
+      heterodimer. This is the specific, core complex for ETFB.
+    action: ACCEPT
+    reason: The 2.1-A crystal structure defines ETF as a heterodimer in which the beta
+      subunit contributes the third structural domain and the AMP site; ETFB is an
+      obligate part of the ETF complex (ComplexPortal CPX-2731). Precise and correct.
+    supported_by:
+    - reference_id: PMID:8962055
+      supporting_text: third domain is made up entirely by the beta subunit
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: HPA immunofluorescence-based IDA placing ETFB in the mitochondrion.
+      Consistent with the established mitochondrial-matrix localization.
+    action: KEEP_AS_NON_CORE
+    reason: Correct mitochondrial localization at organelle resolution; the more precise
+      matrix term is the core location. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: contains the information necessary to reach the mitochondrial matrix
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35362222
+  qualifier: enables
+  review:
+    summary: UniProt/IntAct IPI recording interaction of ETFB with ETFA (P13804) and
+      MBTPS1/S1P (Q14703). MBTPS1 forms a trimeric complex with ETFA/ETFB that promotes
+      FAD incorporation and stabilizes the heterodimer. Real interactions, but the GO
+      term is generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The MBTPS1 and ETFA interactions are genuine and functionally meaningful
+      (MBTPS1 stabilizes and flavinates the ETF heterodimer), but the bare protein
+      binding term is uninformative. Retained as an experimental IPI per policy; the
+      regulatory content is noted in the notes and core functions rather than as protein
+      binding.
+    supported_by:
+    - reference_id: PMID:35362222
+      supporting_text: protein that forms a trimeric complex with ETFA/ETFB. S1P enhances ETFA/ETFB
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: High-throughput assignment of ETFB to the mitochondrion from a
+      high-confidence quantitative mitochondrial-proteome study. Consistent with the
+      established localization.
+    action: KEEP_AS_NON_CORE
+    reason: Corroborates mitochondrial localization at organelle resolution; the matrix
+      term is the precise core location. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: contains the information necessary to reach the mitochondrial matrix
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8931858
+  qualifier: located_in
+  review:
+    summary: Reactome traceable-author-statement (ETFBKMT/METTL20 methylation reaction)
+      placing ETFB in the mitochondrial matrix. Correct core location.
+    action: ACCEPT
+    reason: Consistent with the experimentally established matrix localization; the
+      Reactome reaction annotation correctly reflects the matrix compartment where ETFB
+      is methylated and functions.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: contains the information necessary to reach the mitochondrial matrix
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:8504797
+  qualifier: located_in
+  review:
+    summary: UniProt IDA for mitochondrial matrix, from the beta-ETF cloning study
+      demonstrating energy-dependent import of the polypeptide into the matrix.
+      Directly supports the core location.
+    action: ACCEPT
+    reason: The cited import experiments show that the cDNA-encoded beta-ETF reaches the
+      mitochondrial matrix; this is the primary experimental evidence for the core
+      location.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: contains the information necessary to reach the mitochondrial matrix
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IDA
+  original_reference_id: PMID:25416781
+  qualifier: enables
+  review:
+    summary: UniProt IDA for electron transfer activity, from the METTL20/ETFB study
+      that measured ETF-mediated electron transfer from acyl-CoA dehydrogenases to an
+      artificial acceptor and showed methylation of ETFB reduces this activity. Core
+      molecular function.
+    action: ACCEPT
+    reason: Direct assay evidence that ETFB participates in electron transfer (accepting
+      electrons from MCAD and GCDH), and that modification of the ETFB recognition loop
+      modulates the rate. This is the defining molecular function.
+    supported_by:
+    - reference_id: PMID:25416781
+      supporting_text: reduced its ability to receive electrons from the medium chain acyl-CoA dehydrogenase and the glutaryl-CoA dehydrogenase
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-169260
+  qualifier: located_in
+  review:
+    summary: Reactome TAS (electron transfer from fatty-acid beta-oxidation to ETF)
+      placing ETFB in the matrix compartment. Correct core location.
+    action: ACCEPT
+    reason: Consistent with experimentally established matrix localization; Reactome
+      correctly situates the ETF electron-uptake reaction in the mitochondrial matrix.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: contains the information necessary to reach the mitochondrial matrix
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-169270
+  qualifier: located_in
+  review:
+    summary: Reactome TAS (ETFDH re-oxidizes reduced ETF, reducing CoQ) placing ETFB in
+      the matrix. Correct core location.
+    action: ACCEPT
+    reason: Consistent with the established matrix localization of ETF; correctly
+      reflects the compartment of the ETF/ETFDH electron-relay reaction.
+    supported_by:
+    - reference_id: PMID:8504797
+      supporting_text: contains the information necessary to reach the mitochondrial matrix
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: TAS
+  original_reference_id: PMID:7912128
+  qualifier: enables
+  review:
+    summary: TAS for electron transfer activity, citing the ETFB glutaric-acidemia-II
+      mutation study. The GA2B mutation R164Q reduces ETF electron transfer activity,
+      supporting the core molecular function.
+    action: ACCEPT
+    reason: Disease-mutation evidence corroborates that ETFB is required for ETF
+      electron transfer activity; complementation with wild-type beta-ETF cDNA restores
+      beta-oxidation flux. Consistent with the IDA/IBA annotations.
+    supported_by:
+    - reference_id: PMID:7912128
+      supporting_text: cDNA complements the genetic defect and restores the beta-oxidation flux to
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: PMID:8617498
+  qualifier: located_in
+  review:
+    summary: TAS for mitochondrial matrix, citing the mouse Etf/Etfdh chromosomal
+      mapping paper, which states ETF is located in the mitochondrial matrix and is an
+      obligatory electron acceptor for several dehydrogenases. Correct core location.
+    action: ACCEPT
+    reason: The cited review-style statement correctly places ETF in the mitochondrial
+      matrix, consistent with human experimental import data.
+    supported_by:
+    - reference_id: PMID:8617498
+      supporting_text: obligatory electron acceptor for several dehydrogenases
+core_functions:
+- description: Beta subunit of the electron-transfer flavoprotein (ETF) heterodimer;
+    together with ETFA it accepts electrons from matrix FAD-dependent dehydrogenases
+    and relays them to ETF-ubiquinone oxidoreductase, functioning as a mobile electron
+    carrier.
+  molecular_function:
+    id: GO:0009055
+    label: electron transfer activity
+  directly_involved_in:
+  - id: GO:0022904
+    label: respiratory electron transport chain
+  supported_by:
+  - reference_id: PMID:25416781
+    supporting_text: it is the third major provider of electrons to the ubiquinone pool of the mitochondrial respiratory chain
+  - reference_id: PMID:8962055
+    supporting_text: electron shuttles between primary flavoprotein dehydrogenases involved in
+  in_complex:
+    id: GO:0045251
+    label: electron transfer flavoprotein complex
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+- description: As part of ETF, accepts electrons from acyl-CoA dehydrogenases of
+    mitochondrial fatty-acid beta-oxidation (e.g. medium-chain acyl-CoA dehydrogenase),
+    coupling beta-oxidation to the respiratory chain; the ETFB recognition loop docks
+    these dehydrogenases.
+  molecular_function:
+    id: GO:0009055
+    label: electron transfer activity
+  directly_involved_in:
+  - id: GO:0033539
+    label: fatty acid beta-oxidation using acyl-CoA dehydrogenase
+  supported_by:
+  - reference_id: PMID:25416781
+    supporting_text: reduced its ability to receive electrons from the medium chain acyl-CoA dehydrogenase and the glutaryl-CoA dehydrogenase
+  - reference_id: PMID:7912128
+    supporting_text: cDNA complements the genetic defect and restores the beta-oxidation flux to
+  in_complex:
+    id: GO:0045251
+    label: electron transfer flavoprotein complex
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:25416781
+  title: Human METTL20 is a mitochondrial lysine methyltransferase that targets the
+    β subunit of electron transfer flavoprotein (ETFβ) and modulates its activity.
+  findings:
+  - statement: ETF is a mobile electron carrier that shuttles electrons from matrix
+      FAD-containing dehydrogenases to the membrane-bound ETF quinone oxidoreductase,
+      and is the third major provider of electrons to the respiratory-chain ubiquinone
+      pool after complexes I and II. METTL20/ETFBKMT trimethylates ETFB Lys-200/Lys-203
+      near the recognition loop, reducing electron uptake from MCAD and GCDH.
+    supporting_text: it is the third major provider of electrons to the ubiquinone pool of the mitochondrial respiratory chain
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PMC full text; directly establishes ETFB electron-transfer function,
+      the recognition loop, and its methylation-based regulation. Verified verbatim.
+- id: PMID:27499296
+  title: Mitochondrial Protein Interaction Mapping Identifies Regulators of Respiratory
+    Chain Function.
+  findings:
+  - statement: ETFB interacts with ETFA and ETFRF1/LYRM5; LYRM5 acts as an ETF
+      deflavinase, removing FAD from the electron-transferring flavoprotein that
+      shuttles electrons to coenzyme Q.
+    supporting_text: LYRM5 interacts with and deflavinates
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: PMC full text; supports the ETFA/ETFRF1 interactions underlying the
+      IntAct protein-binding IPIs and the regulation of ETF flavination.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings:
+  - statement: Proteome-scale BioPlex AP-MS interactome; source of the IntAct-curated
+      ETFB interactions with ETFA and ETFRF1.
+    supporting_text: BioPlex 3.0, results from affinity purification
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput interactome; supports the generic protein-binding
+      IPIs only (marked over-annotated).
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings:
+  - statement: High-confidence quantitative human mitochondrial proteome; supports
+      mitochondrial localization of ETFB (HTP).
+    supporting_text: Quantitative high-confidence human mitochondrial proteome
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: HTP proteomics; corroborates mitochondrial localization at organelle
+      resolution.
+- id: PMID:35362222
+  title: S1P defects cause a new entity of cataract, alopecia, oral mucosal disorder,
+    and psoriasis-like syndrome.
+  findings:
+  - statement: MBTPS1/S1P is a mitochondrial protein that forms a trimeric complex with
+      ETFA/ETFB, enhancing ETF flavination (FAD incorporation) and stabilizing the
+      heterodimer; loss impairs mitochondrial respiration and fatty-acid beta-oxidation.
+    supporting_text: protein that forms a trimeric complex with ETFA/ETFB. S1P enhances ETFA/ETFB
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: PMC full text; supports the ETFA/MBTPS1 protein-binding IPI and the
+      regulation of ETF stability/flavination.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings:
+  - statement: Multimodal (AP-MS + immunofluorescence) cell map; source of the
+      IntAct-curated ETFB-ETFA interaction.
+    supporting_text: &#34;interacting partners were identified by tandem MS (AP–MS)&#34;
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput cell-mapping study; supports the generic
+      protein-binding IPI only (marked over-annotated).
+- id: PMID:7912128
+  title: Mutations and polymorphisms of the gene encoding the beta-subunit of the
+    electron transfer flavoprotein in three patients with glutaric acidemia type II.
+  findings:
+  - statement: Beta-ETF (ETFB) mutations cause glutaric acidemia type II; the R164Q
+      mutation reduces electron transfer activity, and wild-type beta-ETF cDNA restores
+      beta-oxidation flux in patient fibroblasts.
+    supporting_text: cDNA complements the genetic defect and restores the beta-oxidation flux to
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract-only cache; establishes disease relevance and functional
+      requirement of ETFB for beta-oxidation flux. Verified verbatim from abstract.
+- id: PMID:8504797
+  title: cDNA cloning and mitochondrial import of the beta-subunit of the human electron-transfer
+    flavoprotein.
+  findings:
+  - statement: The cloned beta-ETF (255 aa) polypeptide contains the information
+      necessary to reach the mitochondrial matrix via energy-dependent import, and
+      lacks a cleavable leader peptide; the mRNA is abundant in liver, heart, and
+      skeletal muscle.
+    supporting_text: contains the information necessary to reach the mitochondrial matrix
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract-only cache; primary evidence for ETFB matrix localization.
+      Verified verbatim from abstract.
+- id: PMID:8617498
+  title: &#39;Assignment of Etfdh, Etfb, and Etfa to chromosomes 3, 7, and 13: the mouse
+    homologs of genes responsible for glutaric acidemia type II in human.&#39;
+  findings:
+  - statement: ETF (alpha/beta) is an obligatory electron acceptor for several
+      dehydrogenases and is located in the mitochondrial matrix; electrons are
+      transferred to the respiratory chain via ETFDH, and deficiency causes glutaric
+      acidemia type II.
+    supporting_text: obligatory electron acceptor for several dehydrogenases
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Abstract-only cache; supports matrix localization and obligatory
+      electron-acceptor role. Verified verbatim from abstract.
+- id: PMID:8962055
+  title: Three-dimensional structure of human electron transfer flavoprotein to 2.1-A
+    resolution.
+  findings:
+  - statement: The 2.1-A crystal structure of human ETF shows a heterodimer of three
+      domains, the third contributed entirely by the beta subunit, with FAD in a cleft
+      between subunits; ETF functions as an electron shuttle between primary
+      flavoprotein dehydrogenases and ETF-ubiquinone oxidoreductase.
+    supporting_text: third domain is made up entirely by the beta subunit
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract-only cache; structural basis for the ETF complex and the
+      beta-subunit domain. Verified verbatim from abstract.
+- id: Reactome:R-HSA-169260
+  title: Reducing equivalents from beta-oxidation of fatty acids transfer to ETF
+  findings: []
+- id: Reactome:R-HSA-169270
+  title: ETFDH oxidises ETF (reduced) to ETF, reduces CoQ to CoQH2
+  findings: []
+- id: Reactome:R-HSA-8931858
+  title: ETFBKMT transfers 3xCH3 from 3xAdoMet to ETFB
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/ETFDH/ETFDH-ai-review.html
+++ b/genes/human/ETFDH/ETFDH-ai-review.html
@@ -1,0 +1,5219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ETFDH - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ETFDH</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q16134" target="_blank" class="term-link">
+                        Q16134
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ETFDH";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q16134" data-a="DESCRIPTION: Electron transfer flavoprotein-ubiquinone oxidored..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO / ETF dehydrogenase; EC 1.5.5.1), a monotopic iron-sulfur flavoprotein of the mitochondrial inner membrane. It accepts electrons from reduced electron-transfer flavoprotein (ETF, the matrix ETFA/ETFB heterodimer) and passes them to ubiquinone in the respiratory chain. This is the terminal step of an electron-transfer relay that couples the FAD-dependent flavoprotein dehydrogenases of fatty-acid beta-oxidation and amino-acid/choline catabolism to oxidative phosphorylation, reducing the ubiquinone pool. Each mature monomer carries one FAD and one [4Fe-4S] cluster. Loss of function causes glutaric aciduria type II / multiple acyl-CoA dehydrogenase deficiency (MADD), which in its late-onset myopathic form is frequently riboflavin-responsive and associated with a secondary coenzyme Q10 deficiency.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0005743" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO is an integral (monotopic) protein of the mitochondrial inner membrane, where it acts. This is the core subcellular location and is directly supported by experiment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence and structural data localize ETF-QO to the inner mitochondrial membrane; the IBA annotation is at the correct level of specificity and matches the human IDA below (PMID:8306995).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link">
+                                        PMID:8306995
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Electron-transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) in the inner mitochondrial membrane accepts electrons from electron-transfer flavoprotein</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link">
+                                        PMID:17050691
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) is a 4Fe4S flavoprotein located in the inner mitochondrial membrane.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004174" target="_blank" class="term-link">
+                                    GO:0004174
+                                </a>
+                            </span>
+                            <span class="term-label">electron-transferring-flavoprotein dehydrogenase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0004174" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the defining molecular function of ETFDH (EC 1.5.5.1): oxidation of reduced ETF with reduction of ubiquinone. Strongly supported by direct human enzymology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IBA annotation matches the multiple human IDA annotations (PMID:12049629, PMID:8306995) and the UniProt catalytic activity. It is the core function of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link">
+                                        PMID:12049629
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) is an iron-sulphur flavoprotein and a component of an electron-transfer system that links 10 different mitochondrial flavoprotein dehydrogenases to the mitochondrial bc1 complex via electron transfer flavoprotein (ETF) and ubiquinone.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022900" target="_blank" class="term-link">
+                                    GO:0022900
+                                </a>
+                            </span>
+                            <span class="term-label">electron transport chain</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0022900" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO participates in mitochondrial electron transport by reducing the ubiquinone pool, feeding electrons from primary flavoprotein dehydrogenases into the respiratory chain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and appropriately general biological process; concordant with the human IDA annotations to this term and with the Reactome respiratory-electron-transport annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18037314" target="_blank" class="term-link">
+                                        PMID:18037314
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) is a membrane-bound electron transfer protein that links primary flavoprotein dehydrogenases with the main respiratory chain.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004174" target="_blank" class="term-link">
+                                    GO:0004174
+                                </a>
+                            </span>
+                            <span class="term-label">electron-transferring-flavoprotein dehydrogenase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0004174" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of the core catalytic activity via InterPro/RHEA/EC mapping (EC 1.5.5.1, RHEA:24052). Consistent with experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IEA maps IPR040156 (ETF-QO) and EC 1.5.5.1 to GO:0004174, the experimentally established function; correct and specific.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link">
+                                        PMID:12049629
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a component of an electron-transfer system that links 10 different mitochondrial flavoprotein dehydrogenases to the mitochondrial bc1 complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0005739" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad mitochondrial localization (ARBA electronic). Correct but less specific than the experimentally supported inner-membrane location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate but a general parent of the inner-membrane annotation; retained as a broader, non-core localization statement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link">
+                                        PMID:8306995
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which targets the protein to mitochondria</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Inner-membrane localization from UniProt Subcellular Location mapping (SL-0168). Matches the experimental IDA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and specific; equivalent to the experimentally supported location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link">
+                                        PMID:17050691
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ETF-QO is a monotopic integral membrane protein.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022900" target="_blank" class="term-link">
+                                    GO:0022900
+                                </a>
+                            </span>
+                            <span class="term-label">electron transport chain</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0022900" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic assignment of electron transport chain involvement; matches the experimentally supported process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with IBA and human IDA annotations to the same term; correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18037314" target="_blank" class="term-link">
+                                        PMID:18037314
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a membrane-bound electron transfer protein that links primary flavoprotein dehydrogenases with the main respiratory chain</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051536" target="_blank" class="term-link">
+                                    GO:0051536
+                                </a>
+                            </span>
+                            <span class="term-label">iron-sulfur cluster binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0051536" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO binds one [4Fe-4S] cluster; this InterPro-derived term is the broader parent of the more specific IDA-supported GO:0051539.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but less specific than 4 iron, 4 sulfur cluster binding (GO:0051539); retained as a broader cofactor-binding statement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link">
+                                        PMID:8306995
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The two redox centers in the protein, FAD and a [4Fe4S]+2,+1 cluster, are present in a 64-kDa monomer.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Seven high-throughput yeast two-hybrid interactions (HuRI) with keratin-associated proteins, transcription factors (OTX1, GSC2, ZNF581) and other proteins (MYH7B, TRIM69, KRTAP11-1/13-2) that share no compartment or pathway with this mitochondrial inner-membrane oxidoreductase. The bare &#34;protein binding&#34; term is also uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> These are large-scale binary-interactome (Y2H) hits from a reference interactome map with no functional context; the partners are cytoplasmic/nuclear and biologically implausible for an inner-membrane enzyme, and the generic term conveys no molecular function. Marked as over-annotated per policy rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A reference map of the human binary protein interactome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006979" target="_blank" class="term-link">
+                                    GO:0006979
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxidative stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0006979" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ortholog-transferred (Ensembl Compara, from mouse Etfdh) association with oxidative-stress response. This is a downstream/phenotypic consequence rather than a direct molecular function of the electron-transfer reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The term is electronically transferred from the mouse ortholog and reflects a secondary phenotype (impaired electron flux increases electron leak/ROS) rather than a core activity of ETF-QO; retained but flagged as over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000107
+
+                                </span>
+
+                                <div class="support-text">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022904" target="_blank" class="term-link">
+                                    GO:0022904
+                                </a>
+                            </span>
+                            <span class="term-label">respiratory electron transport chain</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-611105
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0022904" data-r="Reactome:R-HSA-611105" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome places ETFDH in respiratory electron transport, reducing coenzyme Q; a correct, specific process for this enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Traceable author statement (Reactome) consistent with the enzyme&#39;s role of feeding electrons into the ubiquinone pool of the respiratory chain.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link">
+                                        PMID:17050691
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It catalyzes ubiquinone (UQ) reduction by ETF, linking oxidation of fatty acids and some amino acids to the mitochondrial respiratory chain.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004174" target="_blank" class="term-link">
+                                    GO:0004174
+                                </a>
+                            </span>
+                            <span class="term-label">electron-transferring-flavoprotein dehydrogenase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-169270
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0004174" data-r="Reactome:R-HSA-169270" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome reaction (ETFDH oxidises reduced ETF, reduces CoQ to CoQH2) assigning the core catalytic activity. Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with experimental IDA and the enzyme&#39;s EC 1.5.5.1 catalytic activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link">
+                                        PMID:12049629
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The steady-state kinetic constants of human ETF-QO were determined with ubiquinone homologues, a ubiquinone analogue, and with human wild-type ETF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Immunofluorescence (HPA) localizes ETFDH to mitochondria. Correct but a broad parent of the specific inner-membrane location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate general localization; less specific than the inner-membrane annotation, so kept as a non-core broader term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link">
+                                        PMID:8306995
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which targets the protein to mitochondria</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0005739" data-r="PMID:34800366" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteomics identifies ETFDH as a mitochondrial protein. Correct but broad.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supports mitochondrial localization at low specificity; consistent with the experimentally established inner-membrane location, kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                                        PMID:34800366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Quantitative high-confidence human mitochondrial proteome and its dynamics</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-169270
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0005743" data-r="Reactome:R-HSA-169270" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome asserts inner-membrane localization for the ETFDH reaction; matches experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct, specific location concordant with the IDA and structural evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link">
+                                        PMID:17050691
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) is a 4Fe4S flavoprotein located in the inner mitochondrial membrane.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033539" target="_blank" class="term-link">
+                                    GO:0033539
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid beta-oxidation using acyl-CoA dehydrogenase</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17412732" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17412732
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The myopathic form of coenzyme Q10 deficiency is caused by m...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0033539" data-r="PMID:17412732" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETFDH mutations cause multiple acyl-CoA dehydrogenase deficiency with impaired fatty-acid beta-oxidation flux; ETF-QO is the electron acceptor for the acyl-CoA dehydrogenation step, so its loss blocks beta-oxidation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IMP evidence from patients with ETFDH mutations demonstrates the gene&#39;s required role in the acyl-CoA dehydrogenase branch of fatty-acid beta-oxidation (electron sink); this is the biologically central metabolic process that ETF-QO enables.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17412732" target="_blank" class="term-link">
+                                        PMID:17412732
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All of our patients carried autosomal recessive mutations in ETFDH, suggesting that ETFDH deficiency leads to a secondary CoQ10 deficiency.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link">
+                                        PMID:17050691
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">linking oxidation of fatty acids and some amino acids to the mitochondrial respiratory chain</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004174" target="_blank" class="term-link">
+                                    GO:0004174
+                                </a>
+                            </span>
+                            <span class="term-label">electron-transferring-flavoprotein dehydrogenase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14640977" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14640977
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Alternative quinone substrates and inhibitors of human elect...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0004174" data-r="PMID:14640977" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct kinetic characterization of human ETF-QO catalyzing electron transfer from ETF to the ubiquinone pool. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Steady-state kinetics of purified human enzyme with ETF and ubiquinone substrates directly demonstrate the EC 1.5.5.1 activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14640977" target="_blank" class="term-link">
+                                        PMID:14640977
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a membrane-bound iron-sulphur flavoprotein that participates in an electron-transport pathway between eleven mitochondrial flavoprotein dehydrogenases and the ubiquinone pool</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006979" target="_blank" class="term-link">
+                                    GO:0006979
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxidative stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0006979" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer from the mouse ortholog (Q921G7) of an oxidative-stress response role; a secondary/phenotypic association rather than a direct function of the electron-transfer reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As with the Ensembl IEA to the same term, this is transferred from mouse and reflects a downstream phenotype of impaired electron flux (increased ROS/electron leak), not a core molecular function; flagged as over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000024
+
+                                </span>
+
+                                <div class="support-text">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016491" target="_blank" class="term-link">
+                                    GO:0016491
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14640977" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14640977
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Alternative quinone substrates and inhibitors of human elect...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0016491" data-r="PMID:14640977" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO is an oxidoreductase, but this is the very general parent of the specific GO:0004174 activity established in the same study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct in essence but far too general given that the specific dehydrogenase activity (GO:0004174) is annotated with the same experimental evidence; retained as an over-annotation rather than as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14640977" target="_blank" class="term-link">
+                                        PMID:14640977
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The steady-state kinetic constants of human ETF-QO were determined with ubiquinone homologues and analogues</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048038" target="_blank" class="term-link">
+                                    GO:0048038
+                                </a>
+                            </span>
+                            <span class="term-label">quinone binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14640977" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14640977
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Alternative quinone substrates and inhibitors of human elect...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0048038" data-r="PMID:14640977" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Fluorescence titrations demonstrate a single quinone-binding site per ETF-QO monomer. Correct; the parent of the more specific ubiquinone binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported but broader than the specific ubiquinone binding annotation (GO:0048039); kept as a non-core broader term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14640977" target="_blank" class="term-link">
+                                        PMID:14640977
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consistent with one ubiquinone-binding site per ETF-QO monomer</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048039" target="_blank" class="term-link">
+                                    GO:0048039
+                                </a>
+                            </span>
+                            <span class="term-label">ubiquinone binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14640977" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14640977
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Alternative quinone substrates and inhibitors of human elect...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0048039" data-r="PMID:14640977" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO binds ubiquinone at a single site per monomer and reduces it; the physiological electron acceptor. Core function-related binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct biophysical evidence (fluorescence titration, kinetics) for a specific ubiquinone-binding site; structurally corroborated. Specific and correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14640977" target="_blank" class="term-link">
+                                        PMID:14640977
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">determined by fluorescence titrations of the protein with DBMIB and 6-(10-bromodecyl)ubiquinone, are consistent with one ubiquinone-binding site per ETF-QO monomer</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link">
+                                        PMID:17050691
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The UQ-binding pocket consists mainly of hydrophobic residues</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051539" target="_blank" class="term-link">
+                                    GO:0051539
+                                </a>
+                            </span>
+                            <span class="term-label">4 iron, 4 sulfur cluster binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18037314" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18037314
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Electron spin relaxation enhancement measurements of intersp...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0051539" data-r="PMID:18037314" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> EPR/electron-spin-relaxation measurements confirm a single [4Fe-4S] cluster in human ETF-QO. Core cofactor binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct spectroscopic evidence for one [4Fe-4S] cluster per monomer; specific and correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18037314" target="_blank" class="term-link">
+                                        PMID:18037314
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human, porcine, and Rhodobacter sphaeroides ETF-QO each contain a single [4Fe-4S](2+,1+) cluster and one equivalent of FAD</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004174" target="_blank" class="term-link">
+                                    GO:0004174
+                                </a>
+                            </span>
+                            <span class="term-label">electron-transferring-flavoprotein dehydrogenase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12049629
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression of human electron transfer flavoprotein-ubiquinon...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0004174" data-r="PMID:12049629" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Kinetic and spectral characterization of recombinant human ETF-QO establishes the core EC 1.5.5.1 activity with ETF and ubiquinone substrates.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct enzymology of the human protein; the defining molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link">
+                                        PMID:12049629
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The steady-state kinetic constants of human ETF-QO were determined with ubiquinone homologues, a ubiquinone analogue, and with human wild-type ETF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004174" target="_blank" class="term-link">
+                                    GO:0004174
+                                </a>
+                            </span>
+                            <span class="term-label">electron-transferring-flavoprotein dehydrogenase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8306995
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning and expression of a cDNA encoding human el...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0004174" data-r="PMID:8306995" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Heterologously expressed human ETF-QO transfers electrons from ETF to ubiquinone, demonstrating the core catalytic activity with both cofactors correctly inserted.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct functional demonstration of ETF-to-ubiquinone electron transfer by the human enzyme; defining molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link">
+                                        PMID:8306995
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The detergent-solubilized protein transfers electrons from ETF to the ubiquinone homolog, Q1, indicating that both the FAD and iron-sulfur cluster are properly inserted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8306995
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning and expression of a cDNA encoding human el...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0005743" data-r="PMID:8306995" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence that the mature ETF-QO resides in the inner mitochondrial membrane. Core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental localization of the processed 64-kDa mature protein to the mitochondrial (inner) membrane; matches structural data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link">
+                                        PMID:8306995
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Electron-transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) in the inner mitochondrial membrane accepts electrons from electron-transfer flavoprotein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12049629
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression of human electron transfer flavoprotein-ubiquinon...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0009055" data-r="PMID:12049629" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO functions as an electron carrier, transferring electrons from ETF to ubiquinone. Correct, though broader than the specific dehydrogenase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate description of the electron-carrier property; kept as a correct but more general companion to the specific GO:0004174 core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link">
+                                        PMID:12049629
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a component of an electron-transfer system that links 10 different mitochondrial flavoprotein dehydrogenases to the mitochondrial bc1 complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
+                                    GO:0009055
+                                </a>
+                            </span>
+                            <span class="term-label">electron transfer activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8306995
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning and expression of a cDNA encoding human el...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0009055" data-r="PMID:8306995" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO transfers electrons from ETF to ubiquinone, acting as an electron carrier in the relay to the respiratory chain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct electron-carrier description; retained as a general companion to the specific dehydrogenase activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link">
+                                        PMID:8306995
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The detergent-solubilized protein transfers electrons from ETF to the ubiquinone homolog, Q1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022900" target="_blank" class="term-link">
+                                    GO:0022900
+                                </a>
+                            </span>
+                            <span class="term-label">electron transport chain</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12049629
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression of human electron transfer flavoprotein-ubiquinon...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0022900" data-r="PMID:12049629" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO participates in the mitochondrial electron transport chain, linking flavoprotein dehydrogenases to the bc1 complex via ubiquinone.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct evidence for the enzyme&#39;s role in feeding electrons into the respiratory electron transport chain via the ubiquinone pool.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link">
+                                        PMID:12049629
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">links 10 different mitochondrial flavoprotein dehydrogenases to the mitochondrial bc1 complex via electron transfer flavoprotein (ETF) and ubiquinone</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022900" target="_blank" class="term-link">
+                                    GO:0022900
+                                </a>
+                            </span>
+                            <span class="term-label">electron transport chain</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8306995
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular cloning and expression of a cDNA encoding human el...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0022900" data-r="PMID:8306995" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO reduces ubiquinone in the mitochondrial membrane, participating in the electron transport chain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct evidence that the enzyme reduces ubiquinone, its role in the respiratory electron transport chain.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link">
+                                        PMID:8306995
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reduces ubiquinone in the mitochondrial membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031966" target="_blank" class="term-link">
+                                    GO:0031966
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12049629
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression of human electron transfer flavoprotein-ubiquinon...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0031966" data-r="PMID:12049629" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO is an integral mitochondrial membrane protein; correct but a broad parent of the specific inner-membrane location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate but less specific than mitochondrial inner membrane (GO:0005743); kept as a broader, non-core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link">
+                                        PMID:12049629
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ETF-QO is an integral membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050660" target="_blank" class="term-link">
+                                    GO:0050660
+                                </a>
+                            </span>
+                            <span class="term-label">flavin adenine dinucleotide binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17050691
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of electron transfer flavoprotein-ubiquinone oxido...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q16134" data-a="GO:0050660" data-r="PMID:17050691" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ETF-QO carries one FAD cofactor essential for electron transfer; supported by the structure of the porcine ortholog (source of ISS) and confirmed for the human enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> FAD binding is a core cofactor function; the crystal structure defines the FAD site, and the human enzyme is spectroscopically shown to contain one FAD equivalent. Correct and specific.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link">
+                                        PMID:17050691
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Three functional regions bind FAD, the 4Fe4S cluster, and UQ</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18037314" target="_blank" class="term-link">
+                                        PMID:18037314
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">each contain a single [4Fe-4S](2+,1+) cluster and one equivalent of FAD</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Electron-transferring-flavoprotein dehydrogenase (ETF-QO, EC 1.5.5.1): oxidizes reduced electron-transfer flavoprotein and reduces ubiquinone in the mitochondrial inner membrane, using bound FAD and a [4Fe-4S] cluster as redox relays.</h3>
+                <span class="vote-buttons" data-g="Q16134" data-a="FUNCTION: Electron-transferring-flavoprotein dehydrogenase (..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004174" target="_blank" class="term-link">
+                            electron-transferring-flavoprotein dehydrogenase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022904" target="_blank" class="term-link">
+                                respiratory electron transport chain
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link">
+                                PMID:12049629
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">a component of an electron-transfer system that links 10 different mitochondrial flavoprotein dehydrogenases to the mitochondrial bc1 complex via electron transfer flavoprotein (ETF) and ubiquinone</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link">
+                                PMID:17050691
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">It catalyzes ubiquinone (UQ) reduction by ETF, linking oxidation of fatty acids and some amino acids to the mitochondrial respiratory chain.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Ubiquinone binding at a single hydrophobic site per monomer, positioning the physiological electron acceptor for reduction to ubiquinol.</h3>
+                <span class="vote-buttons" data-g="Q16134" data-a="FUNCTION: Ubiquinone binding at a single hydrophobic site pe..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048039" target="_blank" class="term-link">
+                            ubiquinone binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14640977" target="_blank" class="term-link">
+                                PMID:14640977
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">consistent with one ubiquinone-binding site per ETF-QO monomer</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>FAD cofactor binding; the flavin is a core redox center that shuttles electrons from reduced ETF toward ubiquinone.</h3>
+                <span class="vote-buttons" data-g="Q16134" data-a="FUNCTION: FAD cofactor binding; the flavin is a core redox c..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050660" target="_blank" class="term-link">
+                            flavin adenine dinucleotide binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18037314" target="_blank" class="term-link">
+                                PMID:18037314
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">each contain a single [4Fe-4S](2+,1+) cluster and one equivalent of FAD</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>[4Fe-4S] cluster binding; a single iron-sulfur cluster serves as the second redox center of ETF-QO.</h3>
+                <span class="vote-buttons" data-g="Q16134" data-a="FUNCTION: [4Fe-4S] cluster binding; a single iron-sulfur clu..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051539" target="_blank" class="term-link">
+                            4 iron, 4 sulfur cluster binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18037314" target="_blank" class="term-link">
+                                PMID:18037314
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Human, porcine, and Rhodobacter sphaeroides ETF-QO each contain a single [4Fe-4S](2+,1+) cluster and one equivalent of FAD</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Links fatty-acid beta-oxidation (acyl-CoA dehydrogenase branch) to the respiratory chain by accepting the electrons generated during acyl-CoA dehydrogenation via ETF; loss of ETFDH blocks this flux and causes multiple acyl-CoA dehydrogenase deficiency.</h3>
+                <span class="vote-buttons" data-g="Q16134" data-a="FUNCTION: Links fatty-acid beta-oxidation (acyl-CoA dehydrog..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004174" target="_blank" class="term-link">
+                            electron-transferring-flavoprotein dehydrogenase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033539" target="_blank" class="term-link">
+                                fatty acid beta-oxidation using acyl-CoA dehydrogenase
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17412732" target="_blank" class="term-link">
+                                PMID:17412732
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">All of our patients carried autosomal recessive mutations in ETFDH, suggesting that ETFDH deficiency leads to a secondary CoQ10 deficiency.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link">
+                                PMID:17050691
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">linking oxidation of fatty acids and some amino acids to the mitochondrial respiratory chain</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12049629" target="_blank" class="term-link">
+                            PMID:12049629
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Expression of human electron transfer flavoprotein-ubiquinone oxidoreductase from a baculovirus vector: kinetic and spectral characterization of the human protein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14640977" target="_blank" class="term-link">
+                            PMID:14640977
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Alternative quinone substrates and inhibitors of human electron-transfer flavoprotein-ubiquinone oxidoreductase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17050691" target="_blank" class="term-link">
+                            PMID:17050691
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of electron transfer flavoprotein-ubiquinone oxidoreductase and electron transfer to the mitochondrial ubiquinone pool.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17412732" target="_blank" class="term-link">
+                            PMID:17412732
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The myopathic form of coenzyme Q10 deficiency is caused by mutations in the electron-transferring-flavoprotein dehydrogenase (ETFDH) gene.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18037314" target="_blank" class="term-link">
+                            PMID:18037314
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electron spin relaxation enhancement measurements of interspin distances in human, porcine, and Rhodobacter electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO).</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8306995" target="_blank" class="term-link">
+                            PMID:8306995
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular cloning and expression of a cDNA encoding human electron transfer flavoprotein-ubiquinone oxidoreductase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-169270
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ETFDH oxidises ETF (reduced) to ETF, reduces CoQ to CoQH2</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-611105
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Respiratory electron transport</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ETFDH-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q16134" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="etfdh-human-uniprotkbq16134-review-notes">ETFDH (human, UniProtKB:Q16134) — review notes</h1>
+<h2 id="summary-of-gene-function">Summary of gene function</h2>
+<p>ETFDH encodes <strong>electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO / ETF<br />
+dehydrogenase; EC 1.5.5.1)</strong>, a monotopic iron-sulfur flavoprotein of the mitochondrial<br />
+<strong>inner membrane</strong>. It accepts electrons from reduced electron-transfer flavoprotein (ETF,<br />
+the matrix-soluble ETFA/ETFB heterodimer) and transfers them to <strong>ubiquinone</strong> in the<br />
+respiratory chain. This is the terminal step of an electron-transfer relay that couples<br />
+~10-11 mitochondrial FAD-dependent flavoprotein dehydrogenases (fatty-acid beta-oxidation<br />
+acyl-CoA dehydrogenases; amino-acid and choline catabolism dehydrogenases) to oxidative<br />
+phosphorylation.</p>
+<p>Cofactors: one <strong>FAD</strong> and one <strong>[4Fe-4S] cluster</strong>; both redox centers are in a 64-kDa<br />
+mature monomer.</p>
+<h2 id="key-provenance">Key provenance</h2>
+<ul>
+<li>Reaction / linkage to respiratory chain:<br />
+  [file:UniProt Q16134 FUNCTION "Links fatty acid beta-oxidation and amino acid catabolism to the respiratory chain by transferring electrons from the electron transfer flavoprotein (ETF) to ubiquinone."]</li>
+<li>Inner membrane localization &amp; mechanism (both cofactors in 64-kDa monomer):<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8306995" title="Electron-transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) in the inner mitochondrial membrane accepts electrons from electron-transfer flavoprotein which is located in the mitochondrial matrix and reduces ubiquinone in the mitochondrial membrane. The two redox centers in the protein, FAD and a [4Fe4S]+2,+1 cluster, are present in a 64-kDa monomer.">PMID:8306995</a></li>
+<li>Component of electron-transfer system linking 10 dehydrogenases to bc1:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/12049629" title="Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) is an iron-sulphur flavoprotein and a component of an electron-transfer system that links 10 different mitochondrial flavoprotein dehydrogenases to the mitochondrial bc1 complex via electron transfer flavoprotein (ETF) and ubiquinone.">PMID:12049629</a></li>
+<li>Quinone/ubiquinone binding, single site per monomer:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/14640977" title="consistent with one ubiquinone-binding site per ETF-QO monomer">PMID:14640977</a></li>
+<li>4Fe-4S flavoprotein, inner membrane, catalyzes UQ reduction by ETF:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17050691" title="Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) is a 4Fe4S flavoprotein located in the inner mitochondrial membrane. It catalyzes ubiquinone (UQ) reduction by ETF, linking oxidation of fatty acids and some amino acids to the mitochondrial respiratory chain.">PMID:17050691</a></li>
+<li>Single [4Fe-4S] and one FAD per monomer, links primary flavoprotein dehydrogenases with<br />
+  main respiratory chain:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18037314" title="Human, porcine, and Rhodobacter sphaeroides ETF-QO each contain a single [4Fe-4S](2+,1+) cluster and one equivalent of FAD">PMID:18037314</a></li>
+<li>MADD / secondary CoQ10 deficiency (disease → beta-oxidation involvement):<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17412732" title="All of our patients carried autosomal recessive mutations in ETFDH, suggesting that ETFDH deficiency leads to a secondary CoQ10 deficiency.">PMID:17412732</a></li>
+</ul>
+<h2 id="disease">Disease</h2>
+<p>Biallelic loss-of-function → <strong>glutaric acidemia type II / multiple acyl-CoA dehydrogenase<br />
+deficiency (MADD)</strong>, a disorder of fatty acid, amino acid and choline metabolism; the<br />
+late-onset myopathic form is frequently <strong>riboflavin-responsive</strong> and is associated with a<br />
+<strong>secondary (myopathic) CoQ10 deficiency</strong> (PMID:17412732). Corroborated by the disorder KB<br />
+(<code>dismech/kb/disorders/Multiple_Acyl-CoA_Dehydrogenase_Deficiency.yaml</code>), which also notes an<br />
+ETFDH-CIII-COQ2 metabolon that routes lipid-derived electrons into the respiratory chain.</p>
+<h2 id="annotation-review-reasoning">Annotation review reasoning</h2>
+<ul>
+<li><strong>MF core = GO:0004174</strong> electron-transferring-flavoprotein dehydrogenase activity (EC<br />
+  1.5.5.1). Directly supported by IDA (PMID:12049629, PMID:8306995, PMID:14640977). IBA/IEA/TAS<br />
+  duplicates ACCEPT.</li>
+<li>Cofactor binding: <strong>GO:0050660 FAD binding</strong> (ISS, supported by structure/homolog + UniProt<br />
+  BINDING features); <strong>GO:0051539 4 iron, 4 sulfur cluster binding</strong> (IDA PMID:18037314);<br />
+<strong>GO:0051536 iron-sulfur cluster binding</strong> (IEA) is the parent of 0051539 — accept as broader.</li>
+<li><strong>GO:0048039 ubiquinone binding</strong> (IDA, PMID:14640977) — specific &amp; supported; core.<br />
+<strong>GO:0048038 quinone binding</strong> is its parent (IDA same paper) — accept as broader.</li>
+<li><strong>GO:0009055 electron transfer activity</strong> (IDA x2) — accurate; the enzyme is an electron<br />
+  carrier. Keep (non-core relative to the specific dehydrogenase MF, but correct).</li>
+<li><strong>GO:0016491 oxidoreductase activity</strong> (IDA) — correct but very general parent of GO:0004174;<br />
+  MARK_AS_OVER_ANNOTATED (root-ish MF).</li>
+<li>CC: <strong>GO:0005743 mitochondrial inner membrane</strong> (IBA is_active_in, IDA PMID:8306995, IEA<br />
+  SubCell, TAS Reactome) — core location. <strong>GO:0031966 mitochondrial membrane</strong> (IDA) and<br />
+<strong>GO:0005739 mitochondrion</strong> (IDA/HTP/IEA) are broader parents — accept as broader / non-core.</li>
+<li>BP: <strong>GO:0022900 electron transport chain</strong> (IBA/IDA/IEA) and <strong>GO:0022904 respiratory<br />
+  electron transport chain</strong> (TAS Reactome) — core process; ETF-QO feeds UQ pool.<br />
+<strong>GO:0033539 fatty acid beta-oxidation using acyl-CoA dehydrogenase</strong> (IMP PMID:17412732) —<br />
+  ETFDH is required for FAO flux (electron sink); accept as the biologically central linked<br />
+  process (its role is to accept the electrons from the acyl-CoA dehydrogenation step).</li>
+<li><strong>GO:0006979 response to oxidative stress</strong> (IEA from mouse ortholog Ensembl; ISS from mouse<br />
+  Q921G7) — this is an ortholog-transferred phenotype-adjacent term, not a direct molecular<br />
+  function of ETF-QO; not core. Keep as non-core (mouse ETFDH KO shows oxidative-stress<br />
+  phenotype; over-propagated but not clearly wrong) — MARK_AS_OVER_ANNOTATED / KEEP_AS_NON_CORE.</li>
+<li><strong>GO:0005515 protein binding</strong> (IPI x7, PMID:32296183 HuRI Y2H) — bare protein binding to<br />
+  keratin-associated proteins, transcription factors (OTX1, GSC2, ZNF581), MYH7B, TRIM69 — no<br />
+  functional relevance to a mitochondrial inner-membrane oxidoreductase; classic high-throughput<br />
+  Y2H artifacts. Per policy: MARK_AS_OVER_ANNOTATED (not REMOVE), and per curation guideline the<br />
+  bare "protein binding" term is uninformative.</li>
+</ul>
+<p>Deep research (falcon) file was NOT produced within the 8-min poll window; grounding is from<br />
+UniProt Q16134, seeded GOA, the cached experimental publications above, and the MADD disorder KB.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q16134
+gene_symbol: ETFDH
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO / ETF dehydrogenase;
+  EC 1.5.5.1), a monotopic iron-sulfur flavoprotein of the mitochondrial inner membrane.
+  It accepts electrons from reduced electron-transfer flavoprotein (ETF, the matrix
+  ETFA/ETFB heterodimer) and passes them to ubiquinone in the respiratory chain. This is
+  the terminal step of an electron-transfer relay that couples the FAD-dependent flavoprotein
+  dehydrogenases of fatty-acid beta-oxidation and amino-acid/choline catabolism to oxidative
+  phosphorylation, reducing the ubiquinone pool. Each mature monomer carries one FAD and one
+  [4Fe-4S] cluster. Loss of function causes glutaric aciduria type II / multiple acyl-CoA
+  dehydrogenase deficiency (MADD), which in its late-onset myopathic form is frequently
+  riboflavin-responsive and associated with a secondary coenzyme Q10 deficiency.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q16134-1
+- name: &#39;2&#39;
+  id: Q16134-3
+  sequence_note: VSP_055158
+existing_annotations:
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      ETF-QO is an integral (monotopic) protein of the mitochondrial inner membrane, where
+      it acts. This is the core subcellular location and is directly supported by experiment.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental evidence and structural data localize ETF-QO to the inner
+      mitochondrial membrane; the IBA annotation is at the correct level of specificity and
+      matches the human IDA below (PMID:8306995).
+    supported_by:
+    - reference_id: PMID:8306995
+      supporting_text: &gt;-
+        Electron-transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) in the inner
+        mitochondrial membrane accepts electrons from electron-transfer flavoprotein
+    - reference_id: PMID:17050691
+      supporting_text: &gt;-
+        Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) is a 4Fe4S
+        flavoprotein located in the inner mitochondrial membrane.
+- term:
+    id: GO:0004174
+    label: electron-transferring-flavoprotein dehydrogenase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This is the defining molecular function of ETFDH (EC 1.5.5.1): oxidation of reduced ETF
+      with reduction of ubiquinone. Strongly supported by direct human enzymology.
+    action: ACCEPT
+    reason: &gt;-
+      The IBA annotation matches the multiple human IDA annotations (PMID:12049629,
+      PMID:8306995) and the UniProt catalytic activity. It is the core function of the gene.
+    supported_by:
+    - reference_id: PMID:12049629
+      supporting_text: &gt;-
+        Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) is an iron-sulphur
+        flavoprotein and a component of an electron-transfer system that links 10 different
+        mitochondrial flavoprotein dehydrogenases to the mitochondrial bc1 complex via
+        electron transfer flavoprotein (ETF) and ubiquinone.
+- term:
+    id: GO:0022900
+    label: electron transport chain
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ETF-QO participates in mitochondrial electron transport by reducing the ubiquinone pool,
+      feeding electrons from primary flavoprotein dehydrogenases into the respiratory chain.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and appropriately general biological process; concordant with the human IDA
+      annotations to this term and with the Reactome respiratory-electron-transport annotation.
+    supported_by:
+    - reference_id: PMID:18037314
+      supporting_text: &gt;-
+        Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) is a membrane-bound
+        electron transfer protein that links primary flavoprotein dehydrogenases with the main
+        respiratory chain.
+- term:
+    id: GO:0004174
+    label: electron-transferring-flavoprotein dehydrogenase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic assignment of the core catalytic activity via InterPro/RHEA/EC mapping
+      (EC 1.5.5.1, RHEA:24052). Consistent with experimental data.
+    action: ACCEPT
+    reason: &gt;-
+      The IEA maps IPR040156 (ETF-QO) and EC 1.5.5.1 to GO:0004174, the experimentally
+      established function; correct and specific.
+    supported_by:
+    - reference_id: PMID:12049629
+      supporting_text: &gt;-
+        a component of an electron-transfer system that links 10 different mitochondrial
+        flavoprotein dehydrogenases to the mitochondrial bc1 complex
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Broad mitochondrial localization (ARBA electronic). Correct but less specific than the
+      experimentally supported inner-membrane location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate but a general parent of the inner-membrane annotation; retained as a broader,
+      non-core localization statement.
+    supported_by:
+    - reference_id: PMID:8306995
+      supporting_text: &gt;-
+        which targets the protein to mitochondria
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Inner-membrane localization from UniProt Subcellular Location mapping (SL-0168).
+      Matches the experimental IDA.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and specific; equivalent to the experimentally supported location.
+    supported_by:
+    - reference_id: PMID:17050691
+      supporting_text: &gt;-
+        ETF-QO is a monotopic integral membrane protein.
+- term:
+    id: GO:0022900
+    label: electron transport chain
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic assignment of electron transport chain involvement; matches the
+      experimentally supported process.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with IBA and human IDA annotations to the same term; correct.
+    supported_by:
+    - reference_id: PMID:18037314
+      supporting_text: &gt;-
+        a membrane-bound electron transfer protein that links primary flavoprotein
+        dehydrogenases with the main respiratory chain
+- term:
+    id: GO:0051536
+    label: iron-sulfur cluster binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ETF-QO binds one [4Fe-4S] cluster; this InterPro-derived term is the broader parent of
+      the more specific IDA-supported GO:0051539.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but less specific than 4 iron, 4 sulfur cluster binding (GO:0051539); retained as
+      a broader cofactor-binding statement.
+    supported_by:
+    - reference_id: PMID:8306995
+      supporting_text: &gt;-
+        The two redox centers in the protein, FAD and a [4Fe4S]+2,+1 cluster, are present in a
+        64-kDa monomer.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Seven high-throughput yeast two-hybrid interactions (HuRI) with keratin-associated
+      proteins, transcription factors (OTX1, GSC2, ZNF581) and other proteins (MYH7B, TRIM69,
+      KRTAP11-1/13-2) that share no compartment or pathway with this mitochondrial
+      inner-membrane oxidoreductase. The bare &#34;protein binding&#34; term is also uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These are large-scale binary-interactome (Y2H) hits from a reference interactome map with
+      no functional context; the partners are cytoplasmic/nuclear and biologically implausible
+      for an inner-membrane enzyme, and the generic term conveys no molecular function. Marked as
+      over-annotated per policy rather than removed.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: A reference map of the human binary protein interactome.
+- term:
+    id: GO:0006979
+    label: response to oxidative stress
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ortholog-transferred (Ensembl Compara, from mouse Etfdh) association with oxidative-stress
+      response. This is a downstream/phenotypic consequence rather than a direct molecular
+      function of the electron-transfer reaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The term is electronically transferred from the mouse ortholog and reflects a secondary
+      phenotype (impaired electron flux increases electron leak/ROS) rather than a core activity
+      of ETF-QO; retained but flagged as over-annotated.
+    supported_by:
+    - reference_id: GO_REF:0000107
+      supporting_text: &gt;-
+        Automatic transfer of experimentally verified manual GO annotation data to
+        orthologs using Ensembl Compara
+- term:
+    id: GO:0022904
+    label: respiratory electron transport chain
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-611105
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome places ETFDH in respiratory electron transport, reducing coenzyme Q; a correct,
+      specific process for this enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Traceable author statement (Reactome) consistent with the enzyme&#39;s role of feeding
+      electrons into the ubiquinone pool of the respiratory chain.
+    supported_by:
+    - reference_id: PMID:17050691
+      supporting_text: &gt;-
+        It catalyzes ubiquinone (UQ) reduction by ETF, linking oxidation of fatty acids and
+        some amino acids to the mitochondrial respiratory chain.
+- term:
+    id: GO:0004174
+    label: electron-transferring-flavoprotein dehydrogenase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-169270
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome reaction (ETFDH oxidises reduced ETF, reduces CoQ to CoQH2) assigning the core
+      catalytic activity. Correct.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with experimental IDA and the enzyme&#39;s EC 1.5.5.1 catalytic activity.
+    supported_by:
+    - reference_id: PMID:12049629
+      supporting_text: &gt;-
+        The steady-state kinetic constants of human ETF-QO were determined with ubiquinone
+        homologues, a ubiquinone analogue, and with human wild-type ETF
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Immunofluorescence (HPA) localizes ETFDH to mitochondria. Correct but a broad parent of
+      the specific inner-membrane location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate general localization; less specific than the inner-membrane annotation, so kept
+      as a non-core broader term.
+    supported_by:
+    - reference_id: PMID:8306995
+      supporting_text: &gt;-
+        which targets the protein to mitochondria
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial proteomics identifies ETFDH as a mitochondrial protein.
+      Correct but broad.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Supports mitochondrial localization at low specificity; consistent with the experimentally
+      established inner-membrane location, kept as non-core.
+    supported_by:
+    - reference_id: PMID:34800366
+      supporting_text: Quantitative high-confidence human mitochondrial proteome and its dynamics
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-169270
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome asserts inner-membrane localization for the ETFDH reaction; matches experimental
+      data.
+    action: ACCEPT
+    reason: &gt;-
+      Correct, specific location concordant with the IDA and structural evidence.
+    supported_by:
+    - reference_id: PMID:17050691
+      supporting_text: &gt;-
+        Electron transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) is a 4Fe4S
+        flavoprotein located in the inner mitochondrial membrane.
+- term:
+    id: GO:0033539
+    label: fatty acid beta-oxidation using acyl-CoA dehydrogenase
+  evidence_type: IMP
+  original_reference_id: PMID:17412732
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ETFDH mutations cause multiple acyl-CoA dehydrogenase deficiency with impaired fatty-acid
+      beta-oxidation flux; ETF-QO is the electron acceptor for the acyl-CoA dehydrogenation step,
+      so its loss blocks beta-oxidation.
+    action: ACCEPT
+    reason: &gt;-
+      IMP evidence from patients with ETFDH mutations demonstrates the gene&#39;s required role in
+      the acyl-CoA dehydrogenase branch of fatty-acid beta-oxidation (electron sink); this is the
+      biologically central metabolic process that ETF-QO enables.
+    supported_by:
+    - reference_id: PMID:17412732
+      supporting_text: &gt;-
+        All of our patients carried autosomal recessive mutations in ETFDH, suggesting that
+        ETFDH deficiency leads to a secondary CoQ10 deficiency.
+    - reference_id: PMID:17050691
+      supporting_text: &gt;-
+        linking oxidation of fatty acids and some amino acids to the mitochondrial respiratory
+        chain
+- term:
+    id: GO:0004174
+    label: electron-transferring-flavoprotein dehydrogenase activity
+  evidence_type: IDA
+  original_reference_id: PMID:14640977
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct kinetic characterization of human ETF-QO catalyzing electron transfer from ETF to
+      the ubiquinone pool. Core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Steady-state kinetics of purified human enzyme with ETF and ubiquinone substrates directly
+      demonstrate the EC 1.5.5.1 activity.
+    supported_by:
+    - reference_id: PMID:14640977
+      supporting_text: &gt;-
+        a membrane-bound iron-sulphur flavoprotein that participates in an electron-transport
+        pathway between eleven mitochondrial flavoprotein dehydrogenases and the ubiquinone pool
+- term:
+    id: GO:0006979
+    label: response to oxidative stress
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Sequence-similarity transfer from the mouse ortholog (Q921G7) of an oxidative-stress
+      response role; a secondary/phenotypic association rather than a direct function of the
+      electron-transfer reaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      As with the Ensembl IEA to the same term, this is transferred from mouse and reflects a
+      downstream phenotype of impaired electron flux (increased ROS/electron leak), not a core
+      molecular function; flagged as over-annotated.
+    supported_by:
+    - reference_id: GO_REF:0000024
+      supporting_text: &gt;-
+        Manual transfer of experimentally-verified manual GO annotation data to orthologs
+        by curator judgment of sequence similarity
+- term:
+    id: GO:0016491
+    label: oxidoreductase activity
+  evidence_type: IDA
+  original_reference_id: PMID:14640977
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ETF-QO is an oxidoreductase, but this is the very general parent of the specific
+      GO:0004174 activity established in the same study.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Correct in essence but far too general given that the specific dehydrogenase activity
+      (GO:0004174) is annotated with the same experimental evidence; retained as an
+      over-annotation rather than as a core function.
+    supported_by:
+    - reference_id: PMID:14640977
+      supporting_text: &gt;-
+        The steady-state kinetic constants of human ETF-QO were determined with ubiquinone
+        homologues and analogues
+- term:
+    id: GO:0048038
+    label: quinone binding
+  evidence_type: IDA
+  original_reference_id: PMID:14640977
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Fluorescence titrations demonstrate a single quinone-binding site per ETF-QO monomer.
+      Correct; the parent of the more specific ubiquinone binding.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Directly supported but broader than the specific ubiquinone binding annotation
+      (GO:0048039); kept as a non-core broader term.
+    supported_by:
+    - reference_id: PMID:14640977
+      supporting_text: &gt;-
+        consistent with one ubiquinone-binding site per ETF-QO monomer
+- term:
+    id: GO:0048039
+    label: ubiquinone binding
+  evidence_type: IDA
+  original_reference_id: PMID:14640977
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ETF-QO binds ubiquinone at a single site per monomer and reduces it; the physiological
+      electron acceptor. Core function-related binding.
+    action: ACCEPT
+    reason: &gt;-
+      Direct biophysical evidence (fluorescence titration, kinetics) for a specific
+      ubiquinone-binding site; structurally corroborated. Specific and correct.
+    supported_by:
+    - reference_id: PMID:14640977
+      supporting_text: &gt;-
+        determined by fluorescence titrations of the protein with DBMIB and
+        6-(10-bromodecyl)ubiquinone, are consistent with one ubiquinone-binding site per ETF-QO
+        monomer
+    - reference_id: PMID:17050691
+      supporting_text: &gt;-
+        The UQ-binding pocket consists mainly of hydrophobic residues
+- term:
+    id: GO:0051539
+    label: 4 iron, 4 sulfur cluster binding
+  evidence_type: IDA
+  original_reference_id: PMID:18037314
+  qualifier: enables
+  review:
+    summary: &gt;-
+      EPR/electron-spin-relaxation measurements confirm a single [4Fe-4S] cluster in human
+      ETF-QO. Core cofactor binding.
+    action: ACCEPT
+    reason: &gt;-
+      Direct spectroscopic evidence for one [4Fe-4S] cluster per monomer; specific and correct.
+    supported_by:
+    - reference_id: PMID:18037314
+      supporting_text: &gt;-
+        Human, porcine, and Rhodobacter sphaeroides ETF-QO each contain a single
+        [4Fe-4S](2+,1+) cluster and one equivalent of FAD
+- term:
+    id: GO:0004174
+    label: electron-transferring-flavoprotein dehydrogenase activity
+  evidence_type: IDA
+  original_reference_id: PMID:12049629
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Kinetic and spectral characterization of recombinant human ETF-QO establishes the core
+      EC 1.5.5.1 activity with ETF and ubiquinone substrates.
+    action: ACCEPT
+    reason: &gt;-
+      Direct enzymology of the human protein; the defining molecular function.
+    supported_by:
+    - reference_id: PMID:12049629
+      supporting_text: &gt;-
+        The steady-state kinetic constants of human ETF-QO were determined with ubiquinone
+        homologues, a ubiquinone analogue, and with human wild-type ETF
+- term:
+    id: GO:0004174
+    label: electron-transferring-flavoprotein dehydrogenase activity
+  evidence_type: IDA
+  original_reference_id: PMID:8306995
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Heterologously expressed human ETF-QO transfers electrons from ETF to ubiquinone,
+      demonstrating the core catalytic activity with both cofactors correctly inserted.
+    action: ACCEPT
+    reason: &gt;-
+      Direct functional demonstration of ETF-to-ubiquinone electron transfer by the human
+      enzyme; defining molecular function.
+    supported_by:
+    - reference_id: PMID:8306995
+      supporting_text: &gt;-
+        The detergent-solubilized protein transfers electrons from ETF to the ubiquinone homolog,
+        Q1, indicating that both the FAD and iron-sulfur cluster are properly inserted
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:8306995
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct evidence that the mature ETF-QO resides in the inner mitochondrial membrane.
+      Core location.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental localization of the processed 64-kDa mature protein to the mitochondrial
+      (inner) membrane; matches structural data.
+    supported_by:
+    - reference_id: PMID:8306995
+      supporting_text: &gt;-
+        Electron-transfer flavoprotein-ubiquinone oxidoreductase (ETF-QO) in the inner
+        mitochondrial membrane accepts electrons from electron-transfer flavoprotein
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IDA
+  original_reference_id: PMID:12049629
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ETF-QO functions as an electron carrier, transferring electrons from ETF to ubiquinone.
+      Correct, though broader than the specific dehydrogenase activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate description of the electron-carrier property; kept as a correct but more general
+      companion to the specific GO:0004174 core function.
+    supported_by:
+    - reference_id: PMID:12049629
+      supporting_text: &gt;-
+        a component of an electron-transfer system that links 10 different mitochondrial
+        flavoprotein dehydrogenases to the mitochondrial bc1 complex
+- term:
+    id: GO:0009055
+    label: electron transfer activity
+  evidence_type: IDA
+  original_reference_id: PMID:8306995
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ETF-QO transfers electrons from ETF to ubiquinone, acting as an electron carrier in the
+      relay to the respiratory chain.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct electron-carrier description; retained as a general companion to the specific
+      dehydrogenase activity.
+    supported_by:
+    - reference_id: PMID:8306995
+      supporting_text: &gt;-
+        The detergent-solubilized protein transfers electrons from ETF to the ubiquinone homolog,
+        Q1
+- term:
+    id: GO:0022900
+    label: electron transport chain
+  evidence_type: IDA
+  original_reference_id: PMID:12049629
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ETF-QO participates in the mitochondrial electron transport chain, linking flavoprotein
+      dehydrogenases to the bc1 complex via ubiquinone.
+    action: ACCEPT
+    reason: &gt;-
+      Direct evidence for the enzyme&#39;s role in feeding electrons into the respiratory electron
+      transport chain via the ubiquinone pool.
+    supported_by:
+    - reference_id: PMID:12049629
+      supporting_text: &gt;-
+        links 10 different mitochondrial flavoprotein dehydrogenases to the mitochondrial bc1
+        complex via electron transfer flavoprotein (ETF) and ubiquinone
+- term:
+    id: GO:0022900
+    label: electron transport chain
+  evidence_type: IDA
+  original_reference_id: PMID:8306995
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ETF-QO reduces ubiquinone in the mitochondrial membrane, participating in the electron
+      transport chain.
+    action: ACCEPT
+    reason: &gt;-
+      Direct evidence that the enzyme reduces ubiquinone, its role in the respiratory electron
+      transport chain.
+    supported_by:
+    - reference_id: PMID:8306995
+      supporting_text: &gt;-
+        reduces ubiquinone in the mitochondrial membrane
+- term:
+    id: GO:0031966
+    label: mitochondrial membrane
+  evidence_type: IDA
+  original_reference_id: PMID:12049629
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ETF-QO is an integral mitochondrial membrane protein; correct but a broad parent of the
+      specific inner-membrane location.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Accurate but less specific than mitochondrial inner membrane (GO:0005743); kept as a
+      broader, non-core localization.
+    supported_by:
+    - reference_id: PMID:12049629
+      supporting_text: &gt;-
+        ETF-QO is an integral membrane protein
+- term:
+    id: GO:0050660
+    label: flavin adenine dinucleotide binding
+  evidence_type: ISS
+  original_reference_id: PMID:17050691
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ETF-QO carries one FAD cofactor essential for electron transfer; supported by the
+      structure of the porcine ortholog (source of ISS) and confirmed for the human enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      FAD binding is a core cofactor function; the crystal structure defines the FAD site, and
+      the human enzyme is spectroscopically shown to contain one FAD equivalent. Correct and
+      specific.
+    supported_by:
+    - reference_id: PMID:17050691
+      supporting_text: &gt;-
+        Three functional regions bind FAD, the 4Fe4S cluster, and UQ
+    - reference_id: PMID:18037314
+      supporting_text: &gt;-
+        each contain a single [4Fe-4S](2+,1+) cluster and one equivalent of FAD
+core_functions:
+- description: &gt;-
+    Electron-transferring-flavoprotein dehydrogenase (ETF-QO, EC 1.5.5.1): oxidizes reduced
+    electron-transfer flavoprotein and reduces ubiquinone in the mitochondrial inner membrane,
+    using bound FAD and a [4Fe-4S] cluster as redox relays.
+  molecular_function:
+    id: GO:0004174
+    label: electron-transferring-flavoprotein dehydrogenase activity
+  directly_involved_in:
+  - id: GO:0022904
+    label: respiratory electron transport chain
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  supported_by:
+  - reference_id: PMID:12049629
+    supporting_text: &gt;-
+      a component of an electron-transfer system that links 10 different mitochondrial
+      flavoprotein dehydrogenases to the mitochondrial bc1 complex via electron transfer
+      flavoprotein (ETF) and ubiquinone
+  - reference_id: PMID:17050691
+    supporting_text: &gt;-
+      It catalyzes ubiquinone (UQ) reduction by ETF, linking oxidation of fatty acids and some
+      amino acids to the mitochondrial respiratory chain.
+- description: &gt;-
+    Ubiquinone binding at a single hydrophobic site per monomer, positioning the physiological
+    electron acceptor for reduction to ubiquinol.
+  molecular_function:
+    id: GO:0048039
+    label: ubiquinone binding
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  supported_by:
+  - reference_id: PMID:14640977
+    supporting_text: &gt;-
+      consistent with one ubiquinone-binding site per ETF-QO monomer
+- description: &gt;-
+    FAD cofactor binding; the flavin is a core redox center that shuttles electrons from reduced
+    ETF toward ubiquinone.
+  molecular_function:
+    id: GO:0050660
+    label: flavin adenine dinucleotide binding
+  supported_by:
+  - reference_id: PMID:18037314
+    supporting_text: &gt;-
+      each contain a single [4Fe-4S](2+,1+) cluster and one equivalent of FAD
+- description: &gt;-
+    [4Fe-4S] cluster binding; a single iron-sulfur cluster serves as the second redox center of
+    ETF-QO.
+  molecular_function:
+    id: GO:0051539
+    label: 4 iron, 4 sulfur cluster binding
+  supported_by:
+  - reference_id: PMID:18037314
+    supporting_text: &gt;-
+      Human, porcine, and Rhodobacter sphaeroides ETF-QO each contain a single
+      [4Fe-4S](2+,1+) cluster and one equivalent of FAD
+- description: &gt;-
+    Links fatty-acid beta-oxidation (acyl-CoA dehydrogenase branch) to the respiratory chain by
+    accepting the electrons generated during acyl-CoA dehydrogenation via ETF; loss of ETFDH
+    blocks this flux and causes multiple acyl-CoA dehydrogenase deficiency.
+  molecular_function:
+    id: GO:0004174
+    label: electron-transferring-flavoprotein dehydrogenase activity
+  directly_involved_in:
+  - id: GO:0033539
+    label: fatty acid beta-oxidation using acyl-CoA dehydrogenase
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  supported_by:
+  - reference_id: PMID:17412732
+    supporting_text: &gt;-
+      All of our patients carried autosomal recessive mutations in ETFDH, suggesting that ETFDH
+      deficiency leads to a secondary CoQ10 deficiency.
+  - reference_id: PMID:17050691
+    supporting_text: &gt;-
+      linking oxidation of fatty acids and some amino acids to the mitochondrial respiratory
+      chain
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:12049629
+  title: &#39;Expression of human electron transfer flavoprotein-ubiquinone oxidoreductase
+    from a baculovirus vector: kinetic and spectral characterization of the human
+    protein.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Kinetic and spectral characterization of recombinant human ETF-QO; establishes the core
+      EC 1.5.5.1 catalytic activity with ETF and ubiquinone substrates (IDA source).
+- id: PMID:14640977
+  title: Alternative quinone substrates and inhibitors of human electron-transfer
+    flavoprotein-ubiquinone oxidoreductase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Human ETF-QO enzymology; documents a single ubiquinone-binding site per monomer and the
+      quinone/oxidoreductase activities (IDA source).
+- id: PMID:17050691
+  title: Structure of electron transfer flavoprotein-ubiquinone oxidoreductase and
+    electron transfer to the mitochondrial ubiquinone pool.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Crystal structure (porcine, basis for human ISS FAD binding); defines FAD, 4Fe-4S and UQ
+      sites, inner-membrane monotopic topology, and electron-transfer mechanism.
+- id: PMID:17412732
+  title: The myopathic form of coenzyme Q10 deficiency is caused by mutations in the
+    electron-transferring-flavoprotein dehydrogenase (ETFDH) gene.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes ETFDH mutations as cause of riboflavin-responsive MADD with secondary CoQ10
+      deficiency; source of the beta-oxidation IMP annotation.
+- id: PMID:18037314
+  title: Electron spin relaxation enhancement measurements of interspin distances
+    in human, porcine, and Rhodobacter electron transfer flavoprotein-ubiquinone oxidoreductase
+    (ETF-QO).
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      EPR study confirming a single [4Fe-4S] cluster and one FAD per human ETF-QO monomer
+      (basis for the 4Fe-4S IDA).
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      HuRI large-scale yeast two-hybrid reference interactome; the ETFDH IPI hits are generic
+      &#34;protein binding&#34; to biologically implausible partners (keratin-associated proteins,
+      transcription factors) and are treated as over-annotations.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput mitochondrial proteomics; supports mitochondrial localization at low
+      specificity (HTP source).
+- id: PMID:8306995
+  title: Molecular cloning and expression of a cDNA encoding human electron transfer
+    flavoprotein-ubiquinone oxidoreductase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Cloning and heterologous expression of human ETF-QO; demonstrates inner-membrane
+      localization, ETF-to-ubiquinone electron transfer, and both FAD and [4Fe-4S] cofactors.
+- id: Reactome:R-HSA-169270
+  title: ETFDH oxidises ETF (reduced) to ETF, reduces CoQ to CoQH2
+  findings: []
+- id: Reactome:R-HSA-611105
+  title: Respiratory electron transport
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/modules/electron_transfer_flavoprotein_system.html
+++ b/pages/modules/electron_transfer_flavoprotein_system.html
@@ -1,0 +1,832 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Electron-transfer flavoprotein (ETF) system — electron sink for mitochondrial FAD dehydrogenases - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / Electron-transfer flavoprotein (ETF) system — electron sink for mitochondrial FAD dehydrogenases
+    </nav>
+
+    <header class="header">
+        <h1>Electron-transfer flavoprotein (ETF) system — electron sink for mitochondrial FAD dehydrogenases</h1>            <p class="description">The electron-transfer flavoprotein (ETF) system is the shared electron-relay that couples a large set of mitochondrial matrix FAD-dependent dehydrogenases to the respiratory chain. At least a dozen matrix flavoenzymes — the acyl-CoA dehydrogenases of fatty-acid beta-oxidation (ACADVL, ACADM, ACADS, ACAD9, etc.), the branched-chain and other acyl-CoA dehydrogenases of amino-acid catabolism (IVD, GCDH, etc.), sarcosine and dimethylglycine dehydrogenases, and others — do not pass their electrons directly to the respiratory chain. Instead they reduce a common, soluble matrix heterodimeric flavoprotein, ETF (the ETFA alpha subunit, which carries the FAD, plus the ETFB beta subunit, which carries AMP and provides the docking surface for the partner dehydrogenases). Reduced ETF then diffuses to the inner-membrane iron-sulfur flavoprotein ETF-ubiquinone oxidoreductase (ETFDH / ETF-QO), which reoxidises ETF and transfers the electrons to ubiquinone (CoQ) in the respiratory chain, linking these oxidations to oxidative phosphorylation. Because ETF/ETFDH is the common electron sink for so many dehydrogenases, its inherited deficiency (ETFA, ETFB or ETFDH) causes multiple acyl-CoA dehydrogenase deficiency (MADD / glutaric acidemia type 2), a severe fatty-acid-oxidation and amino-acid-oxidation disorder; the ETFDH form is frequently riboflavin-responsive and can present as a myopathy with secondary coenzyme-Q10 deficiency.</p>        <div class="meta-row"><span class="pill">MODULE:electron_transfer_flavoprotein_system</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/electron_transfer_flavoprotein_system.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>respiratory electron transport chain</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0022904" target="_blank" rel="noopener">GO:0022904</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0045251" target="_blank" rel="noopener">GO:0045251</a><div><strong>electron transfer flavoprotein complex</strong></div><div>The soluble electron acceptor is grounded in the GO electron transfer flavoprotein complex (GO:0045251, the ETFA/ETFB heterodimer).</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-169270</span><div><strong>ETFDH oxidises ETF (reduced) to ETF, reduces CoQ to CoQH2</strong></div><div>The relay follows the human Reactome reactions R-HSA-169260 (acyl-CoA dehydrogenases reduce ETF) and R-HSA-169270 (ETFDH reoxidises ETF and reduces ubiquinone), feeding respiratory electron transport (R-HSA-611105).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ETFA/ETFA-ai-review.yaml</span><div><strong>ETFA gene review (human)</strong></div><div>The ETF alpha-subunit grounding (UniProtKB:P13804, GO:0009055 electron transfer activity, FAD binding, GO:0045251 complex) matches the completed human ETFA review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ETFB/ETFB-ai-review.yaml</span><div><strong>ETFB gene review (human)</strong></div><div>The ETF beta-subunit grounding (UniProtKB:P38117, GO:0009055, GO:0045251 complex) matches the completed human ETFB review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ETFDH/ETFDH-ai-review.yaml</span><div><strong>ETFDH gene review (human)</strong></div><div>The ETF-ubiquinone oxidoreductase grounding (UniProtKB:Q16134, GO:0004174 electron-transferring-flavoprotein dehydrogenase activity, inner membrane) matches the completed human ETFDH review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">1</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:electron_transfer_flavoprotein_system</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(3/3 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        3 complete review(s) &middot;
+                        0 with deep research &middot;
+                        0 missing review &middot;
+                        3 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>ETFA
+                                        <span class="muted term-id">P13804</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>ETFB
+                                        <span class="muted term-id">P38117</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>ETFDH
+                                        <span class="muted term-id">Q16134</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-electron_transfer_flavoprotein_system">Electron-transfer flavoprotein (ETF) system</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">electron_transfer_flavoprotein_system</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. common electron acceptor for matrix FAD dehydrogenases</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-etf_reduction_step">acyl-CoA dehydrogenases reduce the ETF (ETFA/ETFB) flavoprotein</a><span class="pill type">Protein Complex</span><span class="tree-id">etf_reduction_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-etfa_activity">ETFA: electron transfer flavoprotein alpha (FAD-bearing)</a>
+                                <span class="tree-id">Family: Electron transfer flavoprotein alpha-subunit family (ETFA)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-etfb_activity">ETFB: electron transfer flavoprotein beta (dehydrogenase docking)</a>
+                                <span class="tree-id">Family: Electron transfer flavoprotein beta-subunit family (ETFB)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. reoxidation of ETF and electron transfer to ubiquinone</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-etfdh_step">reduced ETF + ubiquinone to oxidised ETF + ubiquinol</a><span class="pill type">Reaction</span><span class="tree-id">etfdh_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-etfdh_activity">ETFDH/ETF-QO: electron transfer flavoprotein-ubiquinone oxidoreductase</a>
+                                <span class="tree-id">Family: Electron transfer flavoprotein-ubiquinone oxidoreductase family (ETFDH)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>                <span class="descriptor">
+            <span>mitochondrial inner membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005743" target="_blank" rel="noopener">GO:0005743</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-electron_transfer_flavoprotein_system">
+        <div class="node-heading">
+            <span class="node-title">Electron-transfer flavoprotein (ETF) system</span><span class="pill type">Metabolic Pathway</span><span class="pill">electron_transfer_flavoprotein_system</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>respiratory electron transport chain</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0022904" target="_blank" rel="noopener">GO:0022904</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>                <span class="descriptor">
+            <span>mitochondrial inner membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005743" target="_blank" rel="noopener">GO:0005743</a></span>        </div>
+
+            </div>
+        <p class="muted small">The electron-transfer flavoprotein system grounded to the human proteins ETFA (UniProtKB:P13804, GO:0009055, FAD-bearing alpha subunit) and ETFB (P38117, GO:0009055, AMP-binding beta subunit) forming the ETF heterodimer (GO:0045251), and ETFDH (Q16134, GO:0004174, EC 1.5.5.1) the inner-membrane ETF-ubiquinone oxidoreductase. GO molecular-function/cellular-component terms were taken from the human GOA records; Reactome reaction ids and titles were verified against the local reactome cache. Each step uses a PANTHER family selector (generic over paralogs and orthologs) plus a concrete human representative member; the ETF heterodimer is modelled as a PROTEIN_COMPLEX node. Upstream, the electron donors are the many matrix FAD-dependent acyl-CoA dehydrogenases (of fatty-acid beta-oxidation — see the fatty_acid_beta_oxidation and carnitine_shuttle modules — and of amino-acid catabolism, e.g. IVD in the leucine_catabolism module and GCDH); downstream, ubiquinol feeds respiratory complex III (GO:0022904). Combined deficiency of any component causes multiple acyl-CoA dehydrogenase deficiency (MADD / glutaric acidemia type 2).</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-etf_reduction_step">etf_reduction_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-etfdh_step">etfdh_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Reduced ETF produced when the matrix dehydrogenases transfer electrons to the ETFA/ETFB heterodimer is the substrate reoxidised by ETFDH, which then reduces ubiquinone.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: common electron acceptor for matrix FAD dehydrogenases</div>
+                <section class="node-detail depth-1" id="node-etf_reduction_step">
+        <div class="node-heading">
+            <span class="node-title">acyl-CoA dehydrogenases reduce the ETF (ETFA/ETFB) flavoprotein</span><span class="pill type">Protein Complex</span><span class="pill">etf_reduction_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-etfa_activity">
+        <div class="annoton-title">ETFA: electron transfer flavoprotein alpha (FAD-bearing)</div>
+        <div class="small muted">etfa_activity</div>            <div class="small"><strong>Participant:</strong> Family: Electron transfer flavoprotein alpha-subunit family (ETFA)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Electron transfer flavoprotein alpha-subunit family (ETFA)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43153" target="_blank" rel="noopener">PANTHER:PTHR43153</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ETFA (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P13804/entry" target="_blank" rel="noopener">UniProtKB:P13804</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>electron transfer activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009055" target="_blank" rel="noopener">GO:0009055</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>reduced acyl-CoA dehydrogenase (electron donor)</span></span>                            <span class="descriptor">
+            <span>FAD (prosthetic group)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>reduced ETF (ETFH2 / ETF semiquinone)</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">FAD-bearing alpha subunit of the ETF heterodimer; its FAD is the redox centre reduced by the partner acyl-CoA dehydrogenases. Deficiency causes MADD / glutaric acidemia type 2 (type I).</p></article>                    <article class="annoton-card" id="annoton-etfb_activity">
+        <div class="annoton-title">ETFB: electron transfer flavoprotein beta (dehydrogenase docking)</div>
+        <div class="small muted">etfb_activity</div>            <div class="small"><strong>Participant:</strong> Family: Electron transfer flavoprotein beta-subunit family (ETFB)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Electron transfer flavoprotein beta-subunit family (ETFB)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR21294" target="_blank" rel="noopener">PANTHER:PTHR21294</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ETFB (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P38117/entry" target="_blank" rel="noopener">UniProtKB:P38117</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>electron transfer activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009055" target="_blank" rel="noopener">GO:0009055</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>reduced acyl-CoA dehydrogenase (electron donor)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>reduced ETF</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Beta subunit of the ETF heterodimer; binds AMP and provides the recognition/docking surface for the many partner dehydrogenases. Deficiency causes MADD / glutaric acidemia type 2 (type II).</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: reoxidation of ETF and electron transfer to ubiquinone</div>
+                <section class="node-detail depth-1" id="node-etfdh_step">
+        <div class="node-heading">
+            <span class="node-title">reduced ETF + ubiquinone to oxidised ETF + ubiquinol</span><span class="pill type">Reaction</span><span class="pill">etfdh_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-etfdh_activity">
+        <div class="annoton-title">ETFDH/ETF-QO: electron transfer flavoprotein-ubiquinone oxidoreductase</div>
+        <div class="small muted">etfdh_activity</div>            <div class="small"><strong>Participant:</strong> Family: Electron transfer flavoprotein-ubiquinone oxidoreductase family (ETFDH)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Electron transfer flavoprotein-ubiquinone oxidoreductase family (ETFDH)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10617" target="_blank" rel="noopener">PANTHER:PTHR10617</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ETFDH (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q16134/entry" target="_blank" rel="noopener">UniProtKB:Q16134</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>electron-transferring-flavoprotein dehydrogenase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004174" target="_blank" rel="noopener">GO:0004174</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>reduced electron-transfer flavoprotein</span></span>                            <span class="descriptor">
+            <span>ubiquinone (CoQ)</span></span>                            <span class="descriptor">
+            <span>FAD and [4Fe-4S] (prosthetic groups)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>oxidised electron-transfer flavoprotein</span></span>                            <span class="descriptor">
+            <span>ubiquinol (CoQH2)</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial inner membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005743" target="_blank" rel="noopener">GO:0005743</a></span>        </div>            <p class="role-description">Inner-membrane FAD + [4Fe-4S] flavoprotein that reoxidises reduced ETF and delivers the electrons to ubiquinone, linking the many matrix FAD dehydrogenases to the respiratory chain. Deficiency causes MADD / glutaric acidemia type 2 (type III), often riboflavin- responsive, with secondary CoQ10 deficiency.</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -285,7 +285,7 @@
 
     <section class="toolbar">
         <input class="search" type="search" placeholder="Filter modules" data-module-search>
-        <div class="count"><span data-visible-count>100</span> / 100 modules</div>
+        <div class="count"><span data-visible-count>101</span> / 101 modules</div>
     </section>
 
     <div class="table-wrap">
@@ -863,6 +863,29 @@ Design intent: the module is organized as an upstream copper-homeostasis layer t
                         6
                     </td>
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/early_metazoan_development.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="Electron-transfer flavoprotein (ETF) system — electron sink for mitochondrial FAD dehydrogenases">
+                        <a class="module-name" href="electron_transfer_flavoprotein_system.html">Electron-transfer flavoprotein (ETF) system — electron sink for mitochondrial FAD dehydrogenases</a><span class="module-id">MODULE:electron_transfer_flavoprotein_system</span>                        <span class="module-desc">The electron-transfer flavoprotein (ETF) system is the shared electron-relay that couples a large set of mitochondrial matrix FAD-dependent...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">The electron-transfer flavoprotein (ETF) system is the shared electron-relay that couples a large set of mitochondrial matrix FAD-dependent dehydrogenases to the respiratory chain. At least a dozen matrix flavoenzymes — the acyl-CoA dehydrogenases of fatty-acid beta-oxidation (ACADVL, ACADM, ACADS, ACAD9, etc.), the branched-chain and other acyl-CoA dehydrogenases of amino-acid catabolism (IVD, GCDH, etc.), sarcosine and dimethylglycine dehydrogenases, and others — do not pass their electrons directly to the respiratory chain. Instead they reduce a common, soluble matrix heterodimeric flavoprotein, ETF (the ETFA alpha subunit, which carries the FAD, plus the ETFB beta subunit, which carries AMP and provides the docking surface for the partner dehydrogenases). Reduced ETF then diffuses to the inner-membrane iron-sulfur flavoprotein ETF-ubiquinone oxidoreductase (ETFDH / ETF-QO), which reoxidises ETF and transfers the electrons to ubiquinone (CoQ) in the respiratory chain, linking these oxidations to oxidative phosphorylation. Because ETF/ETFDH is the common electron sink for so many dehydrogenases, its inherited deficiency (ETFA, ETFB or ETFDH) causes multiple acyl-CoA dehydrogenase deficiency (MADD / glutaric acidemia type 2), a severe fatty-acid-oxidation and amino-acid-oxidation disorder; the ETFDH form is frequently riboflavin-responsive and can present as a myopathy with secondary coenzyme-Q10 deficiency.</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">respiratory electron transport chain</span>                        </div>                    </td>
+                    <td class="num">3</td>
+                    <td class="num">3</td>
+                    <td class="num">2</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">1</td>                    <td class="num" data-sort-value="3">
+                        3/3
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/electron_transfer_flavoprotein_system.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="Embryonic body axis specification module">
                         <a class="module-name" href="body_axis_specification.html">Embryonic body axis specification module</a><span class="module-id">MODULE:body_axis_specification</span>                        <span class="module-desc">An early-metazoan patterning module in which the embryo converts spatially graded maternal and zygotic signals into the three body axes:...</span>                        <details class="module-desc-more">

--- a/pages/projects/OXPHOS.html
+++ b/pages/projects/OXPHOS.html
@@ -951,7 +951,7 @@ F1 (catalytic) + Fo (proton channel) + central/peripheral stalks.</p>
 </thead>
 <tbody>
 <tr>
-<td>ETFDH</td>
+<td><a href="../../genes/human/ETFDH/ETFDH-ai-review.html">ETFDH</a></td>
 <td>Q16134</td>
 <td>ETF:ubiquinone oxidoreductase</td>
 <td>Multiple acyl-CoA dehydrogenase deficiency</td>
@@ -1015,7 +1015,7 @@ mtDNA-encoded genes have limited GO annotations and are lower priority.</p>
 <p><strong>Tier 3 (Lower Priority)</strong> -- Specialized/accessory:<br />
 21. SDHAF2 -- paraganglioma<br />
 22. <a href="../../genes/DANRE/coq8a/coq8a-ai-review.html">COQ8A</a> -- cerebellar ataxia<br />
-23. ETFDH -- FAO electron entry to ETC<br />
+23. <a href="../../genes/human/ETFDH/ETFDH-ai-review.html">ETFDH</a> -- FAO electron entry to ETC<br />
 24. COX7A2L -- supercomplex assembly (controversial)<br />
 25. HCCS -- heme maturation</p>
 <hr />
@@ -1056,7 +1056,7 @@ mtDNA-encoded genes have limited GO annotations and are lower priority.</p>
 <li>[ ] <a href="../../genes/human/ATP5F1A/ATP5F1A-ai-review.html">ATP5F1A</a></li>
 <li>[ ] SDHAF2</li>
 <li>[ ] <a href="../../genes/DANRE/coq8a/coq8a-ai-review.html">COQ8A</a></li>
-<li>[ ] ETFDH</li>
+<li>[ ] <a href="../../genes/human/ETFDH/ETFDH-ai-review.html">ETFDH</a></li>
 <li>[ ] COX7A2L</li>
 <li>[ ] HCCS</li>
 </ul>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3061 |
| Gene review HTML pages | 3061 |
| Project pages | 1108 |
| Module pages | 102 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
