### PR TITLE
Fix deep-research recipes (python 3.9→uv/3.12) + document dark-gene curation highlights

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -190,7 +190,7 @@ descriptions-status organism *args="":
 #   just deep-research-openai human TP53 --fallback perplexity-lite  # fallback on failure/timeout
 #   just deep-research-openai human CFAP300 --extra-args --param "model=gpt-4o"
 deep-research-openai organism gene_id *args="":
-    python3 scripts/deep_research_wrapper.py {{organism}} {{gene_id}} openai {{args}}
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} openai {{args}}
 
 # Deep research using Perplexity (sonar models)
 # Gene symbol automatically looked up from UniProt file if --alias not provided
@@ -199,7 +199,7 @@ deep-research-openai organism gene_id *args="":
 #   just deep-research-perplexity METEA mxcE          # Looks up gene symbol from UniProt
 #   just deep-research-perplexity METEA C5B1I4 --alias mllA  # gene_symbol=mllA, gene_id=C5B1I4
 deep-research-perplexity organism gene_id *args="":
-    python3 scripts/deep_research_wrapper.py {{organism}} {{gene_id}} perplexity {{args}}
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} perplexity {{args}}
 
 # Quick Perplexity research with low reasoning effort
 # Gene symbol automatically looked up from UniProt file if --alias not provided
@@ -207,7 +207,7 @@ deep-research-perplexity organism gene_id *args="":
 #   just deep-research-perplexity-lite human TP53     # Fast research
 #   just deep-research-perplexity-lite ARATH BRI1 --alias brassinosteroid-receptor
 deep-research-perplexity-lite organism gene_id *args="":
-    python3 scripts/deep_research_wrapper.py {{organism}} {{gene_id}} perplexity-lite {{args}}
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} perplexity-lite {{args}}
 
 # Deep research using Falcon (local models)
 # Gene symbol automatically looked up from UniProt file if --alias not provided
@@ -215,7 +215,7 @@ deep-research-perplexity-lite organism gene_id *args="":
 #   just deep-research-falcon human TP53
 #   just deep-research-falcon METEA C5B1I4 --alias mllA
 deep-research-falcon organism gene_id *args="":
-    python3 scripts/deep_research_wrapper.py {{organism}} {{gene_id}} falcon {{args}}
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} falcon {{args}}
 
 # Deep research using Cyberian
 # Gene symbol automatically looked up from UniProt file if --alias not provided
@@ -223,7 +223,7 @@ deep-research-falcon organism gene_id *args="":
 #   just deep-research-cyberian human TP53
 #   just deep-research-cyberian METEA C5B1I4 --alias mllA
 deep-research-cyberian organism gene_id *args="":
-    python3 scripts/deep_research_wrapper.py {{organism}} {{gene_id}} cyberian {{args}}
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} cyberian {{args}}
 
 # Deep research using OpenScientist
 # Gene symbol automatically looked up from UniProt file if --alias not provided
@@ -231,7 +231,7 @@ deep-research-cyberian organism gene_id *args="":
 #   just deep-research-openscientist human TP53
 #   just deep-research-openscientist METEA C5B1I4 --alias mllA
 deep-research-openscientist organism gene_id *args="":
-    python3 scripts/deep_research_wrapper.py {{organism}} {{gene_id}} openscientist {{args}}
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} openscientist {{args}}
 
 # Deep research using Asta (fast provider; works like the other providers)
 # Gene symbol automatically looked up from UniProt file if --alias not provided
@@ -239,7 +239,7 @@ deep-research-openscientist organism gene_id *args="":
 #   just deep-research-asta human TP53
 #   just deep-research-asta METEA C5B1I4 --alias mllA
 deep-research-asta organism gene_id *args="":
-    python3 scripts/deep_research_wrapper.py {{organism}} {{gene_id}} asta {{args}}
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} asta {{args}}
 
 # Deep research using Codex via agentapi (yolo mode)
 # Uses cyberian provider with agent_type=codex for autonomous research
@@ -248,7 +248,7 @@ deep-research-asta organism gene_id *args="":
 #   just deep-research-codex human TP53
 #   just deep-research-codex METEA C5B1I4 --alias mllA
 deep-research-codex organism gene_id *args="":
-    python3 scripts/deep_research_wrapper.py {{organism}} {{gene_id}} cyberian --extra-args --param agent_type=codex {{args}}
+    uv run python scripts/deep_research_wrapper.py {{organism}} {{gene_id}} cyberian --extra-args --param agent_type=codex {{args}}
 
 # Deep research on an InterPro entry (family/domain) behind InterPro2GO annotations.
 # Metadata is auto-fetched and cached under interpro/<database>/<ID>/ if absent.
@@ -477,22 +477,22 @@ term-deep-research-codex concept *args="":
 #   just module-deep-research-openai modules/gluconeogenesis.yaml
 #   just module-deep-research-perplexity-lite peroxisome-lifecycle --dry-run
 module-deep-research-openai module *args="":
-    python3 scripts/module_deep_research_wrapper.py "{{module}}" openai {{args}}
+    uv run python scripts/module_deep_research_wrapper.py "{{module}}" openai {{args}}
 
 module-deep-research-perplexity module *args="":
-    python3 scripts/module_deep_research_wrapper.py "{{module}}" perplexity {{args}}
+    uv run python scripts/module_deep_research_wrapper.py "{{module}}" perplexity {{args}}
 
 module-deep-research-perplexity-lite module *args="":
-    python3 scripts/module_deep_research_wrapper.py "{{module}}" perplexity-lite {{args}}
+    uv run python scripts/module_deep_research_wrapper.py "{{module}}" perplexity-lite {{args}}
 
 module-deep-research-falcon module *args="":
-    python3 scripts/module_deep_research_wrapper.py "{{module}}" falcon {{args}}
+    uv run python scripts/module_deep_research_wrapper.py "{{module}}" falcon {{args}}
 
 module-deep-research-cyberian module *args="":
-    python3 scripts/module_deep_research_wrapper.py "{{module}}" cyberian {{args}}
+    uv run python scripts/module_deep_research_wrapper.py "{{module}}" cyberian {{args}}
 
 module-deep-research-codex module *args="":
-    python3 scripts/module_deep_research_wrapper.py "{{module}}" codex {{args}}
+    uv run python scripts/module_deep_research_wrapper.py "{{module}}" codex {{args}}
 
 # Species/taxon-specific module + pathway research. This writes to the project
 # support folder when a project can be resolved, e.g. projects/P_PUTIDA/deep-research/.
@@ -500,10 +500,10 @@ module-deep-research-codex module *args="":
 #   just module-pathway-deep-research-falcon "central carbon metabolism" ppu00020 PSEPK --dry-run
 #   just module-pathway-deep-research falcon "aromatic compound catabolism" ppu01220 PSEPK
 module-pathway-deep-research provider module pathway organism *args="":
-    python3 scripts/module_pathway_taxon_deep_research_wrapper.py "{{module}}" "{{pathway}}" "{{organism}}" "{{provider}}" {{args}}
+    uv run python scripts/module_pathway_taxon_deep_research_wrapper.py "{{module}}" "{{pathway}}" "{{organism}}" "{{provider}}" {{args}}
 
 module-pathway-deep-research-falcon module pathway organism *args="":
-    python3 scripts/module_pathway_taxon_deep_research_wrapper.py "{{module}}" "{{pathway}}" "{{organism}}" falcon {{args}}
+    uv run python scripts/module_pathway_taxon_deep_research_wrapper.py "{{module}}" "{{pathway}}" "{{organism}}" falcon {{args}}
 
 # Fetch a specific PMID
 fetch-pmid pmid output_dir="publications":

--- a/projects/FUNCTION_KNOWLEDGE_GAPS.md
+++ b/projects/FUNCTION_KNOWLEDGE_GAPS.md
@@ -159,6 +159,12 @@ GTPase-activity review, the missing GEF/GAP).
 register is their queryable, schema-backed counterpart and will grow as gaps are recorded in the
 YAML.
 
+**Curation highlights from the dark-gene campaigns:** the batched reviews of understudied genes
+(50 *C. elegans*, 50 *S. cerevisiae*, 20 *S. pombe*) that populate this register also surfaced
+recurring, generalizable curation findings — identity corrections, pseudoenzyme calls, and
+family over-propagations caught before they became annotations. These are written up in
+[Dark-Gene Batch Reviews: Curation Highlights](FUNCTION_KNOWLEDGE_GAPS/dark-gene-curation-highlights.md).
+
 ## Worked example: the CFAP300 molecular-function gap
 
 CFAP300 (formerly C11orf70) is a dynein axonemal assembly factor; loss-of-function causes

--- a/projects/FUNCTION_KNOWLEDGE_GAPS/dark-gene-curation-highlights.md
+++ b/projects/FUNCTION_KNOWLEDGE_GAPS/dark-gene-curation-highlights.md
@@ -1,0 +1,129 @@
+---
+title: "Dark-Gene Batch Reviews: Curation Highlights"
+maturity: IN_PROGRESS
+tags: [PIPELINE]
+species: [worm, yeast]
+autolink_gene_symbols: false
+---
+
+# Dark-Gene Batch Reviews: Curation Highlights
+
+Three batched review campaigns targeted deliberately *understudied* genes — the population
+where function knowledge gaps concentrate — rather than the well-annotated core:
+
+| Campaign | Organism | Genes | Selection basis |
+|---|---|---|---|
+| CAEEL | *C. elegans* (`worm`) | 50 | Unreviewed members of the flagship CAEEL pathway projects (cilia/IFT, mitophagy, proteostasis, UPR, surveillance immunity, P-granule) |
+| YEAST | *S. cerevisiae* (`yeast`) | 50 | Named-but-dark genes from the SGD GAF: standard gene name, **zero experimental-evidence annotations**, few informative GO terms |
+| POMBE | *S. pombe* (`SCHPO`) | 20 | Named-but-dark genes from the PomBase GAF, same darkness filter |
+
+Each gene received a full annotation review plus a literature-grounded `knowledge_gaps`
+section (the point of the exercise — see the [parent project](../FUNCTION_KNOWLEDGE_GAPS.md)).
+Beyond the gap records themselves, the reviews surfaced recurring, generalizable curation
+findings. Those patterns are collected here because they are the concrete argument for *why*
+dark genes need human-grade review rather than electronic propagation.
+
+## 1. Identity correction before curation
+
+Dark genes are disproportionately mislabeled — a "standard name" or a family hint can point at
+the wrong biology. Grounding every review in the actual UniProt/PomBase record (not the symbol
+or a prior assumption) caught several outright misassignments *before* they could drive wrong
+annotations:
+
+- **`sel0` (pombe, SPAC20G4.05c)** — not a Sel1-repeat / SEL1L ERAD protein as the name suggests,
+  but **Selenoprotein O**, a mitochondrial protein AMPylase / adenylyltransferase (SELO family,
+  pseudokinase fold). Entire review reframed around AMPylation.
+- **`mtl3` (pombe, SPBC215.13)** — not the Mtr4-like MTREC RNA helicase (that is `mtl1`), but a
+  **Mid2-like GPI-anchored plasma-membrane cell-wall stress sensor** with no catalytic domain.
+- **`spa1` (pombe, SPBC577.14c)** — not the mammalian Rap-GAP SIPA1/SPA1 despite the shared
+  symbol, but **ornithine decarboxylase antizyme** (an ODC inhibitor).
+- **`knh4` (pombe, SPBC1E8.05)** — not a Knr4/Smi1 protein, but a **Kre9/Knh1-family β-glucan
+  cell-wall glycoprotein**.
+- **`MNN14` (yeast, YJR061W)** — not a GT15/MNN1 α-1,3-mannosyltransferase, but a **LicD-family
+  mannosyl-phosphate transferase** (activity later added from primary literature; see §4).
+- **`ppgn-1` (worm)** — the flagship-project framing implied an immunity effector; the record
+  shows the **paraplegin / SPG7 m-AAA protease** (a reproducible motif scan confirmed intact
+  catalytic residues).
+- **`MCO14` (yeast)** — `fetch-gene` failed on the symbol; resolved via SGD to **YHL018W**, a
+  PCD/DCoH-family protein. (Yeast/pombe standard names frequently are not in UniProt's gene
+  line — the pipeline now falls back to the systematic name + `--uniprot-id`.)
+
+## 2. Pseudoenzyme detection
+
+A conserved catalytic *fold* is routinely over-annotated with the ancestral catalytic *activity*
+even when the catalytic residues have degenerated. Inline domain analysis (reading the UniProt
+features and checking the specific catalytic motif) flagged several:
+
+- **`KDX1` (yeast)** — protein-kinase fold but activation-loop **DFG→NFG** and catalytic-loop
+  **HRD→HCD**; a catalytically inactive **pseudokinase**. Nine propagated catalytic-kinase MF/BP
+  terms marked as over-annotations; its real role is a non-catalytic Swi4/Rlm1 scaffold.
+- **`OCA6` (yeast)** — PTP/DSP fold but the invariant CX5R catalytic arginine is replaced (→Ile);
+  a likely **pseudophosphatase**; the "protein tyrosine phosphatase activity" IEA flagged.
+- **`GPM3` (yeast)** — retains the phosphoglycerate-mutase histidines yet is experimentally
+  **inactive as a mutase**; glycolysis/mutase terms demoted with `propagation_review`.
+- **`wago-4` (worm)** — an Argonaute lacking the catalytic tetrad; the endonuclease/"slicer" term
+  removed on biological grounds, `miRNA binding` corrected to `siRNA binding` (binds 22G-RNAs).
+
+## 3. Family over-propagation removed or demoted
+
+The dominant false-positive class for dark genes is IBA/ISS transfer from a characterized
+paralog or distant ortholog whose function does not hold for the target:
+
+- **`fis-1` (worm)** — contrary to the FIS1 family's fission-receptor reputation, worm FIS-1 is
+  **not required** for mitochondrial or peroxisomal fission (LOF is silent); family fission
+  terms kept non-core, and its supported role (mitophagy coupling) added as NEW.
+- **`ILT1` (yeast)** — PQ-loop transporter annotated as a *vacuolar* basic-amino-acid transporter
+  by propagation from Ypq1/2; ILT1 is experimentally **plasma-membrane** and in a distinct
+  uncharacterized subfamily — vacuolar terms removed.
+- **`LEE1` (yeast)** — makorin-family; ubiquitin-ligase activity propagated from RING-containing
+  metazoan makorins, but LEE1 has **no RING domain** (confirmed by direct InterPro query) —
+  ligase terms marked over-annotated; only its CCCH zinc-finger zinc-binding kept.
+- **`NVJ3` (yeast)** — PI3P-binding transferred from paralog Mdm1, but NVJ3 shares only the PXA
+  domain and **lacks the PX domain** that carries the activity — removed.
+- **`AAD3` (yeast)** — aryl-alcohol dehydrogenase activity propagated from a lignin-degrader
+  enzyme; the AAD deletants are phenotype-null and budding yeast is not a lignin degrader —
+  demoted to the honest superfamily-level oxidoreductase term.
+- **`THI22` (yeast)** — HMP-P kinase activity: the one direct assay found **no activity** for
+  THI22, so the propagated kinase term was marked over-annotated (residues intact → not a
+  pseudoenzyme, but activity unproven).
+- **`gpa-12` (worm)** — Gα subunit carrying propagated Gs/Gi adenylate-cyclase-modulating and
+  D5-dopamine-receptor-binding terms wrong for the G12/13 subfamily — removed.
+
+In every case the annotation was flagged as electronic over-propagation with a structured
+`propagation_review`, **not** by overruling an experimental annotation.
+
+## 4. Evidence-grounded upgrades
+
+Dark-gene review is not only subtractive; deep reading also finds well-supported functions
+*missing* from GOA:
+
+- **`MNN14` (yeast)** — a falcon-surfaced, PubMed-verified paper (Kang et al. 2021) shows
+  recombinant Mnn14 transfers mannose-phosphate from GDP-mannose to high-mannose N-glycans;
+  `mannosylphosphate transferase activity` (GO:0000031) added as an evidence-backed NEW MF.
+- **`spa1` (pombe)** — ornithine-decarboxylase-inhibitor activity confirmed directly for the
+  fission-yeast protein (recombinant Spa1 inhibits *S. pombe* ODC) and kept as the core function.
+
+## 5. Fabrication guardrails held
+
+The `supporting_text`-must-be-verbatim rule and independent fact-checking caught deep-research
+errors before they entered a review:
+
+- **`tin-44` (worm)** — a falcon report's "RNAi extended lifespan 11.1%" was a hallucination; the
+  cached full text actually groups tin-44 among lifespan-*shortening* import knockdowns. Removed.
+- **`NIT1` (yeast, YIL164C)** — a falcon report conflated NIT1 with its dGSH-amidase paralog
+  NIT2/YJL126W; the misattributed activity claim was fact-checked out (catalytic-residue numbering
+  mismatch) and the reference flagged `MISCITED`.
+- **`prg-2` (worm)** — correctly **failed** rather than being fabricated: it is a WormBase
+  pseudogene with no UniProt entry and zero GO annotations; substituted with another gene.
+- **`LPX2` (yeast)** — a rebase accident degraded a protected publication cache to abstract-only,
+  which had let the review claim the Ploier 2013 full text was "inaccessible." Restoring the
+  full text showed that paper *tested* Ykl050c and found **no** in-vivo lipolytic activity —
+  correcting the review and strengthening its MF-unknown conclusion.
+
+## Why this matters
+
+Across 120 dark genes, the value was rarely a brand-new function statement; it was (a) getting the
+protein's *identity* right, (b) refusing to inherit a paralog's activity through a degenerate fold
+or a wrong-subfamily transfer, and (c) writing down, with provenance, exactly what remains unknown.
+That is the raw material the [Function Knowledge Gaps](../FUNCTION_KNOWLEDGE_GAPS.md) register is
+built from.

--- a/scripts/deep_research_wrapper.py
+++ b/scripts/deep_research_wrapper.py
@@ -8,6 +8,8 @@ This script:
 4. Handles output path construction
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import shlex


### PR DESCRIPTION
## Two changes

### 1. Fix `deep-research-*` recipe failures
The gene- and module-level `deep-research-*` justfile recipes invoked bare `python3`, which on macOS is **3.9** and cannot evaluate the `dict | None` (PEP 604) annotations in `scripts/deep_research_wrapper.py` — so `just deep-research-falcon` (and siblings) failed at import with `TypeError: unsupported operand type(s) for |`. Surfaced repeatedly during the yeast/pombe dark-gene review campaigns (agents worked around it with `uv run python`).

- Switch all 16 affected recipe lines from `python3` → `uv run python`, matching the already-correct concept/family/rules recipes (guarantees the 3.12 venv).
- Add `from __future__ import annotations` to `deep_research_wrapper.py` as defense-in-depth (the two module wrappers already had it).

Verified: the wrapper now imports cleanly under system 3.9, and `just --show deep-research-falcon` resolves to `uv run python`.

### 2. Document dark-gene curation highlights
New FUNCTION_KNOWLEDGE_GAPS sub-page (`projects/FUNCTION_KNOWLEDGE_GAPS/dark-gene-curation-highlights.md`, linked from the parent) summarizing the recurring, generalizable curation findings from the 50 CAEEL + 50 *S. cerevisiae* + 20 *S. pombe* dark-gene review campaigns: identity corrections (e.g. pombe `sel0`=Selenoprotein O, `mtl3`=Mid2-like sensor, `spa1`=ODC antizyme; yeast `MNN14`, `ppgn-1`=SPG7), pseudoenzyme detection (`KDX1`, `OCA6`, `GPM3`, `wago-4`), family over-propagation removals (`fis-1`, `ILT1`, `LEE1`, `AAD3`, `THI22`, `gpa-12`), evidence-grounded upgrades, and fabrication guardrails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)