### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/DLAT/DLAT-ai-review.html
+++ b/genes/human/DLAT/DLAT-ai-review.html
@@ -1,0 +1,6197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DLAT - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>DLAT</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P10515" target="_blank" class="term-link">
+                        P10515
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "DLAT";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P10515" data-a="DESCRIPTION: DLAT is the dihydrolipoyllysine-residue acetyltran..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>DLAT is the dihydrolipoyllysine-residue acetyltransferase (E2) component of the mitochondrial pyruvate dehydrogenase complex (PDC), EC 2.3.1.12. It carries covalently bound lipoyl cofactors on two lipoyl-binding domains (Lys132 and Lys259) and catalyzes the second step of the overall pyruvate-to-acetyl-CoA reaction, accepting the acetyl group from the acetyl-dihydrolipoyl intermediate generated by the E1 component and transferring it to coenzyme A to form acetyl-CoA. The C-terminal catalytic (inner) domains of E2, together with the E3-binding protein (PDHX), assemble into a 60-meric dodecahedral core with icosahedral symmetry that forms the structural scaffold of the PDC and to which the peripheral E1 and E3 enzymes and the regulatory kinases (PDK) and phosphatases (PDP) attach. Acting in the mitochondrial matrix, the PDC links cytosolic glycolysis to the tricarboxylic acid cycle by supplying acetyl-CoA. Biallelic loss-of-function variants in DLAT cause pyruvate dehydrogenase E2 deficiency, a rare subtype of PDC deficiency presenting with lactic acidosis, episodic dystonia and neurologic dysfunction. DLAT is also the 70-kDa M2 mitochondrial autoantigen recognized by antimitochondrial antibodies in primary biliary cholangitis.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004742" target="_blank" class="term-link">
+                                    GO:0004742
+                                </a>
+                            </span>
+                            <span class="term-label">dihydrolipoyllysine-residue acetyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0004742" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of the E2 acetyltransferase activity, the defining catalytic function of DLAT. Well supported by direct experimental data in human and orthologs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core, defining molecular function of DLAT (EC 2.3.1.12) and is corroborated by IDA evidence in the same GOA set.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link">
+                                        PMID:20160912
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic assignment of mitochondrial localization. Correct but the more specific matrix term (GO:0005759) better captures where DLAT acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mitochondrion is a correct but general compartment; the mitochondrial matrix annotations are more informative for the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0006086" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic assignment of the overall PDC process to which DLAT contributes the E2 acetyltransfer step. This is the core biological process for DLAT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> DLAT catalyzes the E2 step of the pyruvate-to-acetyl-CoA conversion; this is its core process and is supported by multiple experimental annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link">
+                                        PMID:20160912
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0045254" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic assignment of DLAT as part of the PDC. DLAT (E2) forms the structural core of this complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> DLAT is the E2 core subunit of the PDC; this complex membership is central to its function and confirmed experimentally.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human PDC is organized around a 60-meric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004742" target="_blank" class="term-link">
+                                    GO:0004742
+                                </a>
+                            </span>
+                            <span class="term-label">dihydrolipoyllysine-residue acetyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0004742" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA/InterPro/EC 2.3.1.12/RHEA:17017) assignment of the core E2 acetyltransferase activity. Consistent with the experimental annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly maps the EC 2.3.1.12 catalytic activity that is DLAT&#39;s core function; the UniProt record carries the same EC/RHEA reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link">
+                                        PMID:20160912
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005759" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of mitochondrial matrix localization (UniProtKB-SubCell SL-0170). This is the compartment where DLAT and the PDC act.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix localization is the correct, specific compartment for DLAT and is stated in the UniProt SUBCELLULAR LOCATION field.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0006086" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of the core PDC process. Consistent with experimental annotations to the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core process; duplicate of experimentally supported annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link">
+                                        PMID:20160912
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016746" target="_blank" class="term-link">
+                                    GO:0016746
+                                </a>
+                            </span>
+                            <span class="term-label">acyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0016746" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic assignment of the general acyltransferase parent term. Correct but far less specific than GO:0004742.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a general parent of the specific dihydrolipoyllysine-residue acetyltransferase activity that DLAT enables; retained but not core, as the specific term is annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9045657" target="_blank" class="term-link">
+                                        PMID:9045657
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Purified E2 had a high</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0045254" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of PDC membership. Consistent with experimental complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core complex membership; duplicate of experimentally supported annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human PDC is organized around a 60-meric</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17683942" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17683942
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Distinct structural mechanisms for inhibition of pyruvate de...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005515" data-r="PMID:17683942" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI capturing the DLAT(E2)-PDK3 interaction (lipoyl domain 2 in complex with pyruvate dehydrogenase kinase 3). A real, structurally characterized interaction, but the term itself is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; conveys no specific function. The underlying interaction (DLAT lipoyl domain 2 with PDK3) is genuine and relates to PDC regulation, but per curation policy this term is marked as over-annotated rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interacts with PDK2 and PDK3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18206651" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18206651
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Binding of pyruvate dehydrogenase to the core of the human p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005515" data-r="PMID:18206651" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI capturing the DLAT(E2)-PDHB (E1 beta) interaction. The E1 component binds the subunit-binding domain of E2. Real interaction, uninformative term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative; the specific E1-E2 assembly interaction is real but is better captured by complex membership. Marked over-annotated per policy rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18206651" target="_blank" class="term-link">
+                                        PMID:18206651
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">(E1) is bound to the E1-binding domain of dihydrolipoamide acetyltransferase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25525879
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Sirtuin 4 is a lipoamidase regulating pyruvate dehydrogenase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005515" data-r="PMID:25525879" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI capturing the DLAT-SIRT4 interaction. SIRT4 is a lipoamidase that delipoylates DLAT to regulate PDC activity. Real interaction, uninformative term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative. The DLAT-SIRT4 interaction is genuine and regulatory, but the term is marked over-annotated per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" target="_blank" class="term-link">
+                                        PMID:25525879
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">SIRT4 hydrolyzes lipoamide cofactors from the DLAT E2 component of the PDH complex, thereby inhibiting PDH activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput affinity-capture interactome (BioPlex) IPI to PDK3. Real but uninformative bare protein-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; from a proteome-scale interactome; uninformative as a molecular function. Marked over-annotated per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interacts with PDK2 and PDK3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteome-scale interactome (BioPlex 3.0) IPI (PDHB/PDK3). Real but uninformative bare protein-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; from a large interactome study; uninformative as a molecular function. Marked over-annotated per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interacts with PDHB</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18184587" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18184587
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extended polypeptide linkers establish the spatial architect...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0042802" data-r="PMID:18184587" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI for DLAT self-association. E2 self-assembles into the 60-meric central core of the PDC, so identical protein binding (homo-oligomerization) is a genuine and informative structural property.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> DLAT self-assembles into the dodecahedral E2 core; identical protein binding captures this real structural oligomerization. Kept as a supporting structural annotation, non-core relative to the catalytic activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18184587" target="_blank" class="term-link">
+                                        PMID:18184587
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consisting of a central E2 core decorated by a shell of peripheral enzymes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18184588" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18184588
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of the human pyruvate dehydrogenase complex cores...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0042802" data-r="PMID:18184588" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI for DLAT self-association based on cryo-EM of the human E2 core. E2 trimers assemble into the 60-meric dodecahedral inner core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Captures the genuine homo-oligomeric self-assembly of E2 into the PDC core. Kept as a supporting structural annotation, non-core relative to catalysis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18184588" target="_blank" class="term-link">
+                                        PMID:18184588
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dihydrolipoyl acetyltransferase (E2) is the central component of pyruvate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016407" target="_blank" class="term-link">
+                                    GO:0016407
+                                </a>
+                            </span>
+                            <span class="term-label">acetyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0016407" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-projected (from mouse ortholog) electronic assignment of the general acetyltransferase parent term. Correct but less specific than GO:0004742.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> General parent of the specific dihydrolipoyllysine-residue acetyltransferase activity; retained but not core because the specific term is annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9045657" target="_blank" class="term-link">
+                                        PMID:9045657
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Purified E2 had a high</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042867" target="_blank" class="term-link">
+                                    GO:0042867
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0042867" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-projected electronic assignment of the general pyruvate catabolism process. Correct but broader than the specific pyruvate-to-acetyl-CoA process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A correct but more general process term; the specific pyruvate decarboxylation to acetyl-CoA (GO:0006086) is the core process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                                        PMID:24534072
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">plays a key role in the conversion of pyruvate to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861559
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0006086" data-r="Reactome:R-HSA-9861559" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for the overall PDC reaction that synthesizes acetyl-CoA from pyruvate. Core process for DLAT as the E2 component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core process, curated by Reactome and consistent with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                                        PMID:24534072
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">acetyl-CoA connecting glycolysis to the citric acid cycle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004742" target="_blank" class="term-link">
+                                    GO:0004742
+                                </a>
+                            </span>
+                            <span class="term-label">dihydrolipoyllysine-residue acetyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861667
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0004742" data-r="Reactome:R-HSA-9861667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for the DLAT-catalyzed transfer of the acetyl group from acetyllipoyl-lysine to CoA. This is the defining E2 reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core catalytic function, curated by Reactome (DLAT trimer transfers acetyl to CoA) and consistent with the EC 2.3.1.12 reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link">
+                                        PMID:20160912
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24534072
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Component co-expression and purification of recombinant huma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005739" data-r="PMID:24534072" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS for mitochondrial localization. Correct but general compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general compartment; the mitochondrial matrix term is more informative for the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                                        PMID:24534072
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mammalian pyruvate dehydrogenase complex (PDC) is a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24534072
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Component co-expression and purification of recombinant huma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0006086" data-r="PMID:24534072" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA from reconstituted recombinant human PDC (all five components co-expressed and lipoylated) demonstrating the functional pyruvate-to-acetyl-CoA reaction. Core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for DLAT participating in the core PDC reaction via a functional reconstituted complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                                        PMID:24534072
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">plays a key role in the conversion of pyruvate to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19240034
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subunit and catalytic component stoichiometries of an in vit...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0045254" data-r="PMID:19240034" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI from in vitro reconstitution and stoichiometry study establishing DLAT (E2p) as part of the 60-meric PDC core. Core complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct evidence that DLAT (E2p) is a subunit of the PDC core; this is central to its function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dihydrolipoyl transacetylase (E2p)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HPA immunofluorescence IDA for mitochondrial localization. Correct but general compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct mitochondrial localization by immunofluorescence; general compartment, with matrix being the more specific and informative term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">GO:0005739; C:mitochondrion; IDA:HPA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005759" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer (from rat ortholog P08461) of mitochondrial matrix localization. Correct specific compartment where DLAT acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix is the correct, specific compartment for DLAT/PDC and is consistent with the UniProt SUBCELLULAR LOCATION field.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20160912
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interaction of E1 and E3 components with the core proteins o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0006086" data-r="PMID:20160912" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA from reconstitution/kinetic study of the human PDC (E1, E2, E3 components) supporting DLAT&#39;s role in the overall pyruvate-to-acetyl-CoA reaction. Core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for DLAT in the core PDC process via functional reconstitution and activity assays.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link">
+                                        PMID:20160912
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004742" target="_blank" class="term-link">
+                                    GO:0004742
+                                </a>
+                            </span>
+                            <span class="term-label">dihydrolipoyllysine-residue acetyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9242632
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dihydrolipoamide dehydrogenase-binding protein of the human ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0004742" data-r="PMID:9242632" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI-curated IDA for the E2 acetyltransferase activity, from a reconstitution study of the human PDC (E3BP/E2). Core catalytic function. The paper title foregrounds E3BP (protein X), but the full-text reconstitution work assays the E2 core; defer to curator.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for the defining E2 catalytic activity; consistent with other IDA/IEA/EC annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                        PMID:9242632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">spontaneously reconstituted the pyruvate dehydrogenase complex in the presence</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9242632
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dihydrolipoamide dehydrogenase-binding protein of the human ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0006086" data-r="PMID:9242632" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI-curated IC (from the GO:0004742 activity) that DLAT acts within the overall pyruvate-to-acetyl-CoA process via functional PDC reconstitution. Core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reasonable inference from the E2 catalytic activity to participation in the PDC process; consistent with the other process annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                        PMID:9242632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">spontaneously reconstituted the pyruvate dehydrogenase complex in the presence</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005739" data-r="PMID:34800366" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteome study assigning DLAT to the mitochondrion. Correct but general compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct mitochondrial localization from a high-confidence proteome; general compartment, with matrix being the more specific term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                                        PMID:34800366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Quantitative high-confidence human mitochondrial proteome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-203946
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005759" data-r="Reactome:R-HSA-203946" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing DLAT in the mitochondrial matrix (PDK phosphorylation of the PDC subunit E1 reaction). Correct specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-204169
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005759" data-r="Reactome:R-HSA-204169" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing DLAT in the mitochondrial matrix (PDP dephosphorylation reaction). Correct specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9858752
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005759" data-r="Reactome:R-HSA-9858752" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing DLAT in the mitochondrial matrix (LIPT1 lipoyl transfer to DLAT reaction). Correct specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861616
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005759" data-r="Reactome:R-HSA-9861616" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing DLAT in the mitochondrial matrix (DLD dehydrogenation of dihydrolipoyl reaction). Correct specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861626
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005759" data-r="Reactome:R-HSA-9861626" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing DLAT in the mitochondrial matrix (SIRT4 delipoylation of DLAT reaction). Correct specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861667
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005759" data-r="Reactome:R-HSA-9861667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing DLAT in the mitochondrial matrix (DLAT acetyl transfer to CoA reaction). Correct specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861734
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005759" data-r="Reactome:R-HSA-9861734" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing DLAT in the mitochondrial matrix (E1 decarboxylation transferring acetyl to DLAT reaction). Correct specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004742" target="_blank" class="term-link">
+                                    GO:0004742
+                                </a>
+                            </span>
+                            <span class="term-label">dihydrolipoyllysine-residue acetyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20160912
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interaction of E1 and E3 components with the core proteins o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0004742" data-r="PMID:20160912" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt-curated IDA for the E2 acetyltransferase activity (catalytic activity and interaction with PDHB reported). Core catalytic function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for the defining E2 catalytic activity; this is the source of the EC 2.3.1.12 assignment in UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link">
+                                        PMID:20160912
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">E1 carries out the decarboxylation of pyruvate and reductive acetylation of the lipoyl moieties of E2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006099" target="_blank" class="term-link">
+                                    GO:0006099
+                                </a>
+                            </span>
+                            <span class="term-label">tricarboxylic acid cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0006099" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer of &#34;tricarboxylic acid cycle&#34; involvement. DLAT/PDC feeds the TCA cycle by producing acetyl-CoA but the PDH reaction itself is not a step of the TCA cycle; this conflates an upstream feeder role with the cycle proper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> DLAT is not a TCA-cycle enzyme. The PDC produces acetyl-CoA that enters the TCA cycle, but pyruvate decarboxylation to acetyl-CoA (GO:0006086) is a distinct process. This ISS is an over-annotation (the correct process is annotated separately). Not removed outright per policy; flagged.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                                        PMID:24534072
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">acetyl-CoA connecting glycolysis to the citric acid cycle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9242632
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dihydrolipoamide dehydrogenase-binding protein of the human ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0045254" data-r="PMID:9242632" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI-curated IDA that DLAT (E2) is part of the reconstituted PDC. Core complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for DLAT as the E2 core subunit of the PDC.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                        PMID:9242632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is required for anchoring dihydrolipoamide dehydrogenase (E3) to the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004742" target="_blank" class="term-link">
+                                    GO:0004742
+                                </a>
+                            </span>
+                            <span class="term-label">dihydrolipoyllysine-residue acetyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9045657" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9045657
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Assembly and full functionality of recombinantly expressed d...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0004742" data-r="PMID:9045657" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI-curated IDA for the E2 acetyltransferase activity from recombinant, fully functional human E2 that assembled into the dodecahedral core and had high acetyltransferase activity. Core catalytic function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental demonstration of DLAT&#39;s E2 acetyltransferase activity using purified, assembled recombinant human protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9045657" target="_blank" class="term-link">
+                                        PMID:9045657
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Purified E2 had a high</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25525879
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Sirtuin 4 is a lipoamidase regulating pyruvate dehydrogenase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0045254" data-r="PMID:25525879" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt-curated IDA (from the SIRT4/PDH study) that DLAT is the E2 component of the PDC. Core complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for DLAT as the E2 subunit forming the PDC catalytic core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" target="_blank" class="term-link">
+                                        PMID:25525879
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DLAT also has a structural role, constituting the PDH catalytic core</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20833797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphoproteome analysis of functional mitochondria isolated...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005739" data-r="PMID:20833797" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput phosphoproteome analysis of isolated mitochondria assigning DLAT to the mitochondrion. Correct but general compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct mitochondrial localization from a mitochondrial phosphoproteome; general compartment, with matrix being the more specific term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link">
+                                        PMID:20833797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">functional mitochondria isolated from resting</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15861126" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15861126
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of pyruvate dehydrogenase kinase 3 bound t...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0005515" data-r="PMID:15861126" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI capturing the DLAT lipoyl-domain-2/PDK3 interaction (crystal structure of PDK3 bound to lipoyl domain 2). Real, structurally defined interaction, but uninformative bare term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative. The lipoyl-domain-2/PDK3 interaction is genuine and structurally characterized, but the term is marked over-annotated per policy rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/DLAT/DLAT-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interacts with PDK2 and PDK3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004742" target="_blank" class="term-link">
+                                    GO:0004742
+                                </a>
+                            </span>
+                            <span class="term-label">dihydrolipoyllysine-residue acetyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3191998" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3191998
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Nucleotide sequence of a cDNA for the dihydrolipoamide acety...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0004742" data-r="PMID:3191998" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NAS from the original human DLAT cDNA sequencing paper, assigning the dihydrolipoamide acetyltransferase (E2) identity/activity. Core function, historically established.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The founding sequence report identifying DLAT as the E2 acetyltransferase of the human PDC; consistent with all later experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3191998" target="_blank" class="term-link">
+                                        PMID:3191998
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the dihydrolipoamide acetyltransferase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3191998" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3191998
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Nucleotide sequence of a cDNA for the dihydrolipoamide acety...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P10515" data-a="GO:0045254" data-r="PMID:3191998" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NAS from the original DLAT cDNA paper, assigning DLAT as a component of the human PDC. Core complex membership, historically established.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The founding report describing DLAT as the E2 component of the human PDC; consistent with later experimental complex annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3191998" target="_blank" class="term-link">
+                                        PMID:3191998
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">human pyruvate dehydrogenase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Dihydrolipoyllysine-residue acetyltransferase (E2) that transfers the acetyl group from the acetyl-dihydrolipoyl-lysine intermediate to coenzyme A, forming acetyl-CoA, as the second catalytic step of the pyruvate dehydrogenase complex reaction, acting as the structural and catalytic core of the complex in the mitochondrial matrix.</h3>
+                <span class="vote-buttons" data-g="P10515" data-a="FUNCTION: Dihydrolipoyllysine-residue acetyltransferase (E2)..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004742" target="_blank" class="term-link">
+                            dihydrolipoyllysine-residue acetyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                pyruvate decarboxylation to acetyl-CoA
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                            pyruvate dehydrogenase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link">
+                                PMID:20160912
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                PMID:19240034
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The human PDC is organized around a 60-meric</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15861126" target="_blank" class="term-link">
+                            PMID:15861126
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Crystal structure of pyruvate dehydrogenase kinase 3 bound to lipoyl domain 2 of human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17683942" target="_blank" class="term-link">
+                            PMID:17683942
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Distinct structural mechanisms for inhibition of pyruvate dehydrogenase kinase isoforms by AZD7545, dichloroacetate, and radicicol.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18184587" target="_blank" class="term-link">
+                            PMID:18184587
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Extended polypeptide linkers establish the spatial architecture of a pyruvate dehydrogenase multienzyme complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18184588" target="_blank" class="term-link">
+                            PMID:18184588
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structures of the human pyruvate dehydrogenase complex cores: a highly conserved catalytic center with flexible N-terminal domains.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18206651" target="_blank" class="term-link">
+                            PMID:18206651
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Binding of pyruvate dehydrogenase to the core of the human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                            PMID:19240034
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Subunit and catalytic component stoichiometries of an in vitro reconstituted human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" target="_blank" class="term-link">
+                            PMID:20160912
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interaction of E1 and E3 components with the core proteins of the human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link">
+                            PMID:20833797
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phosphoproteome analysis of functional mitochondria isolated from resting human muscle reveals extensive phosphorylation of inner membrane protein complexes and enzymes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                            PMID:24534072
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Component co-expression and purification of recombinant human pyruvate dehydrogenase complex from baculovirus infected SF9 cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" target="_blank" class="term-link">
+                            PMID:25525879
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Sirtuin 4 is a lipoamidase regulating pyruvate dehydrogenase complex activity.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/3191998" target="_blank" class="term-link">
+                            PMID:3191998
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Nucleotide sequence of a cDNA for the dihydrolipoamide acetyltransferase component of human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9045657" target="_blank" class="term-link">
+                            PMID:9045657
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Assembly and full functionality of recombinantly expressed dihydrolipoyl acetyltransferase component of the human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                            PMID:9242632
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dihydrolipoamide dehydrogenase-binding protein of the human pyruvate dehydrogenase complex. DNA-derived amino acid sequence, expression, and reconstitution of the pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-203946
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDK isozymes phosphorylate PDHC subunit E1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-204169
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDP1,2 dephosphorylate p-lipo-PDH</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9858752
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LIPT1 transfers lipoyl group from lipoyl-GCSH to DLAT</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861559
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDH complex synthesizes acetyl-CoA from PYR</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861616
+
+                    </span>
+                </div>
+
+                <div class="reference-title">DLD dimer dehydrogenates dihydrolipoyl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861626
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SIRT4 cleaves lipoyl from DLAT</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861667
+
+                    </span>
+                </div>
+
+                <div class="reference-title">DLAT trimer transfers acetyl to CoA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861734
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDH E1 decarboxylates PYR, transferring acetyl to DLAT</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(DLAT-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P10515" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dlat-p10515-curation-notes">DLAT (P10515) — curation notes</h1>
+<p>Deep research (<code>DLAT-deep-research-falcon.md</code>) was NOT present within the 8-min poll window; this<br />
+review is grounded in the UniProt record (<code>DLAT-uniprot.txt</code>), the seeded GOA<br />
+(<code>DLAT-goa.tsv</code>), the cached <code>publications/PMID_*.md</code> files (all 16 cited PMIDs present) and<br />
+Reactome entries, plus <code>~/repos/dismech/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml</code>.</p>
+<h2 id="verified-biology">Verified biology</h2>
+<p>DLAT (ODP2_HUMAN, PDC-E2, EC 2.3.1.12) is the dihydrolipoyllysine-residue acetyltransferase<br />
+(E2) component of the mitochondrial pyruvate dehydrogenase complex (PDC). It is the structural<br />
+and catalytic core of the complex.</p>
+<ul>
+<li><strong>Core MF</strong>: GO:0004742 dihydrolipoyllysine-residue acetyltransferase activity. Reaction<br />
+  (UniProt/RHEA:17017): N6-[(R)-dihydrolipoyl]-L-lysyl-[protein] + acetyl-CoA =<br />
+  N6-[(R)-S(8)-acetyldihydrolipoyl]-L-lysyl-[protein] + CoA. Physiologically DLAT accepts the<br />
+  acetyl group from the E1-generated acetyl-dihydrolipoyl intermediate and transfers it to CoA<br />
+  to form acetyl-CoA <a href="https://pubmed.ncbi.nlm.nih.gov/20160912" title="E2 then transfers the acetyl moiety to CoA forming acetyl-CoA">PMID:20160912</a>.</li>
+<li><strong>Core BP</strong>: GO:0006086 pyruvate decarboxylation to acetyl-CoA — DLAT catalyzes the E2 step of<br />
+  the overall pyruvate→acetyl-CoA conversion linking glycolysis to the TCA cycle.</li>
+<li><strong>Core CC/complex</strong>: GO:0045254 pyruvate dehydrogenase complex; GO:0005759 mitochondrial matrix.<br />
+  The E2 (+E3BP) C-terminal catalytic domains form a 60-meric dodecahedral inner core to which E1,<br />
+  E3 and PDK/PDP attach [PMID:9045657 "inner core was assembled in the expected pentagonal<br />
+  dodecahedron shape"; PMID:19240034 "60-meric dodecahedral core comprising the C-terminal domains<br />
+  of E2p"; PMID:18184588 "Dihydrolipoyl acetyltransferase (E2) is the central component"].</li>
+<li><strong>Cofactor / lipoyl</strong>: two covalent lipoyl cofactors at K132 and K259 (lipoyl-binding domains 1<br />
+  and 2); the lipoyl arm shuttles intermediates between active sites [PMID:25525879 K132/K259<br />
+  lipoyl; PMID:18184587 "lipoyl domains of E2 that carry catalytic intermediates shuttle between<br />
+  E1, E2, and E3 active sites"]. SIRT4 delipoylates DLAT to inhibit PDH (regulatory, non-core).</li>
+<li><strong>Disease</strong>: biallelic loss-of-function DLAT variants cause pyruvate dehydrogenase E2 deficiency<br />
+  (PDHE2, MIM:245348) — a rare PDH-deficiency subtype with childhood lactic acidosis, episodic<br />
+  dystonia and neurologic dysfunction [UniProt DISEASE; PMID:16049940; disorders KB Orphanet<br />
+  record]. DLAT is also the 70-kDa M2 mitochondrial autoantigen of primary biliary cholangitis<br />
+  (genuine but non-core immunological fact) [UniProt; PMID:3174635].</li>
+</ul>
+<h2 id="annotation-review-decisions-summary">Annotation-review decisions (summary)</h2>
+<ul>
+<li>Catalytic MF (GO:0004742): ACCEPT the experimental/IBA/IEA lines as core (IDA PMID:20160912,<br />
+  9242632, 9045657; IBA; IEA GO_REF:0000120 EC 2.3.1.12; TAS Reactome R-HSA-9861667; NAS<br />
+  PMID:3191998). GO:0016407 acetyltransferase activity (IEA) and GO:0016746 acyltransferase<br />
+  activity (IEA) are correct-but-general parents → MARK_AS_OVER_ANNOTATED (keep, non-core parent).</li>
+<li>BP GO:0006086 (multiple IDA/IBA/IEA/TAS/IC): ACCEPT as core process.</li>
+<li>GO:0042867 pyruvate catabolic process (IEA): broader/adjacent, KEEP_AS_NON_CORE.</li>
+<li>GO:0006099 tricarboxylic acid cycle (ISS): DLAT is not a TCA-cycle enzyme — it feeds the TCA<br />
+  cycle by producing acetyl-CoA but the PDH reaction is not part of the TCA cycle. Over-annotation<br />
+  → MARK_AS_OVER_ANNOTATED (do not REMOVE an ISS silently; keep flagged).</li>
+<li>CC: GO:0045254 (PDC) core; GO:0005759 mitochondrial matrix core; GO:0005739 mitochondrion<br />
+  (parent) KEEP_AS_NON_CORE.</li>
+<li>protein binding IPIs (GO:0005515): all bare "protein binding" → MARK_AS_OVER_ANNOTATED per policy<br />
+  (uninformative; underlying interactions are real: PDHB/E1, PDK2/PDK3, SIRT4). identical protein<br />
+  binding IPIs (GO:0042802, PMID:18184587/18184588) capture DLAT self-assembly into the homomeric<br />
+  core — informative → ACCEPT (KEEP_AS_NON_CORE structural).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P10515
+gene_symbol: DLAT
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: DLAT is the dihydrolipoyllysine-residue acetyltransferase (E2) component
+  of the mitochondrial pyruvate dehydrogenase complex (PDC), EC 2.3.1.12. It carries
+  covalently bound lipoyl cofactors on two lipoyl-binding domains (Lys132 and Lys259)
+  and catalyzes the second step of the overall pyruvate-to-acetyl-CoA reaction, accepting
+  the acetyl group from the acetyl-dihydrolipoyl intermediate generated by the E1
+  component and transferring it to coenzyme A to form acetyl-CoA. The C-terminal catalytic
+  (inner) domains of E2, together with the E3-binding protein (PDHX), assemble into
+  a 60-meric dodecahedral core with icosahedral symmetry that forms the structural
+  scaffold of the PDC and to which the peripheral E1 and E3 enzymes and the regulatory
+  kinases (PDK) and phosphatases (PDP) attach. Acting in the mitochondrial matrix,
+  the PDC links cytosolic glycolysis to the tricarboxylic acid cycle by supplying
+  acetyl-CoA. Biallelic loss-of-function variants in DLAT cause pyruvate dehydrogenase
+  E2 deficiency, a rare subtype of PDC deficiency presenting with lactic acidosis,
+  episodic dystonia and neurologic dysfunction. DLAT is also the 70-kDa M2 mitochondrial
+  autoantigen recognized by antimitochondrial antibodies in primary biliary cholangitis.
+existing_annotations:
+- term:
+    id: GO:0004742
+    label: dihydrolipoyllysine-residue acetyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) assignment of the E2 acetyltransferase activity, the
+      defining catalytic function of DLAT. Well supported by direct experimental data
+      in human and orthologs.
+    action: ACCEPT
+    reason: This is the core, defining molecular function of DLAT (EC 2.3.1.12) and
+      is corroborated by IDA evidence in the same GOA set.
+    supported_by:
+    - reference_id: PMID:20160912
+      supporting_text: E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic assignment of mitochondrial localization. Correct but the
+      more specific matrix term (GO:0005759) better captures where DLAT acts.
+    action: KEEP_AS_NON_CORE
+    reason: Mitochondrion is a correct but general compartment; the mitochondrial
+      matrix annotations are more informative for the core function.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: SUBCELLULAR LOCATION Mitochondrion matrix
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic assignment of the overall PDC process to which DLAT contributes
+      the E2 acetyltransfer step. This is the core biological process for DLAT.
+    action: ACCEPT
+    reason: DLAT catalyzes the E2 step of the pyruvate-to-acetyl-CoA conversion; this
+      is its core process and is supported by multiple experimental annotations.
+    supported_by:
+    - reference_id: PMID:20160912
+      supporting_text: E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: Phylogenetic assignment of DLAT as part of the PDC. DLAT (E2) forms the
+      structural core of this complex.
+    action: ACCEPT
+    reason: DLAT is the E2 core subunit of the PDC; this complex membership is central
+      to its function and confirmed experimentally.
+    supported_by:
+    - reference_id: PMID:19240034
+      supporting_text: The human PDC is organized around a 60-meric
+- term:
+    id: GO:0004742
+    label: dihydrolipoyllysine-residue acetyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic (ARBA/InterPro/EC 2.3.1.12/RHEA:17017) assignment of the core
+      E2 acetyltransferase activity. Consistent with the experimental annotations.
+    action: ACCEPT
+    reason: Correctly maps the EC 2.3.1.12 catalytic activity that is DLAT&#39;s core
+      function; the UniProt record carries the same EC/RHEA reaction.
+    supported_by:
+    - reference_id: PMID:20160912
+      supporting_text: E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Electronic assignment of mitochondrial matrix localization (UniProtKB-SubCell
+      SL-0170). This is the compartment where DLAT and the PDC act.
+    action: ACCEPT
+    reason: Matrix localization is the correct, specific compartment for DLAT and
+      is stated in the UniProt SUBCELLULAR LOCATION field.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: SUBCELLULAR LOCATION Mitochondrion matrix
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic assignment of the core PDC process. Consistent with experimental
+      annotations to the same term.
+    action: ACCEPT
+    reason: Correct core process; duplicate of experimentally supported annotations.
+    supported_by:
+    - reference_id: PMID:20160912
+      supporting_text: E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.
+- term:
+    id: GO:0016746
+    label: acyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic assignment of the general acyltransferase parent
+      term. Correct but far less specific than GO:0004742.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: This is a general parent of the specific dihydrolipoyllysine-residue acetyltransferase
+      activity that DLAT enables; retained but not core, as the specific term is annotated.
+    supported_by:
+    - reference_id: PMID:9045657
+      supporting_text: Purified E2 had a high
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: part_of
+  review:
+    summary: Electronic assignment of PDC membership. Consistent with experimental
+      complex annotations.
+    action: ACCEPT
+    reason: Correct core complex membership; duplicate of experimentally supported
+      annotations.
+    supported_by:
+    - reference_id: PMID:19240034
+      supporting_text: The human PDC is organized around a 60-meric
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17683942
+  qualifier: enables
+  review:
+    summary: IntAct IPI capturing the DLAT(E2)-PDK3 interaction (lipoyl domain 2 in
+      complex with pyruvate dehydrogenase kinase 3). A real, structurally characterized
+      interaction, but the term itself is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; conveys no specific function. The underlying interaction
+      (DLAT lipoyl domain 2 with PDK3) is genuine and relates to PDC regulation, but
+      per curation policy this term is marked as over-annotated rather than removed.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: Interacts with PDK2 and PDK3
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18206651
+  qualifier: enables
+  review:
+    summary: IntAct IPI capturing the DLAT(E2)-PDHB (E1 beta) interaction. The E1
+      component binds the subunit-binding domain of E2. Real interaction, uninformative
+      term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative; the specific E1-E2 assembly interaction
+      is real but is better captured by complex membership. Marked over-annotated
+      per policy rather than removed.
+    supported_by:
+    - reference_id: PMID:18206651
+      supporting_text: (E1) is bound to the E1-binding domain of dihydrolipoamide
+        acetyltransferase
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25525879
+  qualifier: enables
+  review:
+    summary: IntAct IPI capturing the DLAT-SIRT4 interaction. SIRT4 is a lipoamidase
+      that delipoylates DLAT to regulate PDC activity. Real interaction, uninformative
+      term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative. The DLAT-SIRT4 interaction is
+      genuine and regulatory, but the term is marked over-annotated per policy.
+    supported_by:
+    - reference_id: PMID:25525879
+      supporting_text: SIRT4 hydrolyzes lipoamide cofactors from the DLAT E2 component
+        of the PDH complex, thereby inhibiting PDH activity
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: High-throughput affinity-capture interactome (BioPlex) IPI to PDK3. Real
+      but uninformative bare protein-binding term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; from a proteome-scale interactome; uninformative
+      as a molecular function. Marked over-annotated per policy.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: Interacts with PDK2 and PDK3
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: High-throughput proteome-scale interactome (BioPlex 3.0) IPI (PDHB/PDK3).
+      Real but uninformative bare protein-binding term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; from a large interactome study; uninformative as
+      a molecular function. Marked over-annotated per policy.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: Interacts with PDHB
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18184587
+  qualifier: enables
+  review:
+    summary: IPI for DLAT self-association. E2 self-assembles into the 60-meric central
+      core of the PDC, so identical protein binding (homo-oligomerization) is a genuine
+      and informative structural property.
+    action: KEEP_AS_NON_CORE
+    reason: DLAT self-assembles into the dodecahedral E2 core; identical protein binding
+      captures this real structural oligomerization. Kept as a supporting structural
+      annotation, non-core relative to the catalytic activity.
+    supported_by:
+    - reference_id: PMID:18184587
+      supporting_text: consisting of a central E2 core decorated by a shell of peripheral
+        enzymes
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18184588
+  qualifier: enables
+  review:
+    summary: IPI for DLAT self-association based on cryo-EM of the human E2 core. E2
+      trimers assemble into the 60-meric dodecahedral inner core.
+    action: KEEP_AS_NON_CORE
+    reason: Captures the genuine homo-oligomeric self-assembly of E2 into the PDC
+      core. Kept as a supporting structural annotation, non-core relative to catalysis.
+    supported_by:
+    - reference_id: PMID:18184588
+      supporting_text: Dihydrolipoyl acetyltransferase (E2) is the central component
+        of pyruvate
+- term:
+    id: GO:0016407
+    label: acetyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: Ensembl-projected (from mouse ortholog) electronic assignment of the
+      general acetyltransferase parent term. Correct but less specific than GO:0004742.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: General parent of the specific dihydrolipoyllysine-residue acetyltransferase
+      activity; retained but not core because the specific term is annotated.
+    supported_by:
+    - reference_id: PMID:9045657
+      supporting_text: Purified E2 had a high
+- term:
+    id: GO:0042867
+    label: pyruvate catabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Ensembl-projected electronic assignment of the general pyruvate catabolism
+      process. Correct but broader than the specific pyruvate-to-acetyl-CoA process.
+    action: KEEP_AS_NON_CORE
+    reason: A correct but more general process term; the specific pyruvate decarboxylation
+      to acetyl-CoA (GO:0006086) is the core process annotation.
+    supported_by:
+    - reference_id: PMID:24534072
+      supporting_text: plays a key role in the conversion of pyruvate to
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861559
+  qualifier: involved_in
+  review:
+    summary: Reactome TAS for the overall PDC reaction that synthesizes acetyl-CoA
+      from pyruvate. Core process for DLAT as the E2 component.
+    action: ACCEPT
+    reason: Correct core process, curated by Reactome and consistent with experimental
+      evidence.
+    supported_by:
+    - reference_id: PMID:24534072
+      supporting_text: acetyl-CoA connecting glycolysis to the citric acid cycle
+- term:
+    id: GO:0004742
+    label: dihydrolipoyllysine-residue acetyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861667
+  qualifier: enables
+  review:
+    summary: Reactome TAS for the DLAT-catalyzed transfer of the acetyl group from
+      acetyllipoyl-lysine to CoA. This is the defining E2 reaction.
+    action: ACCEPT
+    reason: Core catalytic function, curated by Reactome (DLAT trimer transfers acetyl
+      to CoA) and consistent with the EC 2.3.1.12 reaction.
+    supported_by:
+    - reference_id: PMID:20160912
+      supporting_text: E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: NAS
+  original_reference_id: PMID:24534072
+  qualifier: located_in
+  review:
+    summary: ComplexPortal NAS for mitochondrial localization. Correct but general
+      compartment.
+    action: KEEP_AS_NON_CORE
+    reason: Correct but general compartment; the mitochondrial matrix term is more
+      informative for the core function.
+    supported_by:
+    - reference_id: PMID:24534072
+      supporting_text: The mammalian pyruvate dehydrogenase complex (PDC) is a
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IDA
+  original_reference_id: PMID:24534072
+  qualifier: involved_in
+  review:
+    summary: IDA from reconstituted recombinant human PDC (all five components co-expressed
+      and lipoylated) demonstrating the functional pyruvate-to-acetyl-CoA reaction.
+      Core process.
+    action: ACCEPT
+    reason: Direct experimental support for DLAT participating in the core PDC reaction
+      via a functional reconstituted complex.
+    supported_by:
+    - reference_id: PMID:24534072
+      supporting_text: plays a key role in the conversion of pyruvate to
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IPI
+  original_reference_id: PMID:19240034
+  qualifier: part_of
+  review:
+    summary: IPI from in vitro reconstitution and stoichiometry study establishing
+      DLAT (E2p) as part of the 60-meric PDC core. Core complex membership.
+    action: ACCEPT
+    reason: Direct evidence that DLAT (E2p) is a subunit of the PDC core; this is
+      central to its function.
+    supported_by:
+    - reference_id: PMID:19240034
+      supporting_text: dihydrolipoyl transacetylase (E2p)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: HPA immunofluorescence IDA for mitochondrial localization. Correct but
+      general compartment.
+    action: KEEP_AS_NON_CORE
+    reason: Correct mitochondrial localization by immunofluorescence; general compartment,
+      with matrix being the more specific and informative term.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: &#39;GO:0005739; C:mitochondrion; IDA:HPA&#39;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: ISS transfer (from rat ortholog P08461) of mitochondrial matrix localization.
+      Correct specific compartment where DLAT acts.
+    action: ACCEPT
+    reason: Matrix is the correct, specific compartment for DLAT/PDC and is consistent
+      with the UniProt SUBCELLULAR LOCATION field.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: SUBCELLULAR LOCATION Mitochondrion matrix
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IDA
+  original_reference_id: PMID:20160912
+  qualifier: involved_in
+  review:
+    summary: IDA from reconstitution/kinetic study of the human PDC (E1, E2, E3 components)
+      supporting DLAT&#39;s role in the overall pyruvate-to-acetyl-CoA reaction. Core
+      process.
+    action: ACCEPT
+    reason: Direct experimental support for DLAT in the core PDC process via functional
+      reconstitution and activity assays.
+    supported_by:
+    - reference_id: PMID:20160912
+      supporting_text: E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.
+- term:
+    id: GO:0004742
+    label: dihydrolipoyllysine-residue acetyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:9242632
+  qualifier: enables
+  review:
+    summary: MGI-curated IDA for the E2 acetyltransferase activity, from a reconstitution
+      study of the human PDC (E3BP/E2). Core catalytic function. The paper title foregrounds
+      E3BP (protein X), but the full-text reconstitution work assays the E2 core;
+      defer to curator.
+    action: ACCEPT
+    reason: Direct experimental support for the defining E2 catalytic activity; consistent
+      with other IDA/IEA/EC annotations to the same term.
+    supported_by:
+    - reference_id: PMID:9242632
+      supporting_text: spontaneously reconstituted the pyruvate dehydrogenase complex
+        in the presence
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IC
+  original_reference_id: PMID:9242632
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: MGI-curated IC (from the GO:0004742 activity) that DLAT acts within the
+      overall pyruvate-to-acetyl-CoA process via functional PDC reconstitution. Core
+      process.
+    action: ACCEPT
+    reason: Reasonable inference from the E2 catalytic activity to participation in
+      the PDC process; consistent with the other process annotations.
+    supported_by:
+    - reference_id: PMID:9242632
+      supporting_text: spontaneously reconstituted the pyruvate dehydrogenase complex
+        in the presence
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: High-throughput mitochondrial proteome study assigning DLAT to the mitochondrion.
+      Correct but general compartment.
+    action: KEEP_AS_NON_CORE
+    reason: Correct mitochondrial localization from a high-confidence proteome; general
+      compartment, with matrix being the more specific term.
+    supported_by:
+    - reference_id: PMID:34800366
+      supporting_text: Quantitative high-confidence human mitochondrial proteome
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-203946
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing DLAT in the mitochondrial matrix (PDK phosphorylation
+      of the PDC subunit E1 reaction). Correct specific compartment.
+    action: ACCEPT
+    reason: Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: SUBCELLULAR LOCATION Mitochondrion matrix
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-204169
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing DLAT in the mitochondrial matrix (PDP dephosphorylation
+      reaction). Correct specific compartment.
+    action: ACCEPT
+    reason: Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: SUBCELLULAR LOCATION Mitochondrion matrix
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9858752
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing DLAT in the mitochondrial matrix (LIPT1 lipoyl transfer
+      to DLAT reaction). Correct specific compartment.
+    action: ACCEPT
+    reason: Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: SUBCELLULAR LOCATION Mitochondrion matrix
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861616
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing DLAT in the mitochondrial matrix (DLD dehydrogenation
+      of dihydrolipoyl reaction). Correct specific compartment.
+    action: ACCEPT
+    reason: Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: SUBCELLULAR LOCATION Mitochondrion matrix
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861626
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing DLAT in the mitochondrial matrix (SIRT4 delipoylation
+      of DLAT reaction). Correct specific compartment.
+    action: ACCEPT
+    reason: Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: SUBCELLULAR LOCATION Mitochondrion matrix
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861667
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing DLAT in the mitochondrial matrix (DLAT acetyl transfer
+      to CoA reaction). Correct specific compartment.
+    action: ACCEPT
+    reason: Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: SUBCELLULAR LOCATION Mitochondrion matrix
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861734
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing DLAT in the mitochondrial matrix (E1 decarboxylation
+      transferring acetyl to DLAT reaction). Correct specific compartment.
+    action: ACCEPT
+    reason: Matrix is the correct, specific compartment for DLAT/PDC; curated by Reactome.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: SUBCELLULAR LOCATION Mitochondrion matrix
+- term:
+    id: GO:0004742
+    label: dihydrolipoyllysine-residue acetyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:20160912
+  qualifier: enables
+  review:
+    summary: UniProt-curated IDA for the E2 acetyltransferase activity (catalytic
+      activity and interaction with PDHB reported). Core catalytic function.
+    action: ACCEPT
+    reason: Direct experimental support for the defining E2 catalytic activity; this
+      is the source of the EC 2.3.1.12 assignment in UniProt.
+    supported_by:
+    - reference_id: PMID:20160912
+      supporting_text: E1 carries out the decarboxylation of pyruvate and reductive
+        acetylation of the lipoyl moieties of E2
+- term:
+    id: GO:0006099
+    label: tricarboxylic acid cycle
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: ISS transfer of &#34;tricarboxylic acid cycle&#34; involvement. DLAT/PDC feeds
+      the TCA cycle by producing acetyl-CoA but the PDH reaction itself is not a step
+      of the TCA cycle; this conflates an upstream feeder role with the cycle proper.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: DLAT is not a TCA-cycle enzyme. The PDC produces acetyl-CoA that enters
+      the TCA cycle, but pyruvate decarboxylation to acetyl-CoA (GO:0006086) is a
+      distinct process. This ISS is an over-annotation (the correct process is annotated
+      separately). Not removed outright per policy; flagged.
+    supported_by:
+    - reference_id: PMID:24534072
+      supporting_text: acetyl-CoA connecting glycolysis to the citric acid cycle
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IDA
+  original_reference_id: PMID:9242632
+  qualifier: part_of
+  review:
+    summary: MGI-curated IDA that DLAT (E2) is part of the reconstituted PDC. Core
+      complex membership.
+    action: ACCEPT
+    reason: Direct experimental support for DLAT as the E2 core subunit of the PDC.
+    supported_by:
+    - reference_id: PMID:9242632
+      supporting_text: is required for anchoring dihydrolipoamide dehydrogenase (E3)
+        to the
+- term:
+    id: GO:0004742
+    label: dihydrolipoyllysine-residue acetyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:9045657
+  qualifier: enables
+  review:
+    summary: MGI-curated IDA for the E2 acetyltransferase activity from recombinant,
+      fully functional human E2 that assembled into the dodecahedral core and had
+      high acetyltransferase activity. Core catalytic function.
+    action: ACCEPT
+    reason: Direct experimental demonstration of DLAT&#39;s E2 acetyltransferase activity
+      using purified, assembled recombinant human protein.
+    supported_by:
+    - reference_id: PMID:9045657
+      supporting_text: Purified E2 had a high
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IDA
+  original_reference_id: PMID:25525879
+  qualifier: part_of
+  review:
+    summary: UniProt-curated IDA (from the SIRT4/PDH study) that DLAT is the E2 component
+      of the PDC. Core complex membership.
+    action: ACCEPT
+    reason: Direct experimental support for DLAT as the E2 subunit forming the PDC
+      catalytic core.
+    supported_by:
+    - reference_id: PMID:25525879
+      supporting_text: DLAT also has a structural role, constituting the PDH catalytic
+        core
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HDA
+  original_reference_id: PMID:20833797
+  qualifier: located_in
+  review:
+    summary: High-throughput phosphoproteome analysis of isolated mitochondria assigning
+      DLAT to the mitochondrion. Correct but general compartment.
+    action: KEEP_AS_NON_CORE
+    reason: Correct mitochondrial localization from a mitochondrial phosphoproteome;
+      general compartment, with matrix being the more specific term.
+    supported_by:
+    - reference_id: PMID:20833797
+      supporting_text: functional mitochondria isolated from resting
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:15861126
+  qualifier: enables
+  review:
+    summary: IPI capturing the DLAT lipoyl-domain-2/PDK3 interaction (crystal structure
+      of PDK3 bound to lipoyl domain 2). Real, structurally defined interaction, but
+      uninformative bare term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative. The lipoyl-domain-2/PDK3 interaction
+      is genuine and structurally characterized, but the term is marked over-annotated
+      per policy rather than removed.
+    supported_by:
+    - reference_id: file:human/DLAT/DLAT-uniprot.txt
+      supporting_text: Interacts with PDK2 and PDK3
+- term:
+    id: GO:0004742
+    label: dihydrolipoyllysine-residue acetyltransferase activity
+  evidence_type: NAS
+  original_reference_id: PMID:3191998
+  qualifier: enables
+  review:
+    summary: NAS from the original human DLAT cDNA sequencing paper, assigning the
+      dihydrolipoamide acetyltransferase (E2) identity/activity. Core function, historically
+      established.
+    action: ACCEPT
+    reason: The founding sequence report identifying DLAT as the E2 acetyltransferase
+      of the human PDC; consistent with all later experimental evidence.
+    supported_by:
+    - reference_id: PMID:3191998
+      supporting_text: the dihydrolipoamide acetyltransferase
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: NAS
+  original_reference_id: PMID:3191998
+  qualifier: part_of
+  review:
+    summary: NAS from the original DLAT cDNA paper, assigning DLAT as a component of
+      the human PDC. Core complex membership, historically established.
+    action: ACCEPT
+    reason: The founding report describing DLAT as the E2 component of the human PDC;
+      consistent with later experimental complex annotations.
+    supported_by:
+    - reference_id: PMID:3191998
+      supporting_text: human pyruvate dehydrogenase complex
+core_functions:
+- description: Dihydrolipoyllysine-residue acetyltransferase (E2) that transfers the
+    acetyl group from the acetyl-dihydrolipoyl-lysine intermediate to coenzyme A,
+    forming acetyl-CoA, as the second catalytic step of the pyruvate dehydrogenase
+    complex reaction, acting as the structural and catalytic core of the complex in
+    the mitochondrial matrix.
+  molecular_function:
+    id: GO:0004742
+    label: dihydrolipoyllysine-residue acetyltransferase activity
+  directly_involved_in:
+  - id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  in_complex:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  supported_by:
+  - reference_id: PMID:20160912
+    supporting_text: E2 then transfers the acetyl moiety to CoA forming acetyl-CoA.
+  - reference_id: PMID:19240034
+    supporting_text: The human PDC is organized around a 60-meric
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:15861126
+  title: Crystal structure of pyruvate dehydrogenase kinase 3 bound to lipoyl domain
+    2 of human pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Structurally characterizes the DLAT lipoyl-domain-2/PDK3 interaction;
+      supports the (uninformative) protein-binding IPI but not a core function.
+- id: PMID:17683942
+  title: Distinct structural mechanisms for inhibition of pyruvate dehydrogenase kinase
+    isoforms by AZD7545, dichloroacetate, and radicicol.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: PDK3-inhibitor structural study using DLAT lipoyl domain 2; source
+      of a bare protein-binding IPI, peripheral to DLAT&#39;s core function.
+- id: PMID:18184587
+  title: Extended polypeptide linkers establish the spatial architecture of a pyruvate
+    dehydrogenase multienzyme complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Establishes the E2 central core architecture and the shuttling role
+      of E2 lipoyl domains; supports the structural core function.
+- id: PMID:18184588
+  title: &#39;Structures of the human pyruvate dehydrogenase complex cores: a highly conserved
+    catalytic center with flexible N-terminal domains.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Cryo-EM of the human E2 core; identifies E2 as the central component
+      forming the PDC catalytic core.
+- id: PMID:18206651
+  title: Binding of pyruvate dehydrogenase to the core of the human pyruvate dehydrogenase
+    complex.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Maps the E1(beta)-E2 subunit-binding interaction; supports E1 assembly
+      onto the E2 core.
+- id: PMID:19240034
+  title: Subunit and catalytic component stoichiometries of an in vitro reconstituted
+    human pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Establishes DLAT (E2p) as part of the 60-meric dodecahedral PDC
+      core and its stoichiometry.
+- id: PMID:20160912
+  title: Interaction of E1 and E3 components with the core proteins of the human pyruvate
+    dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Source of the UniProt EC 2.3.1.12 catalytic-activity assignment;
+      describes E2 transferring the acetyl moiety to CoA to form acetyl-CoA.
+- id: PMID:20833797
+  title: Phosphoproteome analysis of functional mitochondria isolated from resting
+    human muscle reveals extensive phosphorylation of inner membrane protein complexes
+    and enzymes.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput mitochondrial phosphoproteome; supports mitochondrial
+      localization only.
+- id: PMID:24534072
+  title: Component co-expression and purification of recombinant human pyruvate dehydrogenase
+    complex from baculovirus infected SF9 cells.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Functional reconstitution of the recombinant human PDC; supports
+      DLAT&#39;s role in the pyruvate-to-acetyl-CoA reaction and complex membership.
+- id: PMID:25525879
+  title: Sirtuin 4 is a lipoamidase regulating pyruvate dehydrogenase complex activity.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Identifies DLAT K132/K259 lipoyl sites and the SIRT4 delipoylation
+      regulatory mechanism; explicitly states DLAT constitutes the PDH catalytic core.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Proteome-scale interactome (BioPlex); source of a bare protein-binding
+      IPI, not informative for core function.
+- id: PMID:3191998
+  title: Nucleotide sequence of a cDNA for the dihydrolipoamide acetyltransferase
+    component of human pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Founding cDNA report identifying DLAT as the E2 (dihydrolipoamide
+      acetyltransferase) component of the human PDC.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Proteome-scale interactome (BioPlex 3.0); source of bare protein-binding
+      IPIs, not informative for core function.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-confidence mitochondrial proteome; supports mitochondrial localization
+      only.
+- id: PMID:9045657
+  title: Assembly and full functionality of recombinantly expressed dihydrolipoyl
+    acetyltransferase component of the human pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Recombinant human E2 with high acetyltransferase activity assembling
+      into the pentagonal dodecahedron core; supports both catalytic and structural-core
+      functions.
+- id: PMID:9242632
+  title: Dihydrolipoamide dehydrogenase-binding protein of the human pyruvate dehydrogenase
+    complex. DNA-derived amino acid sequence, expression, and reconstitution of the
+    pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Title foregrounds E3BP (protein X), but the full-text reconstitution
+      assays the E2 core; the associated IDA/IC annotations to DLAT are curator-derived
+      from that work and are accepted.
+- id: Reactome:R-HSA-203946
+  title: PDK isozymes phosphorylate PDHC subunit E1
+  findings: []
+- id: Reactome:R-HSA-204169
+  title: PDP1,2 dephosphorylate p-lipo-PDH
+  findings: []
+- id: Reactome:R-HSA-9858752
+  title: LIPT1 transfers lipoyl group from lipoyl-GCSH to DLAT
+  findings: []
+- id: Reactome:R-HSA-9861559
+  title: PDH complex synthesizes acetyl-CoA from PYR
+  findings: []
+- id: Reactome:R-HSA-9861616
+  title: DLD dimer dehydrogenates dihydrolipoyl
+  findings: []
+- id: Reactome:R-HSA-9861626
+  title: SIRT4 cleaves lipoyl from DLAT
+  findings: []
+- id: Reactome:R-HSA-9861667
+  title: DLAT trimer transfers acetyl to CoA
+  findings: []
+- id: Reactome:R-HSA-9861734
+  title: PDH E1 decarboxylates PYR, transferring acetyl to DLAT
+  findings: []
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PC/PC-ai-review.html
+++ b/genes/human/PC/PC-ai-review.html
@@ -1,0 +1,5908 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PC - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PC</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P11498" target="_blank" class="term-link">
+                        P11498
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PC";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P11498" data-a="DESCRIPTION: Pyruvate carboxylase is the mitochondrial matrix, ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Pyruvate carboxylase is the mitochondrial matrix, biotin-dependent enzyme that catalyzes the ATP-dependent carboxylation of pyruvate to oxaloacetate (pyruvate + bicarbonate + ATP = oxaloacetate + ADP + phosphate + H+; EC 6.4.1.1). It is a homotetramer in which each subunit carries a biotin carboxylase (BC) domain, a carboxyltransferase (CT) domain and a biotinyl-carboxyl-carrier (BCCP) domain with biotin covalently attached to a C-terminal lysine (Lys-1144); catalysis proceeds in two steps, ATP-dependent carboxylation of the tethered biotin followed by transfer of the carboxyl group to pyruvate, and requires a Mn(2+) ion per subunit. The enzyme is allosterically activated by acetyl-CoA. Its product oxaloacetate is the central anaplerotic intermediate that replenishes the tricarboxylic acid cycle and the committed first substrate of gluconeogenesis from pyruvate/lactate; in a tissue-specific manner it also supplies carbon for lipogenesis, neurotransmitter synthesis and insulin secretion, with highest expression in liver and kidney. Loss of pyruvate carboxylase activity causes the autosomal recessive disorder pyruvate carboxylase deficiency, characterized by lactic acidosis, hypoglycemia and neurologic dysfunction.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004736" target="_blank" class="term-link">
+                                    GO:0004736
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0004736" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function. Phylogenetically inferred pyruvate carboxylase activity, fully concordant with the experimentally determined catalytic activity of the human enzyme (EC 6.4.1.1) and with the conserved biotin-dependent carboxylase family.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Represents the defining, experimentally validated catalytic function of the gene product and is supported by orthologs across the PANTHER family.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred mitochondrial localization, consistent with the experimentally established mitochondrial-matrix localization of human PC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct organelle. The more specific compartment (mitochondrial matrix) is captured by other annotations; this broader term is accurate and is retained.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0006094" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. Pyruvate carboxylase catalyzes the committed first step of gluconeogenesis from pyruvate/lactate, generating oxaloacetate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-established, phylogenetically conserved role; UniProt assigns the gluconeogenesis pathway on the basis of characterization of the human enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Children with inborn errors of PC metabolism have lactic acidosis, hypoglycemia, and mental retardation.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-70501
+
+                                </span>
+
+                                <div class="support-text">Activation of PC by acetyl-CoA produced from lipolysis and leading to excess gluconeogenesis is the central mechanism of metabolic syndrome and diabetes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003824" target="_blank" class="term-link">
+                                    GO:0003824
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0003824" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but uninformatively general parent term inferred from an InterPro domain mapping. The specific catalytic activity (pyruvate carboxylase activity, GO:0004736) is separately annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The essence (that PC is catalytic) is correct, but &#39;catalytic activity&#39; is a root-level MF term that adds no information beyond the specific enzyme activity already annotated. Replace with the specific term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004736" target="_blank" class="term-link">
+                                    pyruvate carboxylase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004736" target="_blank" class="term-link">
+                                    GO:0004736
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0004736" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of the specific catalytic activity via ARBA/InterPro/RHEA/EC mapping (EC 6.4.1.1, RHEA:20844). Concordant with experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The EC/RHEA mapping to pyruvate carboxylase activity is correct and matches the UniProt catalytic activity annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ATP binding by the biotin carboxylase (ATP-grasp) domain. PC uses ATP to carboxylate its tethered biotin in the first half-reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by domain architecture (ATP-grasp domain, ATP-binding residues at 152/236/271) and by the ATP-dependent catalytic activity of the enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8048912" target="_blank" class="term-link">
+                                        PMID:8048912
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The translated amino acid sequence of 1178 residues contained consensus sequences for the covalent attachment for biotin, the binding of ATP and the binding of the substrate, pyruvate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005759" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mitochondrial matrix localization, the canonical compartment for PC, assigned by ARBA/UniProt-SubCell mapping.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matches the experimentally determined subcellular location (mitochondrion matrix) in UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005829" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) cytosol assignment. PC is canonically a mitochondrial matrix enzyme; a cytosolic pool exists in specific contexts (the cytosolic hydride transfer complex in cancer/hypoxic cells) but this is not the primary localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The dominant, functionally relevant localization of human PC is the mitochondrial matrix. A minor context-specific cytosolic pool is documented (the cytosolic hydride transfer complex), so the cytosol term is retained as non-core rather than as a core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link">
+                                        PMID:34547241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This hydride transfer complex (HTC) is assembled by malate dehydrogenase 1, malic enzyme 1, and cytosolic pyruvate carboxylase.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0006094" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of the gluconeogenesis pathway via InterPro/UniPathway (UPA00138). Concordant with experimental and phylogenetic annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct pathway assignment; duplicates the well-supported IBA and TAS gluconeogenesis annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-70501
+
+                                </span>
+
+                                <div class="support-text">Activation of PC by acetyl-CoA produced from lipolysis and leading to excess gluconeogenesis is the central mechanism of metabolic syndrome and diabetes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009374" target="_blank" class="term-link">
+                                    GO:0009374
+                                </a>
+                            </span>
+                            <span class="term-label">biotin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0009374" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core cofactor function. PC covalently binds biotin at Lys-1144 in the biotinyl-carboxyl-carrier domain; the tethered biotin is the carboxyl carrier in catalysis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strongly supported by sequence (biotin attachment consensus), by covalent biotinylation at Lys-1144, and by structural data on biotin in the active site.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18297087" target="_blank" class="term-link">
+                                        PMID:18297087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A BCCP domain is located in the active site of the CT domain, providing the first molecular insights into how biotin participates in the carboxyltransfer reaction.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PC binds one Mn(2+) ion per subunit in the carboxyltransferase domain (coordinating residues 572/741-carbamate/771/773), required for catalysis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by crystallography showing Mn(2+) coordination in the active site; &#39;metal ion binding&#39; is a general but accurate term for the Mn(2+)/Mg(2+) requirement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18297087" target="_blank" class="term-link">
+                                        PMID:18297087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Crystal structures of human and Staphylococcus aureus pyruvate carboxylase and molecular insights into the carboxyltransfer reaction.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23861867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Nonstructural 5A protein of hepatitis C virus interacts with...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005515" data-r="PMID:23861867" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction with the hepatitis C virus NS5A protein (Q03463-PRO_0000278740). The bare &#39;protein binding&#39; term is uninformative about PC&#39;s molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The underlying host-pathogen interaction (NS5A binds the biotin carboxylase domain of PC) is real, but &#39;protein binding&#39; conveys no functional information per curation guidelines. Retained but flagged rather than removed (experimental IPI).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link">
+                                        PMID:23861867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">NS5A interacted with PC through the N-terminal region of NS5A and the biotin carboxylase domain of PC.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34547241
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A hydride transfer complex reprograms NAD metabolism and byp...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005515" data-r="PMID:34547241" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction with malic enzyme 1 (ME1, P48163), a partner in the cytosolic hydride transfer complex. The bare &#39;protein binding&#39; term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The interaction (PC as a component of the MDH1-ME1-PC hydride transfer complex) is genuine, but &#39;protein binding&#39; provides no functional specificity. Flagged as over-annotated rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link">
+                                        PMID:34547241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This hydride transfer complex (HTC) is assembled by malate dehydrogenase 1, malic enzyme 1, and cytosolic pyruvate carboxylase.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18297087" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18297087
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structures of human and Staphylococcus aureus pyruva...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0042802" data-r="PMID:18297087" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Self-association reflecting the functional homotetramer of pyruvate carboxylase, established by crystallography.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PC is an obligate homotetramer and self-interaction is a real, structurally characterized property. It supports the oligomeric organization needed for catalysis but is not itself the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18297087" target="_blank" class="term-link">
+                                        PMID:18297087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A conserved tetrameric association is observed for both enzymes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34547241
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A hydride transfer complex reprograms NAD metabolism and byp...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0042802" data-r="PMID:34547241" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Self-association (homotetramer) detected in the study of the cytosolic hydride transfer complex; consistent with the known homotetrameric assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicate evidence for the biologically real homo-oligomerization of PC. Retained as supporting the tetrameric quaternary structure, not the core MF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18297087" target="_blank" class="term-link">
+                                        PMID:18297087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A conserved tetrameric association is observed for both enzymes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70501
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0006094" data-r="Reactome:R-HSA-70501" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted role of PC in gluconeogenesis, based on the characterized enzymatic reaction (PC carboxylates pyruvate to oxaloacetate).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Authoritative pathway assertion consistent with the committed-step role of PC in gluconeogenesis; duplicates the IBA/IEA gluconeogenesis annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-70501
+
+                                </span>
+
+                                <div class="support-text">Activation of PC by acetyl-CoA produced from lipolysis and leading to excess gluconeogenesis is the central mechanism of metabolic syndrome and diabetes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004736" target="_blank" class="term-link">
+                                    GO:0004736
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12437512" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12437512
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression and characterization of a human pyruvate carboxyl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0004736" data-r="PMID:12437512" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental characterization of human PC enzyme activity via a retroviral expression system, including PC enzyme activity assays on wild-type and the Ala610Thr disease variant.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental measurement of pyruvate carboxylase activity for the human enzyme; core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12437512" target="_blank" class="term-link">
+                                        PMID:12437512
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We show, through immunoblot analysis, PC enzyme activity assays, reverse-transcription PCR and mitochondrial-import experiments, that this mutation is disease-causing</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34547241
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A hydride transfer complex reprograms NAD metabolism and byp...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005737" data-r="PMID:34547241" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal/IDA cytoplasmic localization associated with the cytosolic hydride transfer complex (HTC). PC is canonically mitochondrial matrix; a cytosolic pool participates in the HTC in cancer/hypoxic cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real but context-specific (a minor cytosolic pool assembled into the MDH1-ME1-PC complex). Not the primary localization or core function; retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link">
+                                        PMID:34547241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">HTC is found in phase-separated bodies in the cytosol of cancer or hypoxic cells and can be assembled in vitro with recombinant proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006739" target="_blank" class="term-link">
+                                    GO:0006739
+                                </a>
+                            </span>
+                            <span class="term-label">NADP+ metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34547241
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A hydride transfer complex reprograms NAD metabolism and byp...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0006739" data-r="PMID:34547241" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PC contributes to NADP+/NAD metabolism as a member of the cytosolic hydride transfer complex, which transfers reducing equivalents from NADH to NADP+.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A genuine, experimentally supported role, but it is an emergent, context-specific function of the MDH1-ME1-PC complex in cancer/hypoxic cells rather than the core anaplerotic/gluconeogenic function of PC.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link">
+                                        PMID:34547241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We report a multi-enzymatic complex that reprograms NAD metabolism by transferring reducing equivalents from NADH to NADP+.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019674" target="_blank" class="term-link">
+                                    GO:0019674
+                                </a>
+                            </span>
+                            <span class="term-label">NAD+ metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34547241
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A hydride transfer complex reprograms NAD metabolism and byp...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0019674" data-r="PMID:34547241" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PC as part of the hydride transfer complex participates in NAD metabolism (consuming NADH as reducing-equivalent donor).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same rationale as the NADP+ annotation; real but emergent and context-specific to the cytosolic HTC, not PC&#39;s core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link">
+                                        PMID:34547241
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We report a multi-enzymatic complex that reprograms NAD metabolism by transferring reducing equivalents from NADH to NADP+.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Immunofluorescence-based (HPA) mitochondrial localization, consistent with the canonical mitochondrial-matrix localization of PC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct organelle localization corroborated by orthogonal evidence (UniProt subcellular location, MGI IDA, mitochondrial proteomics).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9585002
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular characterization of pyruvate carboxylase deficienc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005759" data-r="PMID:9585002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally determined mitochondrial-matrix localization; this is the canonical compartment where PC is active.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental subcellular-location evidence for the specific compartment (matrix); core localization for the enzyme&#39;s function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005739" data-r="PMID:34800366" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteomics places PC in the mitochondrion, consistent with the canonical localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborating high-confidence mitochondrial-proteome evidence for the established mitochondrial localization of PC.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004736" target="_blank" class="term-link">
+                                    GO:0004736
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9585002
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular characterization of pyruvate carboxylase deficienc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0004736" data-r="PMID:9585002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pyruvate carboxylase activity inferred from the functional consequences of PC-deficiency mutations (patients with low PC activity, 2-25% of control), confirming the enzyme&#39;s activity in the human gene product.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Loss-of-function mutations that reduce PC activity directly link the gene to pyruvate carboxylase activity; core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the probands were found to have low PC activity (range, 2-25% of control) in blood lymphocytes and skin fibroblasts</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23861867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Nonstructural 5A protein of hepatitis C virus interacts with...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005737" data-r="PMID:23861867" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AgBase/IDA cytoplasmic localization from the HCV NS5A interaction study, which also documents mitochondrial colocalization of PC and NS5A. PC is canonically mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A cytoplasmic signal is reported, but the study emphasizes mitochondrial colocalization; cytoplasmic localization is not the primary compartment or a core function. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link">
+                                        PMID:23861867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we verified that both PC and NS5A were colocalized in the mitochondria as determined by immunofluorescence assay</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010629" target="_blank" class="term-link">
+                                    GO:0010629
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of gene expression</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23861867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Nonstructural 5A protein of hepatitis C virus interacts with...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0010629" data-r="PMID:23861867" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This annotation derives from a host-pathogen study in which HCV NS5A downregulates the PC promoter. Here PC is the target of downregulation, not the effector; the process does not describe an intrinsic molecular function of PC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The experimental finding is that NS5A (and NS4B) down-regulate PC transcription; PC itself is not shown to negatively regulate gene expression. Attributing negative regulation of gene expression to PC as an actor is an over-annotation (PC is the regulated gene, not the regulator).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link">
+                                        PMID:23861867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We also showed that the transcriptional activity of PC was downregulated in cells expressing NS5A, in HCV replicon cells, and in HCV infected cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019074" target="_blank" class="term-link">
+                                    GO:0019074
+                                </a>
+                            </span>
+                            <span class="term-label">viral RNA genome packaging</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23861867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Nonstructural 5A protein of hepatitis C virus interacts with...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0019074" data-r="PMID:23861867" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Derived from the observation that silencing PC reduces production of infectious HCV particles in infected cells. This reflects an indirect metabolic dependency of the virus on host PC, not a direct role of PC in packaging the viral genome.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The study shows PC is a host metabolic enzyme whose basal activity the virus depends on (silencing reduces infectious-particle production), but there is no evidence PC directly participates in packaging of the viral RNA genome. This is an over-interpretation of a metabolic-dependency phenotype.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link">
+                                        PMID:23861867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">silencing of PC reduced infectious particle production in HCV infected cells. This may explain that basal level of PC is also required for HCV propagation.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019076" target="_blank" class="term-link">
+                                    GO:0019076
+                                </a>
+                            </span>
+                            <span class="term-label">viral release from host cell</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23861867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Nonstructural 5A protein of hepatitis C virus interacts with...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0019076" data-r="PMID:23861867" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Also derived from the PC-silencing/reduced-infectious-particle phenotype. This is an indirect host metabolic contribution to the HCV life cycle rather than a direct role of PC in viral release.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The phenotype (reduced infectious-particle production on PC silencing) is a metabolic dependency of the virus on host lipogenesis/anaplerosis, not evidence that PC mediates viral egress. Over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link">
+                                        PMID:23861867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">silencing of PC reduced infectious particle production in HCV infected cells. This may explain that basal level of PC is also required for HCV propagation.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044794" target="_blank" class="term-link">
+                                    GO:0044794
+                                </a>
+                            </span>
+                            <span class="term-label">host-mediated activation of viral process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23861867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Nonstructural 5A protein of hepatitis C virus interacts with...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0044794" data-r="PMID:23861867" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Captures the general finding that host PC activity supports HCV propagation. This is a systemic host-pathogen metabolic effect, not a specific molecular function of PC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PC is a housekeeping metabolic enzyme co-opted by HCV; the paper frames PC as a host factor whose basal level is required for propagation. Annotating PC with a viral-process term over-states the specificity and directness of PC&#39;s involvement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link">
+                                        PMID:23861867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This may explain that basal level of PC is also required for HCV propagation.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-2993802
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005829" data-r="Reactome:R-HSA-2993802" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted cytosolic localization referring to the biotinylation of apo-PC by holocarboxylase synthetase (HLCS) prior to mitochondrial import; the mature enzyme functions in the matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects a transient, maturation-stage cytosolic state (biotinylation before matrix translocation) documented by Reactome, not the enzyme&#39;s functional compartment. Retained as non-core rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-3323111
+
+                                </span>
+
+                                <div class="support-text">Once biotinylated, three halocarboxylases (hCBXs) are localised to the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3323111
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005829" data-r="Reactome:R-HSA-3323111" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome cytosolic assignment for the pre-import step in which biotinylated carboxylases translocate to the mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same maturation-pathway rationale; cytosolic localization is a transient pre-import state, not the functional compartment. Non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-3323111
+
+                                </span>
+
+                                <div class="support-text">Cytosolic carboxylases translocate to mitochondrial matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9035988
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005829" data-r="Reactome:R-HSA-9035988" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome cytosolic assignment for the defective-HLCS reaction (failure to biotinylate PC:Mn2+), again referring to the pre-import cytosolic state.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transient maturation-stage cytosolic localization, consistent with the other Reactome cytosol assertions; not the functional compartment. Non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-3323111
+
+                                </span>
+
+                                <div class="support-text">Once biotinylated, three halocarboxylases (hCBXs) are localised to the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3065959
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005759" data-r="Reactome:R-HSA-3065959" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted mitochondrial-matrix localization (degradation of mitochondrial holocarboxylases). Consistent with the canonical matrix localization of PC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct functional compartment for PC, corroborated by experimental and electronic mitochondrial-matrix annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-3323111
+
+                                </span>
+
+                                <div class="support-text">Once biotinylated, three halocarboxylases (hCBXs) are localised to the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3323111
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005759" data-r="Reactome:R-HSA-3323111" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted mitochondrial-matrix localization following translocation of biotinylated PC; the functional compartment of the enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matches the canonical, experimentally established mitochondrial-matrix localization of PC.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-3323111
+
+                                </span>
+
+                                <div class="support-text">Once biotinylated, three halocarboxylases (hCBXs) are localised to the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70501
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005759" data-r="Reactome:R-HSA-70501" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome localizes the PC-catalyzed carboxylation of pyruvate to oxaloacetate to the mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The functional compartment where PC catalysis occurs; concordant with all other matrix annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-70501
+
+                                </span>
+
+                                <div class="support-text">Mitochondrial pyruvate carboxylase (PC) catalyzes the irreversible reaction of pyruvate (PYR), bicarbonate (HCO3-), and ATP to form oxaloacetate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16729965" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16729965
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel localization of OCTN1, an organic cation/carnitine tra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005739" data-r="PMID:16729965" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI/IDA mitochondrial localization. The cited paper is primarily about the OCTN1 carnitine transporter but is used by MGI to support PC&#39;s mitochondrial localization; the assignment is consistent with the canonical localization of PC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mitochondrial localization of PC is overwhelmingly supported by multiple independent lines of evidence; this IDA is consistent with that. Deferring to the curator on the specific supporting data (abstract-only cache).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006107" target="_blank" class="term-link">
+                                    GO:0006107
+                                </a>
+                            </span>
+                            <span class="term-label">oxaloacetate metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0006107" data-r="GO_REF:0000033" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation capturing PC&#39;s core anaplerotic role - the production of oxaloacetate, the central TCA-cycle intermediate, from pyruvate. GOA currently records gluconeogenesis but not the more general/direct oxaloacetate-production process that PC carries out.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PC&#39;s immediate biological product is oxaloacetate, and its principal physiological role beyond gluconeogenesis is anaplerotic replenishment of TCA cycle oxaloacetate. The oxaloacetate metabolic process term directly reflects the enzyme&#39;s committed reaction and is not otherwise represented in GOA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-70501
+
+                                </span>
+
+                                <div class="support-text">Mitochondrial pyruvate carboxylase (PC) catalyzes the irreversible reaction of pyruvate (PYR), bicarbonate (HCO3-), and ATP to form oxaloacetate</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                        PMID:9585002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004736" target="_blank" class="term-link">
+                                    GO:0004736
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate carboxylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7918683" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7918683
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Primary amino acid sequence and structure of human pyruvate ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0004736" data-r="PMID:7918683" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable statement of pyruvate carboxylase activity from the primary characterization of the human PC cDNA and sequence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Authoritative early characterization identifying the enzyme and its activity; supports the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7918683" target="_blank" class="term-link">
+                                        PMID:7918683
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a nuclear-encoded mitochondrial enzyme, catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8048912" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8048912
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    cDNA cloning of human kidney pyruvate carboxylase.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0005524" data-r="PMID:8048912" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable statement of ATP binding based on identification of the ATP-binding consensus in the human PC sequence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the ATP-grasp domain architecture and the ATP-dependent catalytic mechanism; supports the ATP-binding cofactor function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8048912" target="_blank" class="term-link">
+                                        PMID:8048912
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The translated amino acid sequence of 1178 residues contained consensus sequences for the covalent attachment for biotin, the binding of ATP and the binding of the substrate, pyruvate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009374" target="_blank" class="term-link">
+                                    GO:0009374
+                                </a>
+                            </span>
+                            <span class="term-label">biotin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8048912" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8048912
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    cDNA cloning of human kidney pyruvate carboxylase.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11498" data-a="GO:0009374" data-r="PMID:8048912" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable statement of biotin binding based on identification of the biotin covalent-attachment consensus in the human PC sequence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with covalent biotinylation at Lys-1144 and the enzyme&#39;s biotin-dependent mechanism; core cofactor function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8048912" target="_blank" class="term-link">
+                                        PMID:8048912
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The translated amino acid sequence of 1178 residues contained consensus sequences for the covalent attachment for biotin, the binding of ATP and the binding of the substrate, pyruvate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Biotin- and ATP-dependent carboxylation of pyruvate to oxaloacetate in the mitochondrial matrix, using covalently bound biotin as the carboxyl carrier and requiring a Mn(2+) ion; the committed step of gluconeogenesis from pyruvate/lactate.</h3>
+                <span class="vote-buttons" data-g="P11498" data-a="FUNCTION: Biotin- and ATP-dependent carboxylation of pyruvat..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004736" target="_blank" class="term-link">
+                            pyruvate carboxylase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                gluconeogenesis
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                                PMID:9585002
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme that catalyzes the conversion of pyruvate to oxaloacetate.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            Reactome:R-HSA-70501
+
+                        </span>
+
+                        <div class="finding-text">Mitochondrial pyruvate carboxylase (PC) catalyzes the irreversible reaction of pyruvate (PYR), bicarbonate (HCO3-), and ATP to form oxaloacetate</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Anaplerotic production of oxaloacetate, the central TCA-cycle intermediate, from pyruvate; a carboxylation reaction that is allosterically activated by acetyl-CoA.</h3>
+                <span class="vote-buttons" data-g="P11498" data-a="FUNCTION: Anaplerotic production of oxaloacetate, the centra..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004736" target="_blank" class="term-link">
+                            pyruvate carboxylase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006107" target="_blank" class="term-link">
+                                oxaloacetate metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            Reactome:R-HSA-70501
+
+                        </span>
+
+                        <div class="finding-text">Mitochondrial pyruvate carboxylase (PC) catalyzes the irreversible reaction of pyruvate (PYR), bicarbonate (HCO3-), and ATP to form oxaloacetate</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cofactor binding required for catalysis - covalent biotin (at Lys-1144 in the biotinyl-carboxyl-carrier domain) as the mobile carboxyl carrier and ATP (via the ATP-grasp domain) used to carboxylate the tethered biotin.</h3>
+                <span class="vote-buttons" data-g="P11498" data-a="FUNCTION: Cofactor binding required for catalysis - covalent..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009374" target="_blank" class="term-link">
+                            biotin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18297087" target="_blank" class="term-link">
+                                PMID:18297087
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">A BCCP domain is located in the active site of the CT domain, providing the first molecular insights into how biotin participates in the carboxyltransfer reaction.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8048912" target="_blank" class="term-link">
+                                PMID:8048912
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The translated amino acid sequence of 1178 residues contained consensus sequences for the covalent attachment for biotin, the binding of ATP and the binding of the substrate, pyruvate.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12437512" target="_blank" class="term-link">
+                            PMID:12437512
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Expression and characterization of a human pyruvate carboxylase variant by retroviral gene transfer.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16729965" target="_blank" class="term-link">
+                            PMID:16729965
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Novel localization of OCTN1, an organic cation/carnitine transporter, to mammalian mitochondria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18297087" target="_blank" class="term-link">
+                            PMID:18297087
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Crystal structures of human and Staphylococcus aureus pyruvate carboxylase and molecular insights into the carboxyltransfer reaction.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23861867" target="_blank" class="term-link">
+                            PMID:23861867
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Nonstructural 5A protein of hepatitis C virus interacts with pyruvate carboxylase and modulates viral propagation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34547241" target="_blank" class="term-link">
+                            PMID:34547241
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A hydride transfer complex reprograms NAD metabolism and bypasses senescence.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7918683" target="_blank" class="term-link">
+                            PMID:7918683
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Primary amino acid sequence and structure of human pyruvate carboxylase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8048912" target="_blank" class="term-link">
+                            PMID:8048912
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">cDNA cloning of human kidney pyruvate carboxylase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9585002" target="_blank" class="term-link">
+                            PMID:9585002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular characterization of pyruvate carboxylase deficiency in two consanguineous families.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-2993802
+
+                    </span>
+                </div>
+
+                <div class="reference-title">HLCS biotinylates PC:Mn2+</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3065959
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An unknown protease degrades hCBXs</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3323111
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cytosolic carboxylases translocate to mitochondrial matrix</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70501
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PC carboxylates PYR to OA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9035988
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective HLCS does not biotinylate PC:Mn2+</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Beyond the reported cytosolic hydride transfer complex, what fraction of cellular PC is cytosolic under normal physiology, and is there a functionally significant extra-mitochondrial pyruvate carboxylase pool?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P11498" data-a="Q: Beyond the reported cytosolic hydride transfer com..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does acetyl-CoA allosteric activation of human PC differ quantitatively across the gluconeogenic (liver/kidney) versus lipogenic (adipose/brain) tissue contexts?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P11498" data-a="Q: Does acetyl-CoA allosteric activation of human PC ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Kinetic characterization (kcat/Km, acetyl-CoA activation constant) of recombinant wild-type versus disease-variant human PC to quantify how deficiency mutations impair anaplerosis versus gluconeogenesis.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P11498" data-a="EXPERIMENT: Kinetic characterization (kcat/Km, acetyl-CoA acti..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compartment-resolved metabolic flux analysis (e.g. 13C tracing) in liver-derived cells to distinguish PC&#39;s anaplerotic (TCA/oxaloacetate) from gluconeogenic flux contributions.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P11498" data-a="EXPERIMENT: Compartment-resolved metabolic flux analysis (e.g...." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PC-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P11498" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pc-pyruvate-carboxylase-mitochondrial-review-notes">PC (Pyruvate carboxylase, mitochondrial) — review notes</h1>
+<p>UniProt: P11498 (PYC_HUMAN); HGNC:8636; EC 6.4.1.1; 1178 aa precursor, mitochondrial transit peptide 1-20.</p>
+<h2 id="core-biology-verified">Core biology (verified)</h2>
+<ul>
+<li>Biotin-dependent, ATP-dependent carboxylation of pyruvate to oxaloacetate:<br />
+  hydrogencarbonate + pyruvate + ATP = oxaloacetate + ADP + phosphate + H+ (RHEA:20844).<br />
+  [file:UniProt CATALYTIC ACTIVITY; ECO:0000269|PubMed:9585002]</li>
+<li>Two-step mechanism: ATP-dependent carboxylation of covalently attached biotin (biotin<br />
+  carboxylase / BC domain), then carboxyl transfer to pyruvate (carboxyltransferase / CT<br />
+  domain). Biotin covalently attached at Lys-1144 (BCCP / biotinyl-binding domain).<br />
+  [file:UniProt FUNCTION; PMID:18297087]</li>
+<li>Homotetramer; F1077 required for tetramerization/activity (F1077A/E = inactive dimer).<br />
+  Mn(2+) cofactor (1 per subunit); biotin cofactor. <a href="https://pubmed.ncbi.nlm.nih.gov/18297087">PMID:18297087</a></li>
+<li>Allosterically activated by acetyl-CoA; inhibited by 2-oxoglutarate/L-malate/L-glutamate.<br />
+  [reactome:R-HSA-70501]</li>
+<li>Anaplerotic: replenishes TCA-cycle oxaloacetate; committed first step of gluconeogenesis<br />
+  from pyruvate/lactate (liver, kidney). Also feeds lipogenesis (adipose, liver, brain),<br />
+  neurotransmitter synthesis, insulin secretion. [file:UniProt FUNCTION; PMID:18297087;<br />
+  reactome:R-HSA-3323111]</li>
+<li>Subcellular location: mitochondrial matrix. [file:UniProt SUBCELLULAR LOCATION; PMID:9585002]</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>Pyruvate carboxylase deficiency (MIM:266150; MONDO:0009949), autosomal recessive:<br />
+  lactic acidosis, hypoglycemia, neurologic dysfunction/intellectual disability, death.<br />
+  Types A (infantile), B (severe neonatal), C (benign). [file:UniProt DISEASE;<br />
+  ~/repos/dismech/kb/disorders/Pyruvate_Carboxylase_Deficiency_Disease.yaml]</li>
+</ul>
+<h2 id="annotation-assessment-highlights">Annotation assessment highlights</h2>
+<ul>
+<li>Catalytic + gluconeogenesis + mito matrix + biotin/ATP/metal binding are all strongly<br />
+  supported (EXP/IMP/IBA/TAS + UniProt + structure). Core.</li>
+<li>CYTOSOL / CYTOPLASM annotations: PC is canonically mitochondrial matrix. A cytosolic<br />
+  pool participates in the cytosolic "hydride transfer complex" (HTC: MDH1 + ME1 +<br />
+  cytosolic PC) that shuttles reducing equivalents NADH-&gt;NADP+ in cancer/hypoxic cells<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/34547241">PMID:34547241</a>. Cytosol/cytoplasm annotations kept as non-core (context-specific,<br />
+  minor pool) rather than removed.</li>
+<li>NAD+/NADP+ metabolic process (IDA, ComplexPortal, PMID:34547241): via the cytosolic HTC.<br />
+  Real but non-core / context-specific (cancer, senescence bypass).</li>
+<li>Viral process IMPs (viral RNA genome packaging GO:0019074, viral release GO:0019076,<br />
+  host-mediated activation of viral process GO:0044794, negative regulation of gene<br />
+  expression GO:0010629; all IMP, PMID:23861867): PC is a host metabolic enzyme that HCV<br />
+  NS5A binds (via PC biotin carboxylase domain) and whose promoter NS5A downregulates;<br />
+  silencing PC reduces infectious particle production. These are indirect<br />
+  metabolic-dependency / host-pathogen effects, not core PC molecular functions -&gt;<br />
+  MARK_AS_OVER_ANNOTATED. Note GO:0010629 is actually NS5A downregulating PC's own<br />
+  promoter (PC is the target, not the actor) — over-annotation.</li>
+<li>protein binding (GO:0005515) IPIs: uninformative; MARK_AS_OVER_ANNOTATED per policy<br />
+  (do not REMOVE). identical protein binding (GO:0042802) reflects the homotetramer —<br />
+  genuine, keep as non-core supporting detail.</li>
+<li>IEA catalytic activity (GO:0003824) is a correct but over-general parent of the specific<br />
+  pyruvate carboxylase activity -&gt; MODIFY to GO:0004736.</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<ul>
+<li><code>just deep-research-falcon human PC</code> failed: scripts/deep_research_wrapper.py uses<br />
+  PEP 604 <code>dict | None</code> type syntax incompatible with the interpreter (TypeError at import).<br />
+  No PC-deep-research-falcon.md produced. Grounded review in UniProt, GOA, cached<br />
+  publications, disorders KB, and cached Reactome entries instead.<br />
+</content></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P11498
+gene_symbol: PC
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: Pyruvate carboxylase is the mitochondrial matrix, biotin-dependent enzyme
+  that catalyzes the ATP-dependent carboxylation of pyruvate to oxaloacetate (pyruvate
+  + bicarbonate + ATP = oxaloacetate + ADP + phosphate + H+; EC 6.4.1.1). It is a
+  homotetramer in which each subunit carries a biotin carboxylase (BC) domain, a
+  carboxyltransferase (CT) domain and a biotinyl-carboxyl-carrier (BCCP) domain with
+  biotin covalently attached to a C-terminal lysine (Lys-1144); catalysis proceeds
+  in two steps, ATP-dependent carboxylation of the tethered biotin followed by transfer
+  of the carboxyl group to pyruvate, and requires a Mn(2+) ion per subunit. The
+  enzyme is allosterically activated by acetyl-CoA. Its product oxaloacetate is the
+  central anaplerotic intermediate that replenishes the tricarboxylic acid cycle and
+  the committed first substrate of gluconeogenesis from pyruvate/lactate; in a
+  tissue-specific manner it also supplies carbon for lipogenesis, neurotransmitter
+  synthesis and insulin secretion, with highest expression in liver and kidney. Loss
+  of pyruvate carboxylase activity causes the autosomal recessive disorder pyruvate
+  carboxylase deficiency, characterized by lactic acidosis, hypoglycemia and
+  neurologic dysfunction.
+alternative_products:
+- name: &#39;1&#39;
+  id: P11498-1
+- name: &#39;2&#39;
+  id: P11498-2
+  sequence_note: VSP_056358, VSP_056359
+existing_annotations:
+- term:
+    id: GO:0004736
+    label: pyruvate carboxylase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Core molecular function. Phylogenetically inferred pyruvate carboxylase
+      activity, fully concordant with the experimentally determined catalytic activity
+      of the human enzyme (EC 6.4.1.1) and with the conserved biotin-dependent
+      carboxylase family.
+    action: ACCEPT
+    reason: Represents the defining, experimentally validated catalytic function of
+      the gene product and is supported by orthologs across the PANTHER family.
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+        that catalyzes the conversion of pyruvate to oxaloacetate.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetically inferred mitochondrial localization, consistent with
+      the experimentally established mitochondrial-matrix localization of human PC.
+    action: ACCEPT
+    reason: Correct organelle. The more specific compartment (mitochondrial matrix)
+      is captured by other annotations; this broader term is accurate and is retained.
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+        that catalyzes the conversion of pyruvate to oxaloacetate.
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Core biological process. Pyruvate carboxylase catalyzes the committed
+      first step of gluconeogenesis from pyruvate/lactate, generating oxaloacetate.
+    action: ACCEPT
+    reason: Well-established, phylogenetically conserved role; UniProt assigns the
+      gluconeogenesis pathway on the basis of characterization of the human enzyme.
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: Children with inborn errors of PC metabolism have lactic acidosis,
+        hypoglycemia, and mental retardation.
+    - reference_id: Reactome:R-HSA-70501
+      supporting_text: Activation of PC by acetyl-CoA produced from lipolysis and leading
+        to excess gluconeogenesis is the central mechanism of metabolic syndrome and
+        diabetes
+- term:
+    id: GO:0003824
+    label: catalytic activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: Correct but uninformatively general parent term inferred from an InterPro
+      domain mapping. The specific catalytic activity (pyruvate carboxylase activity,
+      GO:0004736) is separately annotated.
+    action: MODIFY
+    reason: The essence (that PC is catalytic) is correct, but &#39;catalytic activity&#39;
+      is a root-level MF term that adds no information beyond the specific enzyme
+      activity already annotated. Replace with the specific term.
+    proposed_replacement_terms:
+    - id: GO:0004736
+      label: pyruvate carboxylase activity
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+        that catalyzes the conversion of pyruvate to oxaloacetate.
+- term:
+    id: GO:0004736
+    label: pyruvate carboxylase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic assignment of the specific catalytic activity via ARBA/InterPro/RHEA/EC
+      mapping (EC 6.4.1.1, RHEA:20844). Concordant with experimental data.
+    action: ACCEPT
+    reason: The EC/RHEA mapping to pyruvate carboxylase activity is correct and matches
+      the UniProt catalytic activity annotation.
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+        that catalyzes the conversion of pyruvate to oxaloacetate.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: ATP binding by the biotin carboxylase (ATP-grasp) domain. PC uses ATP
+      to carboxylate its tethered biotin in the first half-reaction.
+    action: ACCEPT
+    reason: Supported by domain architecture (ATP-grasp domain, ATP-binding residues
+      at 152/236/271) and by the ATP-dependent catalytic activity of the enzyme.
+    supported_by:
+    - reference_id: PMID:8048912
+      supporting_text: The translated amino acid sequence of 1178 residues contained
+        consensus sequences for the covalent attachment for biotin, the binding of ATP
+        and the binding of the substrate, pyruvate.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Mitochondrial matrix localization, the canonical compartment for PC,
+      assigned by ARBA/UniProt-SubCell mapping.
+    action: ACCEPT
+    reason: Matches the experimentally determined subcellular location (mitochondrion
+      matrix) in UniProt.
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+        that catalyzes the conversion of pyruvate to oxaloacetate.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: Electronic (ARBA) cytosol assignment. PC is canonically a mitochondrial
+      matrix enzyme; a cytosolic pool exists in specific contexts (the cytosolic
+      hydride transfer complex in cancer/hypoxic cells) but this is not the primary
+      localization.
+    action: KEEP_AS_NON_CORE
+    reason: The dominant, functionally relevant localization of human PC is the
+      mitochondrial matrix. A minor context-specific cytosolic pool is documented
+      (the cytosolic hydride transfer complex), so the cytosol term is retained as
+      non-core rather than as a core localization.
+    supported_by:
+    - reference_id: PMID:34547241
+      supporting_text: This hydride transfer complex (HTC) is assembled by malate
+        dehydrogenase 1, malic enzyme 1, and cytosolic pyruvate carboxylase.
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic assignment of the gluconeogenesis pathway via InterPro/UniPathway
+      (UPA00138). Concordant with experimental and phylogenetic annotations.
+    action: ACCEPT
+    reason: Correct pathway assignment; duplicates the well-supported IBA and TAS
+      gluconeogenesis annotations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-70501
+      supporting_text: Activation of PC by acetyl-CoA produced from lipolysis and leading
+        to excess gluconeogenesis is the central mechanism of metabolic syndrome and
+        diabetes
+- term:
+    id: GO:0009374
+    label: biotin binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: Core cofactor function. PC covalently binds biotin at Lys-1144 in the
+      biotinyl-carboxyl-carrier domain; the tethered biotin is the carboxyl carrier
+      in catalysis.
+    action: ACCEPT
+    reason: Strongly supported by sequence (biotin attachment consensus), by covalent
+      biotinylation at Lys-1144, and by structural data on biotin in the active site.
+    supported_by:
+    - reference_id: PMID:18297087
+      supporting_text: A BCCP domain is located in the active site of the CT domain,
+        providing the first molecular insights into how biotin participates in the
+        carboxyltransfer reaction.
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: PC binds one Mn(2+) ion per subunit in the carboxyltransferase domain
+      (coordinating residues 572/741-carbamate/771/773), required for catalysis.
+    action: ACCEPT
+    reason: Supported by crystallography showing Mn(2+) coordination in the active
+      site; &#39;metal ion binding&#39; is a general but accurate term for the Mn(2+)/Mg(2+)
+      requirement.
+    supported_by:
+    - reference_id: PMID:18297087
+      supporting_text: Crystal structures of human and Staphylococcus aureus pyruvate
+        carboxylase and molecular insights into the carboxyltransfer reaction.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23861867
+  qualifier: enables
+  review:
+    summary: IntAct-curated interaction with the hepatitis C virus NS5A protein
+      (Q03463-PRO_0000278740). The bare &#39;protein binding&#39; term is uninformative
+      about PC&#39;s molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The underlying host-pathogen interaction (NS5A binds the biotin carboxylase
+      domain of PC) is real, but &#39;protein binding&#39; conveys no functional information
+      per curation guidelines. Retained but flagged rather than removed (experimental
+      IPI).
+    supported_by:
+    - reference_id: PMID:23861867
+      supporting_text: NS5A interacted with PC through the N-terminal region of NS5A
+        and the biotin carboxylase domain of PC.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34547241
+  qualifier: enables
+  review:
+    summary: IntAct-curated interaction with malic enzyme 1 (ME1, P48163), a partner
+      in the cytosolic hydride transfer complex. The bare &#39;protein binding&#39; term is
+      uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction (PC as a component of the MDH1-ME1-PC hydride transfer
+      complex) is genuine, but &#39;protein binding&#39; provides no functional specificity.
+      Flagged as over-annotated rather than removed.
+    supported_by:
+    - reference_id: PMID:34547241
+      supporting_text: This hydride transfer complex (HTC) is assembled by malate
+        dehydrogenase 1, malic enzyme 1, and cytosolic pyruvate carboxylase.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18297087
+  qualifier: enables
+  review:
+    summary: Self-association reflecting the functional homotetramer of pyruvate
+      carboxylase, established by crystallography.
+    action: KEEP_AS_NON_CORE
+    reason: PC is an obligate homotetramer and self-interaction is a real, structurally
+      characterized property. It supports the oligomeric organization needed for
+      catalysis but is not itself the core molecular function.
+    supported_by:
+    - reference_id: PMID:18297087
+      supporting_text: A conserved tetrameric association is observed for both enzymes
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34547241
+  qualifier: enables
+  review:
+    summary: Self-association (homotetramer) detected in the study of the cytosolic
+      hydride transfer complex; consistent with the known homotetrameric assembly.
+    action: KEEP_AS_NON_CORE
+    reason: Duplicate evidence for the biologically real homo-oligomerization of PC.
+      Retained as supporting the tetrameric quaternary structure, not the core MF.
+    supported_by:
+    - reference_id: PMID:18297087
+      supporting_text: A conserved tetrameric association is observed for both enzymes
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70501
+  qualifier: involved_in
+  review:
+    summary: Reactome-asserted role of PC in gluconeogenesis, based on the
+      characterized enzymatic reaction (PC carboxylates pyruvate to oxaloacetate).
+    action: ACCEPT
+    reason: Authoritative pathway assertion consistent with the committed-step role
+      of PC in gluconeogenesis; duplicates the IBA/IEA gluconeogenesis annotations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-70501
+      supporting_text: Activation of PC by acetyl-CoA produced from lipolysis and leading
+        to excess gluconeogenesis is the central mechanism of metabolic syndrome and
+        diabetes
+- term:
+    id: GO:0004736
+    label: pyruvate carboxylase activity
+  evidence_type: EXP
+  original_reference_id: PMID:12437512
+  qualifier: enables
+  review:
+    summary: Experimental characterization of human PC enzyme activity via a
+      retroviral expression system, including PC enzyme activity assays on wild-type
+      and the Ala610Thr disease variant.
+    action: ACCEPT
+    reason: Direct experimental measurement of pyruvate carboxylase activity for the
+      human enzyme; core molecular function.
+    supported_by:
+    - reference_id: PMID:12437512
+      supporting_text: &#39;We show, through immunoblot analysis, PC enzyme activity assays,
+        reverse-transcription PCR and mitochondrial-import experiments, that this
+        mutation is disease-causing&#39;
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:34547241
+  qualifier: located_in
+  review:
+    summary: ComplexPortal/IDA cytoplasmic localization associated with the cytosolic
+      hydride transfer complex (HTC). PC is canonically mitochondrial matrix; a
+      cytosolic pool participates in the HTC in cancer/hypoxic cells.
+    action: KEEP_AS_NON_CORE
+    reason: Real but context-specific (a minor cytosolic pool assembled into the
+      MDH1-ME1-PC complex). Not the primary localization or core function; retained
+      as non-core.
+    supported_by:
+    - reference_id: PMID:34547241
+      supporting_text: HTC is found in phase-separated bodies in the cytosol of cancer
+        or hypoxic cells and can be assembled in vitro with recombinant proteins.
+- term:
+    id: GO:0006739
+    label: NADP+ metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:34547241
+  qualifier: involved_in
+  review:
+    summary: PC contributes to NADP+/NAD metabolism as a member of the cytosolic
+      hydride transfer complex, which transfers reducing equivalents from NADH to
+      NADP+.
+    action: KEEP_AS_NON_CORE
+    reason: A genuine, experimentally supported role, but it is an emergent,
+      context-specific function of the MDH1-ME1-PC complex in cancer/hypoxic cells
+      rather than the core anaplerotic/gluconeogenic function of PC.
+    supported_by:
+    - reference_id: PMID:34547241
+      supporting_text: We report a multi-enzymatic complex that reprograms NAD
+        metabolism by transferring reducing equivalents from NADH to NADP+.
+- term:
+    id: GO:0019674
+    label: NAD+ metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:34547241
+  qualifier: involved_in
+  review:
+    summary: PC as part of the hydride transfer complex participates in NAD
+      metabolism (consuming NADH as reducing-equivalent donor).
+    action: KEEP_AS_NON_CORE
+    reason: Same rationale as the NADP+ annotation; real but emergent and
+      context-specific to the cytosolic HTC, not PC&#39;s core function.
+    supported_by:
+    - reference_id: PMID:34547241
+      supporting_text: We report a multi-enzymatic complex that reprograms NAD
+        metabolism by transferring reducing equivalents from NADH to NADP+.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: Immunofluorescence-based (HPA) mitochondrial localization, consistent
+      with the canonical mitochondrial-matrix localization of PC.
+    action: ACCEPT
+    reason: Correct organelle localization corroborated by orthogonal evidence
+      (UniProt subcellular location, MGI IDA, mitochondrial proteomics).
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+        that catalyzes the conversion of pyruvate to oxaloacetate.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: EXP
+  original_reference_id: PMID:9585002
+  qualifier: located_in
+  review:
+    summary: Experimentally determined mitochondrial-matrix localization; this is the
+      canonical compartment where PC is active.
+    action: ACCEPT
+    reason: Direct experimental subcellular-location evidence for the specific
+      compartment (matrix); core localization for the enzyme&#39;s function.
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+        that catalyzes the conversion of pyruvate to oxaloacetate.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: High-throughput mitochondrial proteomics places PC in the mitochondrion,
+      consistent with the canonical localization.
+    action: ACCEPT
+    reason: Corroborating high-confidence mitochondrial-proteome evidence for the
+      established mitochondrial localization of PC.
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+        that catalyzes the conversion of pyruvate to oxaloacetate.
+- term:
+    id: GO:0004736
+    label: pyruvate carboxylase activity
+  evidence_type: IMP
+  original_reference_id: PMID:9585002
+  qualifier: enables
+  review:
+    summary: Pyruvate carboxylase activity inferred from the functional consequences
+      of PC-deficiency mutations (patients with low PC activity, 2-25% of control),
+      confirming the enzyme&#39;s activity in the human gene product.
+    action: ACCEPT
+    reason: Loss-of-function mutations that reduce PC activity directly link the gene
+      to pyruvate carboxylase activity; core molecular function.
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: the probands were found to have low PC activity (range, 2-25%
+        of control) in blood lymphocytes and skin fibroblasts
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:23861867
+  qualifier: located_in
+  review:
+    summary: AgBase/IDA cytoplasmic localization from the HCV NS5A interaction study,
+      which also documents mitochondrial colocalization of PC and NS5A. PC is
+      canonically mitochondrial matrix.
+    action: KEEP_AS_NON_CORE
+    reason: A cytoplasmic signal is reported, but the study emphasizes mitochondrial
+      colocalization; cytoplasmic localization is not the primary compartment or a
+      core function. Retained as non-core.
+    supported_by:
+    - reference_id: PMID:23861867
+      supporting_text: we verified that both PC and NS5A were colocalized in the
+        mitochondria as determined by immunofluorescence assay
+- term:
+    id: GO:0010629
+    label: negative regulation of gene expression
+  evidence_type: IMP
+  original_reference_id: PMID:23861867
+  qualifier: involved_in
+  review:
+    summary: This annotation derives from a host-pathogen study in which HCV NS5A
+      downregulates the PC promoter. Here PC is the target of downregulation, not the
+      effector; the process does not describe an intrinsic molecular function of PC.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The experimental finding is that NS5A (and NS4B) down-regulate PC
+      transcription; PC itself is not shown to negatively regulate gene expression.
+      Attributing negative regulation of gene expression to PC as an actor is an
+      over-annotation (PC is the regulated gene, not the regulator).
+    supported_by:
+    - reference_id: PMID:23861867
+      supporting_text: We also showed that the transcriptional activity of PC was
+        downregulated in cells expressing NS5A, in HCV replicon cells, and in HCV
+        infected cells
+- term:
+    id: GO:0019074
+    label: viral RNA genome packaging
+  evidence_type: IMP
+  original_reference_id: PMID:23861867
+  qualifier: involved_in
+  review:
+    summary: Derived from the observation that silencing PC reduces production of
+      infectious HCV particles in infected cells. This reflects an indirect metabolic
+      dependency of the virus on host PC, not a direct role of PC in packaging the
+      viral genome.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The study shows PC is a host metabolic enzyme whose basal activity the
+      virus depends on (silencing reduces infectious-particle production), but there
+      is no evidence PC directly participates in packaging of the viral RNA genome.
+      This is an over-interpretation of a metabolic-dependency phenotype.
+    supported_by:
+    - reference_id: PMID:23861867
+      supporting_text: silencing of PC reduced infectious particle production in HCV
+        infected cells. This may explain that basal level of PC is also required for
+        HCV propagation.
+- term:
+    id: GO:0019076
+    label: viral release from host cell
+  evidence_type: IMP
+  original_reference_id: PMID:23861867
+  qualifier: involved_in
+  review:
+    summary: Also derived from the PC-silencing/reduced-infectious-particle
+      phenotype. This is an indirect host metabolic contribution to the HCV life
+      cycle rather than a direct role of PC in viral release.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The phenotype (reduced infectious-particle production on PC silencing)
+      is a metabolic dependency of the virus on host lipogenesis/anaplerosis, not
+      evidence that PC mediates viral egress. Over-annotation.
+    supported_by:
+    - reference_id: PMID:23861867
+      supporting_text: silencing of PC reduced infectious particle production in HCV
+        infected cells. This may explain that basal level of PC is also required for
+        HCV propagation.
+- term:
+    id: GO:0044794
+    label: host-mediated activation of viral process
+  evidence_type: IMP
+  original_reference_id: PMID:23861867
+  qualifier: involved_in
+  review:
+    summary: Captures the general finding that host PC activity supports HCV
+      propagation. This is a systemic host-pathogen metabolic effect, not a specific
+      molecular function of PC.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PC is a housekeeping metabolic enzyme co-opted by HCV; the paper frames
+      PC as a host factor whose basal level is required for propagation. Annotating
+      PC with a viral-process term over-states the specificity and directness of
+      PC&#39;s involvement.
+    supported_by:
+    - reference_id: PMID:23861867
+      supporting_text: This may explain that basal level of PC is also required for
+        HCV propagation.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2993802
+  qualifier: located_in
+  review:
+    summary: Reactome-asserted cytosolic localization referring to the biotinylation
+      of apo-PC by holocarboxylase synthetase (HLCS) prior to mitochondrial import;
+      the mature enzyme functions in the matrix.
+    action: KEEP_AS_NON_CORE
+    reason: Reflects a transient, maturation-stage cytosolic state (biotinylation
+      before matrix translocation) documented by Reactome, not the enzyme&#39;s functional
+      compartment. Retained as non-core rather than removed.
+    supported_by:
+    - reference_id: Reactome:R-HSA-3323111
+      supporting_text: Once biotinylated, three halocarboxylases (hCBXs) are localised
+        to the mitochondrial matrix.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3323111
+  qualifier: located_in
+  review:
+    summary: Reactome cytosolic assignment for the pre-import step in which biotinylated
+      carboxylases translocate to the mitochondrial matrix.
+    action: KEEP_AS_NON_CORE
+    reason: Same maturation-pathway rationale; cytosolic localization is a transient
+      pre-import state, not the functional compartment. Non-core.
+    supported_by:
+    - reference_id: Reactome:R-HSA-3323111
+      supporting_text: Cytosolic carboxylases translocate to mitochondrial matrix
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9035988
+  qualifier: located_in
+  review:
+    summary: Reactome cytosolic assignment for the defective-HLCS reaction (failure
+      to biotinylate PC:Mn2+), again referring to the pre-import cytosolic state.
+    action: KEEP_AS_NON_CORE
+    reason: Transient maturation-stage cytosolic localization, consistent with the
+      other Reactome cytosol assertions; not the functional compartment. Non-core.
+    supported_by:
+    - reference_id: Reactome:R-HSA-3323111
+      supporting_text: Once biotinylated, three halocarboxylases (hCBXs) are localised
+        to the mitochondrial matrix.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3065959
+  qualifier: located_in
+  review:
+    summary: Reactome-asserted mitochondrial-matrix localization (degradation of
+      mitochondrial holocarboxylases). Consistent with the canonical matrix
+      localization of PC.
+    action: ACCEPT
+    reason: Correct functional compartment for PC, corroborated by experimental and
+      electronic mitochondrial-matrix annotations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-3323111
+      supporting_text: Once biotinylated, three halocarboxylases (hCBXs) are localised
+        to the mitochondrial matrix.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3323111
+  qualifier: located_in
+  review:
+    summary: Reactome-asserted mitochondrial-matrix localization following translocation
+      of biotinylated PC; the functional compartment of the enzyme.
+    action: ACCEPT
+    reason: Matches the canonical, experimentally established mitochondrial-matrix
+      localization of PC.
+    supported_by:
+    - reference_id: Reactome:R-HSA-3323111
+      supporting_text: Once biotinylated, three halocarboxylases (hCBXs) are localised
+        to the mitochondrial matrix.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70501
+  qualifier: located_in
+  review:
+    summary: Reactome localizes the PC-catalyzed carboxylation of pyruvate to
+      oxaloacetate to the mitochondrial matrix.
+    action: ACCEPT
+    reason: The functional compartment where PC catalysis occurs; concordant with all
+      other matrix annotations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-70501
+      supporting_text: Mitochondrial pyruvate carboxylase (PC) catalyzes the irreversible
+        reaction of pyruvate (PYR), bicarbonate (HCO3-), and ATP to form oxaloacetate
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:16729965
+  qualifier: located_in
+  review:
+    summary: MGI/IDA mitochondrial localization. The cited paper is primarily about
+      the OCTN1 carnitine transporter but is used by MGI to support PC&#39;s mitochondrial
+      localization; the assignment is consistent with the canonical localization of PC.
+    action: ACCEPT
+    reason: Mitochondrial localization of PC is overwhelmingly supported by multiple
+      independent lines of evidence; this IDA is consistent with that. Deferring to
+      the curator on the specific supporting data (abstract-only cache).
+    supported_by:
+    - reference_id: PMID:9585002
+      supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+        that catalyzes the conversion of pyruvate to oxaloacetate.
+- term:
+    id: GO:0006107
+    label: oxaloacetate metabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Proposed new annotation capturing PC&#39;s core anaplerotic role - the
+      production of oxaloacetate, the central TCA-cycle intermediate, from pyruvate.
+      GOA currently records gluconeogenesis but not the more general/direct
+      oxaloacetate-production process that PC carries out.
+    action: NEW
+    reason: PC&#39;s immediate biological product is oxaloacetate, and its principal
+      physiological role beyond gluconeogenesis is anaplerotic replenishment of TCA
+      cycle oxaloacetate. The oxaloacetate metabolic process term directly reflects
+      the enzyme&#39;s committed reaction and is not otherwise represented in GOA.
+    supported_by:
+    - reference_id: Reactome:R-HSA-70501
+      supporting_text: Mitochondrial pyruvate carboxylase (PC) catalyzes the irreversible
+        reaction of pyruvate (PYR), bicarbonate (HCO3-), and ATP to form oxaloacetate
+    - reference_id: PMID:9585002
+      supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+        that catalyzes the conversion of pyruvate to oxaloacetate.
+- term:
+    id: GO:0004736
+    label: pyruvate carboxylase activity
+  evidence_type: TAS
+  original_reference_id: PMID:7918683
+  qualifier: enables
+  review:
+    summary: Traceable statement of pyruvate carboxylase activity from the primary
+      characterization of the human PC cDNA and sequence.
+    action: ACCEPT
+    reason: Authoritative early characterization identifying the enzyme and its
+      activity; supports the core molecular function.
+    supported_by:
+    - reference_id: PMID:7918683
+      supporting_text: a nuclear-encoded mitochondrial enzyme, catalyzes the conversion
+        of pyruvate to oxaloacetate.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: TAS
+  original_reference_id: PMID:8048912
+  qualifier: enables
+  review:
+    summary: Traceable statement of ATP binding based on identification of the ATP-binding
+      consensus in the human PC sequence.
+    action: ACCEPT
+    reason: Consistent with the ATP-grasp domain architecture and the ATP-dependent
+      catalytic mechanism; supports the ATP-binding cofactor function.
+    supported_by:
+    - reference_id: PMID:8048912
+      supporting_text: The translated amino acid sequence of 1178 residues contained
+        consensus sequences for the covalent attachment for biotin, the binding of ATP
+        and the binding of the substrate, pyruvate.
+- term:
+    id: GO:0009374
+    label: biotin binding
+  evidence_type: TAS
+  original_reference_id: PMID:8048912
+  qualifier: enables
+  review:
+    summary: Traceable statement of biotin binding based on identification of the
+      biotin covalent-attachment consensus in the human PC sequence.
+    action: ACCEPT
+    reason: Concordant with covalent biotinylation at Lys-1144 and the enzyme&#39;s
+      biotin-dependent mechanism; core cofactor function.
+    supported_by:
+    - reference_id: PMID:8048912
+      supporting_text: The translated amino acid sequence of 1178 residues contained
+        consensus sequences for the covalent attachment for biotin, the binding of ATP
+        and the binding of the substrate, pyruvate.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:12437512
+  title: Expression and characterization of a human pyruvate carboxylase variant by
+    retroviral gene transfer.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Experimental characterization of human PC enzyme
+      activity (EXP) including the Type A Ala610Thr disease variant; supports the
+      catalytic-activity annotation.
+- id: PMID:16729965
+  title: Novel localization of OCTN1, an organic cation/carnitine transporter, to
+    mammalian mitochondria.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Paper is primarily about OCTN1, not PC; used by
+      MGI as IDA support for PC mitochondrial localization. Cache is abstract-only,
+      so the specific PC supporting data cannot be inspected; deferring to the curator.
+- id: PMID:18297087
+  title: Crystal structures of human and Staphylococcus aureus pyruvate carboxylase
+    and molecular insights into the carboxyltransfer reaction.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Crystal structures of human (C-terminal region)
+      and S. aureus PC; establishes homotetramer, Mn(2+) binding and the biotin/BCCP
+      role in the carboxyltransfer reaction.
+- id: PMID:23861867
+  title: Nonstructural 5A protein of hepatitis C virus interacts with pyruvate carboxylase
+    and modulates viral propagation.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: PubMed-verified, full text available. Documents the HCV NS5A-PC
+      interaction (via PC biotin carboxylase domain) and that silencing PC reduces
+      infectious-particle production. The derived viral-process and negative-regulation
+      IMP annotations over-state PC&#39;s directness (host metabolic dependency; PC is
+      the transcriptional target of NS5A, not the regulator).
+- id: PMID:34547241
+  title: A hydride transfer complex reprograms NAD metabolism and bypasses senescence.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Establishes cytosolic PC as a component of the
+      MDH1-ME1-PC hydride transfer complex that reprograms NAD/NADP metabolism in
+      cancer/hypoxic cells. Supports the context-specific cytosolic and
+      NAD(P)-metabolism annotations kept as non-core.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: PubMed-verified. High-confidence mitochondrial proteomics; corroborates
+      PC&#39;s mitochondrial localization.
+- id: PMID:7918683
+  title: Primary amino acid sequence and structure of human pyruvate carboxylase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Primary characterization of the human PC cDNA/protein
+      sequence; identifies ATP, pyruvate and biotin-binding sites; highest expression
+      in liver.
+- id: PMID:8048912
+  title: cDNA cloning of human kidney pyruvate carboxylase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. cDNA cloning of human PC; identifies the biotin
+      attachment, ATP-binding and pyruvate-binding consensus sequences.
+- id: PMID:9585002
+  title: Molecular characterization of pyruvate carboxylase deficiency in two consanguineous
+    families.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Source of UniProt catalytic activity, cofactor and
+      subcellular-location evidence; documents disease-causing mutations with reduced
+      PC activity (IMP support).
+- id: Reactome:R-HSA-2993802
+  title: HLCS biotinylates PC:Mn2+
+  findings: []
+- id: Reactome:R-HSA-3065959
+  title: An unknown protease degrades hCBXs
+  findings: []
+- id: Reactome:R-HSA-3323111
+  title: Cytosolic carboxylases translocate to mitochondrial matrix
+  findings: []
+- id: Reactome:R-HSA-70501
+  title: PC carboxylates PYR to OA
+  findings: []
+- id: Reactome:R-HSA-9035988
+  title: Defective HLCS does not biotinylate PC:Mn2+
+  findings: []
+core_functions:
+- description: Biotin- and ATP-dependent carboxylation of pyruvate to oxaloacetate
+    in the mitochondrial matrix, using covalently bound biotin as the carboxyl carrier
+    and requiring a Mn(2+) ion; the committed step of gluconeogenesis from pyruvate/lactate.
+  molecular_function:
+    id: GO:0004736
+    label: pyruvate carboxylase activity
+  directly_involved_in:
+  - id: GO:0006094
+    label: gluconeogenesis
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:9585002
+    supporting_text: Pyruvate carboxylase (PC) is a biotinylated mitochondrial enzyme
+      that catalyzes the conversion of pyruvate to oxaloacetate.
+  - reference_id: Reactome:R-HSA-70501
+    supporting_text: Mitochondrial pyruvate carboxylase (PC) catalyzes the irreversible
+      reaction of pyruvate (PYR), bicarbonate (HCO3-), and ATP to form oxaloacetate
+- description: Anaplerotic production of oxaloacetate, the central TCA-cycle intermediate,
+    from pyruvate; a carboxylation reaction that is allosterically activated by acetyl-CoA.
+  molecular_function:
+    id: GO:0004736
+    label: pyruvate carboxylase activity
+  directly_involved_in:
+  - id: GO:0006107
+    label: oxaloacetate metabolic process
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: Reactome:R-HSA-70501
+    supporting_text: Mitochondrial pyruvate carboxylase (PC) catalyzes the irreversible
+      reaction of pyruvate (PYR), bicarbonate (HCO3-), and ATP to form oxaloacetate
+- description: Cofactor binding required for catalysis - covalent biotin (at Lys-1144
+    in the biotinyl-carboxyl-carrier domain) as the mobile carboxyl carrier and ATP
+    (via the ATP-grasp domain) used to carboxylate the tethered biotin.
+  molecular_function:
+    id: GO:0009374
+    label: biotin binding
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:18297087
+    supporting_text: A BCCP domain is located in the active site of the CT domain,
+      providing the first molecular insights into how biotin participates in the
+      carboxyltransfer reaction.
+  - reference_id: PMID:8048912
+    supporting_text: The translated amino acid sequence of 1178 residues contained
+      consensus sequences for the covalent attachment for biotin, the binding of ATP
+      and the binding of the substrate, pyruvate.
+proposed_new_terms: []
+suggested_questions:
+- question: Beyond the reported cytosolic hydride transfer complex, what fraction of
+    cellular PC is cytosolic under normal physiology, and is there a functionally
+    significant extra-mitochondrial pyruvate carboxylase pool?
+- question: Does acetyl-CoA allosteric activation of human PC differ quantitatively
+    across the gluconeogenic (liver/kidney) versus lipogenic (adipose/brain) tissue
+    contexts?
+suggested_experiments:
+- description: Kinetic characterization (kcat/Km, acetyl-CoA activation constant) of
+    recombinant wild-type versus disease-variant human PC to quantify how deficiency
+    mutations impair anaplerosis versus gluconeogenesis.
+- description: Compartment-resolved metabolic flux analysis (e.g. 13C tracing) in
+    liver-derived cells to distinguish PC&#39;s anaplerotic (TCA/oxaloacetate) from
+    gluconeogenic flux contributions.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PDHA1/PDHA1-ai-review.html
+++ b/genes/human/PDHA1/PDHA1-ai-review.html
@@ -1,0 +1,5928 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PDHA1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PDHA1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P08559" target="_blank" class="term-link">
+                        P08559
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PDHA1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P08559" data-a="DESCRIPTION: PDHA1 encodes the somatic form of the pyruvate deh..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PDHA1 encodes the somatic form of the pyruvate dehydrogenase E1 component subunit alpha (E1alpha), a mitochondrial matrix protein. Together with PDHB (E1beta) it assembles into the alpha2-beta2 heterotetrameric E1 component of the pyruvate dehydrogenase complex (PDC), the multienzyme assembly (E1, E2/DLAT, E3/DLD, plus the E3-binding protein) that catalyzes the committed, rate-limiting oxidative decarboxylation of pyruvate to acetyl-CoA and CO2 with reduction of NAD+ to NADH. The E1 alpha subunit carries the thiamine pyrophosphate (TPP)- and Mg2+-dependent active site and performs two consecutive steps: TPP-dependent decarboxylation of pyruvate to a hydroxyethyl-TPP intermediate, and reductive acetylation of the lipoyl group covalently attached to the E2 lipoyl domains. By converting pyruvate to acetyl-CoA, PDC forms the metabolic gateway that links cytoplasmic glycolysis to the mitochondrial tricarboxylic acid (TCA) cycle and lipogenesis. Enzyme activity is switched off by phosphorylation of conserved serine residues on E1alpha (Ser-232, Ser-293, Ser-300; sites 3, 1, 2) by pyruvate dehydrogenase kinases (PDKs) and switched back on by dephosphorylation by pyruvate dehydrogenase phosphatases (PDPs). The gene is X-linked, and pathogenic variants cause pyruvate dehydrogenase E1-alpha deficiency, the most common cause of PDC deficiency, presenting with primary lactic acidosis and neurological disease (including Leigh syndrome).</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                                    GO:0004739
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase (acetyl-transferring) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0004739" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assertion of the core molecular function: pyruvate dehydrogenase (acetyl-transferring) activity (EC 1.2.4.1). This is the defining catalytic activity of the E1 alpha subunit and is independently confirmed by direct experimental annotations (EXP/IDA) on this protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and central function. E1alpha, with E1beta, catalyzes the TPP-dependent decarboxylation of pyruvate and reductive acetylation of the E2 lipoyl group.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate (Reaction 2) and the reductive acetylation of a lipoyl group</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3034892" target="_blank" class="term-link">
+                                        PMID:3034892
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the alpha subunit of human pyruvate dehydrogenase (EC 1.2.4.1), the E1 component of the pyruvate dehydrogenase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005759" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic assertion that PDHA1 is active in the mitochondrial matrix. This is the established compartment of the PDH complex and is supported by the UniProt subcellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHA1 is synthesized with a mitochondrial import leader and functions in the matrix as part of the soluble PDH complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3034892" target="_blank" class="term-link">
+                                        PMID:3034892
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The protein is synthesized with a typical mitochondrial import leader</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0006086" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic assertion that PDHA1 is involved in pyruvate decarboxylation to acetyl-CoA, the biological process carried out by the PDH complex. Consistent with direct experimental annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core process to which the E1 catalytic activity contributes; the PDH complex converts pyruvate to acetyl-CoA and CO2.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human pyruvate dehydrogenase complex (PDC) catalyzes the oxidative decarboxylation of pyruvate to produce acetyl-CoA and NADH</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0045254" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic assertion that PDHA1 is part of the pyruvate dehydrogenase complex. PDHA1 is a constitutive catalytic subunit of the PDC (as the E1 alpha subunit).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHA1 forms the E1 heterotetramer with PDHB and is a core component of the multienzyme PDH complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human pyruvate dehydrogenase complex (PDC) is a 9.5-megadalton catalytic machine that employs three catalytic components, i.e. pyruvate dehydrogenase (E1p)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                                    GO:0004739
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase (acetyl-transferring) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0004739" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (IEA) assertion of pyruvate dehydrogenase activity, mapped from the EC 1.2.4.1 / RHEA:19189 / InterPro E1alpha signature. Redundant with the IBA and experimental MF annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly captures the enzymatic function via EC/RHEA/InterPro mapping.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=1.2.4.1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated location annotation derived from the UniProt subcellular location controlled vocabulary (mitochondrion matrix, SL-0170).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the curated UniProt subcellular location and the IBA matrix annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0006086" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (IEA) assertion of involvement in pyruvate decarboxylation to acetyl-CoA, from the InterPro E1alpha signature. Redundant with the IBA and experimental process annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct process for the E1 subunit of the PDH complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyzes the oxidative decarboxylation of pyruvate to produce acetyl-CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016624" target="_blank" class="term-link">
+                                    GO:0016624
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity, acting on the aldehyde or oxo group of donors, disulfide as acceptor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0016624" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping to the general oxidoreductase class. This is the parent of the specific, EC-mapped pyruvate dehydrogenase activity (GO:0004739) already annotated to PDHA1, so it is correct but too general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong, but this broad oxidoreductase class is less informative than the specific EC 1.2.4.1 activity; replace with the specific term already supported experimentally.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                                    pyruvate dehydrogenase (acetyl-transferring) activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=1.2.4.1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0045254" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (ARBA) assertion that PDHA1 is part of the pyruvate dehydrogenase complex. Redundant with IBA/IDA complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct complex assignment for the E1 alpha subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">pyruvate dehydrogenase (E1p)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12651851" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12651851
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for flip-flop action of thiamin pyrophospha...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005515" data-r="PMID:12651851" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI capturing the physical interaction of PDHA1 with PDHB (UniProtKB:P11177), derived from the human E1 crystal structure. This is the genuine intra-E1 alpha-beta subunit contact, but the bare &#34;protein binding&#34; term is uninformative; the biologically meaningful assertion (PDHA1 as part of the E1 heterotetramer / PDH complex) is already captured by GO:0045254.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real experimental interaction (E1alpha-E1beta), but GO:0005515 conveys no specific function; retain as non-core evidence rather than a core annotation. Per curation policy, an experimental IPI is not removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651851" target="_blank" class="term-link">
+                                        PMID:12651851
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In alpha2beta2-heterotetrameric human pyruvate dehydrogenase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29128334" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29128334
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A Map of Human Mitochondrial Protein Interactions Linked to ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005515" data-r="PMID:29128334" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI from a large-scale human mitochondrial protein interaction map (interactors PDHB/P11177 and IMMT/Q16891). Bare &#34;protein binding&#34; is uninformative; PDHB interaction is already captured by complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput interaction evidence; the informative content (PDH complex membership) is captured elsewhere. Not removed per policy for experimental IPI.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29128334" target="_blank" class="term-link">
+                                        PMID:29128334
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A Map of Human Mitochondrial Protein Interactions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29568061" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29568061
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An AP-MS- and BioID-compatible MAC-tag enables comprehensive...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005515" data-r="PMID:29568061" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (interactor PDK1/Q15118) from a MAC-tag AP-MS/BioID interaction and localization mapping study. The PDK1 contact is consistent with the known regulation of E1alpha by PDK-family kinases, but &#34;protein binding&#34; itself is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proximity/AP-MS-derived interaction; biologically the regulatory PDK contact, but a bare protein-binding term is not a useful function annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29568061" target="_blank" class="term-link">
+                                        PMID:29568061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">comprehensive mapping of protein interactions and subcellular localizations</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (interactor PDHB/P11177) from a proteome-scale interactome study (BioPlex). Bare &#34;protein binding&#34;; the PDHB interaction is captured by complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Large-scale interactome evidence; uninformative MF term. Not removed per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35156780" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35156780
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CFTR interactome mapping using the mammalian membrane two-hy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005515" data-r="PMID:35156780" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (interactor CFTR/P13569) from a mammalian membrane two-hybrid CFTR-interactome screen. A CFTR-PDHA1 contact from a high-throughput screen is of uncertain physiological relevance and the term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput screen against CFTR; bare protein-binding term with no clear functional meaning for PDHA1. Not removed (experimental IPI).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35156780" target="_blank" class="term-link">
+                                        PMID:35156780
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CFTR interactome mapping using the mammalian membrane two-hybrid</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36012204" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36012204
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Differential CFTR-Interactome Proximity Labeling Procedures ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005515" data-r="PMID:36012204" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (interactor CFTR/P13569) from a differential CFTR proximity-labeling study. As above, high-throughput CFTR-proximity evidence; uninformative MF term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proximity-labeling screen; not a core PDHA1 function and the term is uninformative. Not removed per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36012204" target="_blank" class="term-link">
+                                        PMID:36012204
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Differential CFTR-Interactome Proximity Labeling Procedures</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7782287" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7782287
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutagenesis studies of the phosphorylation sites of recombin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005515" data-r="PMID:7782287" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (interactor PDK1/Q15118) linked to the mutagenesis study of the E1alpha phosphorylation sites. Reflects the physiologically important E1alpha-PDK interaction (PDK phosphorylates and inactivates E1), but the bare &#34;protein binding&#34; term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real regulatory interaction (E1alpha is the PDK substrate), but captured better as regulation/phosphorylation than as generic protein binding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7782287" target="_blank" class="term-link">
+                                        PMID:7782287
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">regulated by phosphorylation-dephosphorylation, catalyzed by the E1-kinase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005739" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (IEA) mitochondrion localization. Correct but less specific than the mitochondrial matrix annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment; parent of the more specific matrix location that better represents PDHA1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                                    GO:0032991
+                                </a>
+                            </span>
+                            <span class="term-label">protein-containing complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0032991" data-r="GO_REF:0000107" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (Ensembl Compara) generic protein-containing complex membership. This is uninformative given that the specific complex (pyruvate dehydrogenase complex, GO:0045254) is already annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Too general; PDHA1&#39;s complex is specifically the pyruvate dehydrogenase complex.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    pyruvate dehydrogenase complex
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">pyruvate dehydrogenase (E1p)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24534072
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Component co-expression and purification of recombinant huma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005739" data-r="PMID:24534072" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable-author-statement mitochondrion localization from ComplexPortal, based on the PDC being a mitochondrial enzyme. Correct but less specific than matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment (the mammalian PDC is a mitochondrial enzyme); matrix is the more precise location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                                        PMID:24534072
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mammalian pyruvate dehydrogenase complex (PDC) is a multi-component mitochondrial enzyme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19081061
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for inactivation of the human pyruvate dehy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0006086" data-r="PMID:19081061" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) annotation from the human E1p structure/kinetics study showing PDHA1&#39;s role in converting pyruvate to acetyl-CoA within the PDH complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strong experimental support for the core process; the study measures the overall PDC reaction and E1p decarboxylation/reductive acetylation activities.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyzes the oxidative decarboxylation of pyruvate to produce acetyl-CoA and NADH</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24534072
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Component co-expression and purification of recombinant huma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0006086" data-r="PMID:24534072" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) annotation from the recombinant human PDC that produced a functional, active complex, confirming PDHA1&#39;s role in the pyruvate-to-acetyl-CoA process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Functional reconstituted PDC demonstrates the process; supports the core role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                                        PMID:24534072
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">conversion of pyruvate to acetyl-CoA connecting glycolysis to the citric acid cycle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19081061
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for inactivation of the human pyruvate dehy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0045254" data-r="PMID:19081061" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental complex-membership annotation for PDHA1 as the E1 alpha subunit of the PDC, from the human E1p structural study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHA1 is experimentally established as part of the PDH complex (E1 heterotetramer).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Phosphorylation of the heterotetrameric (α2β2) E1p component</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19240034
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subunit and catalytic component stoichiometries of an in vit...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0045254" data-r="PMID:19240034" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IPI complex-membership annotation from the study defining the subunit stoichiometry of the reconstituted human PDC, in which PDHA1 (as E1p heterotetramer) associates with the E2p/E3BP core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Establishes PDHA1 as part of the assembled PDH complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">40 copies of E1p heterotetramers and 20 copies of E3 dimers associated with the E2p/E3BP core</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Immunofluorescence-based (Human Protein Atlas) mitochondrion localization. Correct compartment; less specific than matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent mitochondrial localization; matrix is the more precise sub-compartment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                                    GO:0004739
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase (acetyl-transferring) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17474719" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17474719
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphorylation of serine 264 impedes active site accessibil...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0004739" data-r="PMID:17474719" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (EXP) annotation of pyruvate dehydrogenase activity based on kinetic characterization of human E1 (wild-type and S264-phosphorylation variant), demonstrating pyruvate decarboxylation and reductive acetylation of E2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the strongest, most direct experimental evidence for the core molecular function of PDHA1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17474719" target="_blank" class="term-link">
+                                        PMID:17474719
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the pyruvate dehydrogenase multienzyme complex (PDHc) catalyzes the oxidative decarboxylation of pyruvate to acetyl-CoA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                                    GO:0004739
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase (acetyl-transferring) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7782287" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7782287
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutagenesis studies of the phosphorylation sites of recombin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0004739" data-r="PMID:7782287" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (EXP) annotation of pyruvate dehydrogenase activity from site-directed mutagenesis of recombinant human E1 phosphorylation sites, measuring E1 specific activity and Km for TPP and pyruvate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental measurement of E1 catalytic activity on the human protein supports the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7782287" target="_blank" class="term-link">
+                                        PMID:7782287
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutation at site 1 but not at sites 2 and/or 3 decreased E1 specific activity and also increased Km values for thiamin pyrophosphate and pyruvate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005759" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity-based (ISS) transfer of the mitochondrial matrix location from an ortholog. Consistent with the curated matrix location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment for PDHA1, matching UniProt and the IBA annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005739" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity-based (ISS) transfer of mitochondrion (is_active_in) from an ortholog. Correct but less specific than matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment; matrix is the more precise location where PDHA1 is active.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005739" data-r="PMID:34800366" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomics (HTP) mitochondrion localization from a quantitative high-confidence human mitochondrial proteome (MitoCoP). Supports mitochondrial residence; less specific than matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with mitochondrial localization; parent of the matrix location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                                        PMID:34800366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mitochondrial high-confidence proteome of &gt;1,100 proteins (MitoCoP)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                                    GO:0004739
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase (acetyl-transferring) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19081061
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for inactivation of the human pyruvate dehy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0004739" data-r="PMID:19081061" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) annotation with the contributes_to qualifier: PDHA1 contributes the E1 catalytic activity to the pyruvate dehydrogenase activity of the multi-subunit complex. The contributes_to qualifier is appropriate because the full activity requires the heterotetramer and the assembled PDC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct use of contributes_to for a subunit whose activity is realized in the context of the E1 heterotetramer / PDH complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-203946
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005759" data-r="Reactome:R-HSA-203946" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS matrix localization associated with the PDK phosphorylation reaction of the PDHC E1 subunit. Correct compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome places the PDH E1 subunit and its phospho-regulation in the mitochondrial matrix, consistent with all other evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-204169
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005759" data-r="Reactome:R-HSA-204169" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS matrix localization associated with the PDP1/2 dephosphorylation reaction of phospho-lipo-PDH. Correct compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent matrix localization for the reversibly phospho-regulated PDH E1 subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9838035
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005759" data-r="Reactome:R-HSA-9838035" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS matrix localization associated with the CLPXP protease binding mitochondrial matrix proteins reaction (PDHA1 as a matrix substrate). Location correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHA1 is a mitochondrial matrix protein; the annotation reflects its residence in the matrix (here as a CLPXP substrate).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9838289
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005759" data-r="Reactome:R-HSA-9838289" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS matrix localization associated with the CLPXP degradation of mitochondrial matrix proteins reaction. Location correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects PDHA1&#39;s matrix residence (as a substrate of matrix quality-control proteolysis); the location is correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861616
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005759" data-r="Reactome:R-HSA-9861616" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS matrix localization associated with the DLD (E3) dihydrolipoyl dehydrogenation reaction of the PDC. Correct compartment for the PDC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The PDH complex, including PDHA1, operates in the mitochondrial matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861667
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005759" data-r="Reactome:R-HSA-9861667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS matrix localization associated with the DLAT (E2) acetyl transfer to CoA reaction of the PDC. Correct compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The PDC reaction sequence, of which PDHA1 is the E1 component, takes place in the matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHA1/PDHA1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Mitochondrion matrix</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861734
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005759" data-r="Reactome:R-HSA-9861734" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS matrix localization associated with the reaction in which PDH E1 decarboxylates pyruvate and transfers acetyl to DLAT. This is PDHA1&#39;s own catalytic step and it is placed in the mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly describes PDHA1&#39;s E1 catalytic reaction occurring in the mitochondrial matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-9861734
+
+                                </span>
+
+                                <div class="support-text">The E1 component of the pyruvate dehydrogenase complex (PDC, PDHC) catalyzes the decarboxylation of pyruvate (PYR) with subsequent transfer of acetyl to the E2 subunit (DLAT)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21630459
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteomic characterization of the human sperm nucleus.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005634" data-r="PMID:21630459" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of PDHA1 in an isolated human sperm nucleus preparation. This does not establish a nuclear function or a physiological nuclear localization for the somatic E1alpha, which is an established mitochondrial matrix protein; it likely reflects the specialized sperm proteome and/or preparation carry-over.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Single high-throughput proteomic dataset in a specialized cell type; not corroborated as a functional nuclear localization. The compartment of any non-mitochondrial pool is unresolved. Retained (experimental HDA) but flagged as over-annotation, not core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
+                                        PMID:21630459
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">sperm nuclei were obtained</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20833797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphoproteome analysis of functional mitochondria isolated...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005739" data-r="PMID:20833797" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of PDHA1 in mitochondria isolated from human skeletal muscle (a mitochondrial phosphoproteome). Supports mitochondrial residence; less specific than matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent mitochondrial localization; parent of the matrix location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link">
+                                        PMID:20833797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mitochondria isolated from resting human muscle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3034892" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3034892
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The human pyruvate dehydrogenase complex. Isolation of cDNA ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P08559" data-a="GO:0005739" data-r="PMID:3034892" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement mitochondrion localization from the original human E1alpha cDNA characterization, which established the mitochondrial import leader and matrix maturation of the protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment; the same study establishes mitochondrial import, and matrix is the precise location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3034892" target="_blank" class="term-link">
+                                        PMID:3034892
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The protein is synthesized with a typical mitochondrial import leader</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Thiamine-pyrophosphate (TPP)- and Mg2+-dependent E1 alpha subunit of the pyruvate dehydrogenase complex that, together with PDHB (E1beta), catalyzes the oxidative decarboxylation of pyruvate and the reductive acetylation of the E2 lipoyl group, the committed step converting pyruvate to acetyl-CoA and linking glycolysis to the TCA cycle.</h3>
+                <span class="vote-buttons" data-g="P08559" data-a="FUNCTION: Thiamine-pyrophosphate (TPP)- and Mg2+-dependent E..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                            pyruvate dehydrogenase (acetyl-transferring) activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                pyruvate decarboxylation to acetyl-CoA
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                            pyruvate dehydrogenase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                PMID:19081061
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate (Reaction 2) and the reductive acetylation of a lipoyl group</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17474719" target="_blank" class="term-link">
+                                PMID:17474719
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the pyruvate dehydrogenase multienzyme complex (PDHc) catalyzes the oxidative decarboxylation of pyruvate to acetyl-CoA</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12651851" target="_blank" class="term-link">
+                            PMID:12651851
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for flip-flop action of thiamin pyrophosphate-dependent enzymes revealed by human pyruvate dehydrogenase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17474719" target="_blank" class="term-link">
+                            PMID:17474719
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phosphorylation of serine 264 impedes active site accessibility in the E1 component of the human pyruvate dehydrogenase multienzyme complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                            PMID:19081061
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for inactivation of the human pyruvate dehydrogenase complex by phosphorylation: role of disordered phosphorylation loops.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                            PMID:19240034
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Subunit and catalytic component stoichiometries of an in vitro reconstituted human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link">
+                            PMID:20833797
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phosphoproteome analysis of functional mitochondria isolated from resting human muscle reveals extensive phosphorylation of inner membrane protein complexes and enzymes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
+                            PMID:21630459
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteomic characterization of the human sperm nucleus.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                            PMID:24534072
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Component co-expression and purification of recombinant human pyruvate dehydrogenase complex from baculovirus infected SF9 cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29128334" target="_blank" class="term-link">
+                            PMID:29128334
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A Map of Human Mitochondrial Protein Interactions Linked to Neurodegeneration Reveals New Mechanisms of Redox Homeostasis and NF-κB Signaling.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29568061" target="_blank" class="term-link">
+                            PMID:29568061
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An AP-MS- and BioID-compatible MAC-tag enables comprehensive mapping of protein interactions and subcellular localizations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/3034892" target="_blank" class="term-link">
+                            PMID:3034892
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The human pyruvate dehydrogenase complex. Isolation of cDNA clones for the E1 alpha subunit, sequence analysis, and characterization of the mRNA.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35156780" target="_blank" class="term-link">
+                            PMID:35156780
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CFTR interactome mapping using the mammalian membrane two-hybrid high-throughput screening system.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36012204" target="_blank" class="term-link">
+                            PMID:36012204
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Differential CFTR-Interactome Proximity Labeling Procedures Identify Enrichment in Multiple SLC Transporters.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7782287" target="_blank" class="term-link">
+                            PMID:7782287
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutagenesis studies of the phosphorylation sites of recombinant human pyruvate dehydrogenase. Site-specific regulation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-203946
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDK isozymes phosphorylate PDHC subunit E1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-204169
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDP1,2 dephosphorylate p-lipo-PDH</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9838035
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CLPXP binds mitochondrial matrix proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9838289
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CLPXP degrades mitochondrial matrix proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861616
+
+                    </span>
+                </div>
+
+                <div class="reference-title">DLD dimer dehydrogenates dihydrolipoyl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861667
+
+                    </span>
+                </div>
+
+                <div class="reference-title">DLAT trimer transfers acetyl to CoA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861734
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDH E1 decarboxylates PYR, transferring acetyl to DLAT</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PDHA1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P08559" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pdha1-p08559-review-notes">PDHA1 (P08559) review notes</h1>
+<p>Human PDHA1 = pyruvate dehydrogenase E1 component subunit alpha, somatic form, mitochondrial (UniProt RecName, ODPA_HUMAN). Gene HGNC:8806, X-linked. EC 1.2.4.1.</p>
+<h2 id="verified-biology-grounding">Verified biology (grounding)</h2>
+<ul>
+<li><strong>E1 alpha subunit of the mitochondrial pyruvate dehydrogenase complex (PDC).</strong> Together with PDHB (E1beta) it forms the heterotetrameric (alpha2-beta2) E1 component. [UniProt SUBUNIT: "Heterotetramer of two PDHA1 and two PDHB subunits."]</li>
+<li><strong>Reaction / MF:</strong> thiamine-pyrophosphate (TPP)-dependent oxidative decarboxylation of pyruvate followed by reductive acetylation of the E2 lipoyl group. EC=1.2.4.1; RHEA:19189. GO MF = GO:0004739 pyruvate dehydrogenase (acetyl-transferring) activity. [UniProt FUNCTION: "The E1 subunit catalyzes both the thiamine pyrophosphate (TPP)-dependent decarboxylation of pyruvate and the reductive acetylation of a lipoyl group..."]</li>
+<li><strong>Overall PDC:</strong> pyruvate + CoA + NAD+ -&gt; acetyl-CoA + CO2 + NADH; gateway linking glycolysis to the TCA cycle. [PMID:19081061 full text: "gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways"; UniProt "links cytoplasmic glycolysis and the mitochondrial tricarboxylic acid (TCA) cycle".]</li>
+<li><strong>Cofactors:</strong> thiamine diphosphate (ThDP/TPP) and Mg2+ (also K+ per Reactome). [UniProt COFACTOR; PMID:12651851 holo-structure with Mg2+ and TPP.]</li>
+<li><strong>Location:</strong> mitochondrial matrix. [UniProt SUBCELLULAR LOCATION: "Mitochondrion matrix".]</li>
+<li><strong>Regulation:</strong> activity inhibited by phosphorylation of E1alpha at Ser-232/Ser-293/Ser-300 (PDK isozymes; single-site phosphorylation is sufficient to inactivate) and reactivated by dephosphorylation (PDP1/2). [PMID:7782287 abstract "Phosphorylation of each site resulted in complete inactivation of the E1"; PMID:17474719; PMID:19081061; UniProt ACTIVITY REGULATION/PTM.]</li>
+<li><strong>Disease:</strong> Pyruvate dehydrogenase E1-alpha deficiency (PDHAD, MIM:312170); X-linked; commonest cause of PDC deficiency (~up to 90%); primary lactic acidosis, Leigh syndrome, neurodevelopmental disease. [UniProt DISEASE; dismech KB Pyruvate_Dehydrogenase_Deficiency.yaml "Pyruvate dehydrogenase complex deficiency is in up to 90% caused by pathogenic variants in the X-linked PDHA1 gene."]</li>
+</ul>
+<h2 id="annotation-decisions-summary">Annotation decisions (summary)</h2>
+<p>Core catalytic + complex + location + process annotations (GO:0004739, GO:0045254, GO:0005759, GO:0006086) are well supported by structure/biochemistry (PMID:12651851, 17474719, 19081061, 7782287, 24534072, 19240034) and accepted; the strongest experimental MF annotation is EXP/IDA GO:0004739.</p>
+<ul>
+<li>GO:0016624 (IEA, InterPro) is the parent oxidoreductase class of the specific EC-mapped GO:0004739 -&gt; MODIFY (too general; replace with GO:0004739).</li>
+<li><code>protein binding</code> GO:0005515 IPIs: uninformative bare MF term (per curation policy). PMID:12651851 (interactor P11177=PDHB) is the genuine intra-E1 alpha-beta interaction from the crystal structure; PMID:29128334 (PDHB, IMMT), 7782287 (PDK1, Q15118), 29568061 (PDK1 Q15118) reflect real complex/regulator contacts; PMID:33961781/35156780/36012204 are large-scale interactome/CFTR proximity screens. All -&gt; MARK_AS_OVER_ANNOTATED (keep, but not core; more informative terms are complex part_of / MF captured elsewhere). Not REMOVE (experimental IPIs).</li>
+<li>Nucleus GO:0005634 HDA from sperm-nucleus proteomics (PMID:21630459) -&gt; MARK_AS_OVER_ANNOTATED (single high-throughput proteomic detection; not an established site of PDHA1 function; PDHA1 is matrix). Not REMOVE.</li>
+<li>mitochondrion (parent of matrix) IEA/ISS/HDA/HTP/NAS/TAS -&gt; ACCEPT (correct but less specific than matrix) or KEEP_AS_NON_CORE where redundant with matrix.</li>
+<li>Reactome TAS mitochondrial matrix (multiple reaction IDs incl. CLPXP degradation reactions) -&gt; ACCEPT location (matrix correct); the CLPXP reactions reflect PDHA1 as a matrix substrate, location still valid.</li>
+<li>GO:0032991 protein-containing complex (IEA, Ensembl Compara) -&gt; MODIFY to the specific PDC complex GO:0045254 (already annotated).</li>
+</ul>
+<p>DR (falcon) not available within the 8-min poll window; grounded in UniProt, GOA, cached publications, Reactome, and the dismech disorder KB.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P08559
+gene_symbol: PDHA1
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PDHA1 encodes the somatic form of the pyruvate dehydrogenase E1 component subunit
+  alpha (E1alpha), a mitochondrial matrix protein. Together with PDHB (E1beta) it
+  assembles into the alpha2-beta2 heterotetrameric E1 component of the pyruvate
+  dehydrogenase complex (PDC), the multienzyme assembly (E1, E2/DLAT, E3/DLD, plus
+  the E3-binding protein) that catalyzes the committed, rate-limiting oxidative
+  decarboxylation of pyruvate to acetyl-CoA and CO2 with reduction of NAD+ to NADH.
+  The E1 alpha subunit carries the thiamine pyrophosphate (TPP)- and Mg2+-dependent
+  active site and performs two consecutive steps: TPP-dependent decarboxylation of
+  pyruvate to a hydroxyethyl-TPP intermediate, and reductive acetylation of the
+  lipoyl group covalently attached to the E2 lipoyl domains. By converting pyruvate
+  to acetyl-CoA, PDC forms the metabolic gateway that links cytoplasmic glycolysis
+  to the mitochondrial tricarboxylic acid (TCA) cycle and lipogenesis. Enzyme
+  activity is switched off by phosphorylation of conserved serine residues on
+  E1alpha (Ser-232, Ser-293, Ser-300; sites 3, 1, 2) by pyruvate dehydrogenase
+  kinases (PDKs) and switched back on by dephosphorylation by pyruvate dehydrogenase
+  phosphatases (PDPs). The gene is X-linked, and pathogenic variants cause pyruvate
+  dehydrogenase E1-alpha deficiency, the most common cause of PDC deficiency,
+  presenting with primary lactic acidosis and neurological disease (including Leigh
+  syndrome).
+alternative_products:
+- name: &#39;1&#39;
+  id: P08559-1
+- name: &#39;2&#39;
+  id: P08559-2
+  sequence_note: VSP_042569
+- name: &#39;3&#39;
+  id: P08559-3
+  sequence_note: VSP_042570
+- name: &#39;4&#39;
+  id: P08559-4
+  sequence_note: VSP_043363
+existing_annotations:
+- term:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assertion of the core molecular function: pyruvate
+      dehydrogenase (acetyl-transferring) activity (EC 1.2.4.1). This is the defining
+      catalytic activity of the E1 alpha subunit and is independently confirmed by
+      direct experimental annotations (EXP/IDA) on this protein.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and central function. E1alpha, with E1beta, catalyzes the TPP-dependent
+      decarboxylation of pyruvate and reductive acetylation of the E2 lipoyl group.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: &gt;-
+        The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate
+        (Reaction 2) and the reductive acetylation of a lipoyl group
+    - reference_id: PMID:3034892
+      supporting_text: &gt;-
+        the alpha subunit of
+        human pyruvate dehydrogenase (EC 1.2.4.1), the E1 component of the pyruvate
+        dehydrogenase complex
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic assertion that PDHA1 is active in the mitochondrial matrix. This
+      is the established compartment of the PDH complex and is supported by the
+      UniProt subcellular location.
+    action: ACCEPT
+    reason: &gt;-
+      PDHA1 is synthesized with a mitochondrial import leader and functions in the
+      matrix as part of the soluble PDH complex.
+    supported_by:
+    - reference_id: PMID:3034892
+      supporting_text: &gt;-
+        The protein is synthesized with a typical mitochondrial import leader
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic assertion that PDHA1 is involved in pyruvate decarboxylation to
+      acetyl-CoA, the biological process carried out by the PDH complex. Consistent
+      with direct experimental annotations.
+    action: ACCEPT
+    reason: &gt;-
+      This is the core process to which the E1 catalytic activity contributes; the
+      PDH complex converts pyruvate to acetyl-CoA and CO2.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: &gt;-
+        The human pyruvate dehydrogenase complex (PDC) catalyzes the oxidative
+        decarboxylation of pyruvate to produce acetyl-CoA and NADH
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Phylogenetic assertion that PDHA1 is part of the pyruvate dehydrogenase complex.
+      PDHA1 is a constitutive catalytic subunit of the PDC (as the E1 alpha subunit).
+    action: ACCEPT
+    reason: &gt;-
+      PDHA1 forms the E1 heterotetramer with PDHB and is a core component of the
+      multienzyme PDH complex.
+    supported_by:
+    - reference_id: PMID:19240034
+      supporting_text: &gt;-
+        The human pyruvate dehydrogenase complex (PDC) is a 9.5-megadalton
+        catalytic
+        machine that employs three catalytic components, i.e. pyruvate dehydrogenase
+        (E1p)
+- term:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Automated (IEA) assertion of pyruvate dehydrogenase activity, mapped from the
+      EC 1.2.4.1 / RHEA:19189 / InterPro E1alpha signature. Redundant with the IBA
+      and experimental MF annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Correctly captures the enzymatic function via EC/RHEA/InterPro mapping.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;EC=1.2.4.1&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Automated location annotation derived from the UniProt subcellular location
+      controlled vocabulary (mitochondrion matrix, SL-0170).
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the curated UniProt subcellular location and the IBA
+      matrix annotation.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Automated (IEA) assertion of involvement in pyruvate decarboxylation to
+      acetyl-CoA, from the InterPro E1alpha signature. Redundant with the IBA and
+      experimental process annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Correct process for the E1 subunit of the PDH complex.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: &gt;-
+        catalyzes the oxidative decarboxylation of pyruvate to produce acetyl-CoA
+- term:
+    id: GO:0016624
+    label: oxidoreductase activity, acting on the aldehyde or oxo group of donors,
+      disulfide as acceptor
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO mapping to the general oxidoreductase class. This is the parent
+      of the specific, EC-mapped pyruvate dehydrogenase activity (GO:0004739) already
+      annotated to PDHA1, so it is correct but too general.
+    action: MODIFY
+    reason: &gt;-
+      Not wrong, but this broad oxidoreductase class is less informative than the
+      specific EC 1.2.4.1 activity; replace with the specific term already supported
+      experimentally.
+    proposed_replacement_terms:
+    - id: GO:0004739
+      label: pyruvate dehydrogenase (acetyl-transferring) activity
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;EC=1.2.4.1&#34;
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Automated (ARBA) assertion that PDHA1 is part of the pyruvate dehydrogenase
+      complex. Redundant with IBA/IDA complex annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Correct complex assignment for the E1 alpha subunit.
+    supported_by:
+    - reference_id: PMID:19240034
+      supporting_text: &gt;-
+        pyruvate dehydrogenase
+        (E1p)
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12651851
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI capturing the physical interaction of PDHA1 with PDHB (UniProtKB:P11177),
+      derived from the human E1 crystal structure. This is the genuine intra-E1
+      alpha-beta subunit contact, but the bare &#34;protein binding&#34; term is uninformative;
+      the biologically meaningful assertion (PDHA1 as part of the E1 heterotetramer /
+      PDH complex) is already captured by GO:0045254.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Real experimental interaction (E1alpha-E1beta), but GO:0005515 conveys no
+      specific function; retain as non-core evidence rather than a core annotation.
+      Per curation policy, an experimental IPI is not removed.
+    supported_by:
+    - reference_id: PMID:12651851
+      supporting_text: &gt;-
+        In
+        alpha2beta2-heterotetrameric human pyruvate dehydrogenase
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:29128334
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI from a large-scale human mitochondrial protein interaction map
+      (interactors PDHB/P11177 and IMMT/Q16891). Bare &#34;protein binding&#34; is
+      uninformative; PDHB interaction is already captured by complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput interaction evidence; the informative content (PDH complex
+      membership) is captured elsewhere. Not removed per policy for experimental IPI.
+    supported_by:
+    - reference_id: PMID:29128334
+      supporting_text: A Map of Human Mitochondrial Protein Interactions
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:29568061
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI (interactor PDK1/Q15118) from a MAC-tag AP-MS/BioID interaction and
+      localization mapping study. The PDK1 contact is consistent with the known
+      regulation of E1alpha by PDK-family kinases, but &#34;protein binding&#34; itself is
+      uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Proximity/AP-MS-derived interaction; biologically the regulatory PDK contact,
+      but a bare protein-binding term is not a useful function annotation.
+    supported_by:
+    - reference_id: PMID:29568061
+      supporting_text: comprehensive mapping of protein
+        interactions and subcellular localizations
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI (interactor PDHB/P11177) from a proteome-scale interactome study
+      (BioPlex). Bare &#34;protein binding&#34;; the PDHB interaction is captured by complex
+      membership.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Large-scale interactome evidence; uninformative MF term. Not removed per policy.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: Dual proteome-scale networks reveal cell-specific remodeling
+        of the human
+        interactome
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35156780
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI (interactor CFTR/P13569) from a mammalian membrane two-hybrid
+      CFTR-interactome screen. A CFTR-PDHA1 contact from a high-throughput screen is
+      of uncertain physiological relevance and the term is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput screen against CFTR; bare protein-binding term with no clear
+      functional meaning for PDHA1. Not removed (experimental IPI).
+    supported_by:
+    - reference_id: PMID:35156780
+      supporting_text: CFTR interactome mapping using the mammalian membrane two-hybrid
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:36012204
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI (interactor CFTR/P13569) from a differential CFTR proximity-labeling
+      study. As above, high-throughput CFTR-proximity evidence; uninformative MF term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Proximity-labeling screen; not a core PDHA1 function and the term is
+      uninformative. Not removed per policy.
+    supported_by:
+    - reference_id: PMID:36012204
+      supporting_text: Differential CFTR-Interactome Proximity Labeling Procedures
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:7782287
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI (interactor PDK1/Q15118) linked to the mutagenesis study of the
+      E1alpha phosphorylation sites. Reflects the physiologically important
+      E1alpha-PDK interaction (PDK phosphorylates and inactivates E1), but the bare
+      &#34;protein binding&#34; term is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Real regulatory interaction (E1alpha is the PDK substrate), but captured better
+      as regulation/phosphorylation than as generic protein binding.
+    supported_by:
+    - reference_id: PMID:7782287
+      supporting_text: &gt;-
+        regulated by
+        phosphorylation-dephosphorylation, catalyzed by the E1-kinase
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Automated (IEA) mitochondrion localization. Correct but less specific than the
+      mitochondrial matrix annotations.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct compartment; parent of the more specific matrix location that better
+      represents PDHA1.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0032991
+    label: protein-containing complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Automated (Ensembl Compara) generic protein-containing complex membership. This
+      is uninformative given that the specific complex (pyruvate dehydrogenase complex,
+      GO:0045254) is already annotated.
+    action: MODIFY
+    reason: &gt;-
+      Too general; PDHA1&#39;s complex is specifically the pyruvate dehydrogenase complex.
+    proposed_replacement_terms:
+    - id: GO:0045254
+      label: pyruvate dehydrogenase complex
+    supported_by:
+    - reference_id: PMID:19240034
+      supporting_text: &gt;-
+        pyruvate dehydrogenase
+        (E1p)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: NAS
+  original_reference_id: PMID:24534072
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Non-traceable-author-statement mitochondrion localization from ComplexPortal,
+      based on the PDC being a mitochondrial enzyme. Correct but less specific than
+      matrix.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct compartment (the mammalian PDC is a mitochondrial enzyme); matrix is
+      the more precise location.
+    supported_by:
+    - reference_id: PMID:24534072
+      supporting_text: &gt;-
+        The mammalian pyruvate dehydrogenase complex (PDC) is a multi-component
+        mitochondrial enzyme
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IDA
+  original_reference_id: PMID:19081061
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) annotation from the human E1p structure/kinetics study
+      showing PDHA1&#39;s role in converting pyruvate to acetyl-CoA within the PDH complex.
+    action: ACCEPT
+    reason: &gt;-
+      Strong experimental support for the core process; the study measures the overall
+      PDC reaction and E1p decarboxylation/reductive acetylation activities.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: &gt;-
+        catalyzes the oxidative decarboxylation of pyruvate to produce acetyl-CoA
+        and NADH
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IDA
+  original_reference_id: PMID:24534072
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) annotation from the recombinant human PDC that
+      produced a functional, active complex, confirming PDHA1&#39;s role in the
+      pyruvate-to-acetyl-CoA process.
+    action: ACCEPT
+    reason: &gt;-
+      Functional reconstituted PDC demonstrates the process; supports the core role.
+    supported_by:
+    - reference_id: PMID:24534072
+      supporting_text: &gt;-
+        conversion of pyruvate to
+        acetyl-CoA connecting glycolysis to the citric acid cycle
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IDA
+  original_reference_id: PMID:19081061
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct experimental complex-membership annotation for PDHA1 as the E1 alpha
+      subunit of the PDC, from the human E1p structural study.
+    action: ACCEPT
+    reason: &gt;-
+      PDHA1 is experimentally established as part of the PDH complex (E1 heterotetramer).
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: &gt;-
+        Phosphorylation of the heterotetrameric (α2β2) E1p component
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IPI
+  original_reference_id: PMID:19240034
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ComplexPortal IPI complex-membership annotation from the study defining the
+      subunit stoichiometry of the reconstituted human PDC, in which PDHA1 (as E1p
+      heterotetramer) associates with the E2p/E3BP core.
+    action: ACCEPT
+    reason: &gt;-
+      Establishes PDHA1 as part of the assembled PDH complex.
+    supported_by:
+    - reference_id: PMID:19240034
+      supporting_text: &gt;-
+        40
+        copies of E1p heterotetramers and 20 copies of E3 dimers associated with the
+        E2p/E3BP core
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Immunofluorescence-based (Human Protein Atlas) mitochondrion localization.
+      Correct compartment; less specific than matrix.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent mitochondrial localization; matrix is the more precise sub-compartment.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  evidence_type: EXP
+  original_reference_id: PMID:17474719
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (EXP) annotation of pyruvate dehydrogenase activity based on
+      kinetic characterization of human E1 (wild-type and S264-phosphorylation variant),
+      demonstrating pyruvate decarboxylation and reductive acetylation of E2.
+    action: ACCEPT
+    reason: &gt;-
+      This is the strongest, most direct experimental evidence for the core molecular
+      function of PDHA1.
+    supported_by:
+    - reference_id: PMID:17474719
+      supporting_text: &gt;-
+        the
+        pyruvate dehydrogenase multienzyme complex (PDHc) catalyzes the oxidative
+        decarboxylation of pyruvate to acetyl-CoA
+- term:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  evidence_type: EXP
+  original_reference_id: PMID:7782287
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental (EXP) annotation of pyruvate dehydrogenase activity from
+      site-directed mutagenesis of recombinant human E1 phosphorylation sites,
+      measuring E1 specific activity and Km for TPP and pyruvate.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental measurement of E1 catalytic activity on the human protein supports
+      the core molecular function.
+    supported_by:
+    - reference_id: PMID:7782287
+      supporting_text: &gt;-
+        Mutation at site 1 but not at sites 2 and/or 3 decreased E1 specific activity
+        and also increased Km values for thiamin pyrophosphate and pyruvate
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Sequence-similarity-based (ISS) transfer of the mitochondrial matrix location
+      from an ortholog. Consistent with the curated matrix location.
+    action: ACCEPT
+    reason: &gt;-
+      Correct compartment for PDHA1, matching UniProt and the IBA annotation.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Sequence-similarity-based (ISS) transfer of mitochondrion (is_active_in) from an
+      ortholog. Correct but less specific than matrix.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct compartment; matrix is the more precise location where PDHA1 is active.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomics (HTP) mitochondrion localization from a quantitative
+      high-confidence human mitochondrial proteome (MitoCoP). Supports mitochondrial
+      residence; less specific than matrix.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent with mitochondrial localization; parent of the matrix location.
+    supported_by:
+    - reference_id: PMID:34800366
+      supporting_text: &gt;-
+        mitochondrial high-confidence proteome of &gt;1,100 proteins (MitoCoP)
+- term:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  evidence_type: IDA
+  original_reference_id: PMID:19081061
+  qualifier: contributes_to
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) annotation with the contributes_to qualifier: PDHA1
+      contributes the E1 catalytic activity to the pyruvate dehydrogenase activity of
+      the multi-subunit complex. The contributes_to qualifier is appropriate because
+      the full activity requires the heterotetramer and the assembled PDC.
+    action: ACCEPT
+    reason: &gt;-
+      Correct use of contributes_to for a subunit whose activity is realized in the
+      context of the E1 heterotetramer / PDH complex.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: &gt;-
+        The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-203946
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS matrix localization associated with the PDK phosphorylation reaction
+      of the PDHC E1 subunit. Correct compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Reactome places the PDH E1 subunit and its phospho-regulation in the mitochondrial
+      matrix, consistent with all other evidence.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-204169
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS matrix localization associated with the PDP1/2 dephosphorylation
+      reaction of phospho-lipo-PDH. Correct compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent matrix localization for the reversibly phospho-regulated PDH E1 subunit.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9838035
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS matrix localization associated with the CLPXP protease binding
+      mitochondrial matrix proteins reaction (PDHA1 as a matrix substrate). Location
+      correct.
+    action: ACCEPT
+    reason: &gt;-
+      PDHA1 is a mitochondrial matrix protein; the annotation reflects its residence in
+      the matrix (here as a CLPXP substrate).
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9838289
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS matrix localization associated with the CLPXP degradation of
+      mitochondrial matrix proteins reaction. Location correct.
+    action: ACCEPT
+    reason: &gt;-
+      Reflects PDHA1&#39;s matrix residence (as a substrate of matrix quality-control
+      proteolysis); the location is correct.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861616
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS matrix localization associated with the DLD (E3) dihydrolipoyl
+      dehydrogenation reaction of the PDC. Correct compartment for the PDC.
+    action: ACCEPT
+    reason: &gt;-
+      The PDH complex, including PDHA1, operates in the mitochondrial matrix.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861667
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS matrix localization associated with the DLAT (E2) acetyl transfer to
+      CoA reaction of the PDC. Correct compartment.
+    action: ACCEPT
+    reason: &gt;-
+      The PDC reaction sequence, of which PDHA1 is the E1 component, takes place in the
+      matrix.
+    supported_by:
+    - reference_id: file:human/PDHA1/PDHA1-uniprot.txt
+      supporting_text: &#34;Mitochondrion matrix&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861734
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS matrix localization associated with the reaction in which PDH E1
+      decarboxylates pyruvate and transfers acetyl to DLAT. This is PDHA1&#39;s own
+      catalytic step and it is placed in the mitochondrial matrix.
+    action: ACCEPT
+    reason: &gt;-
+      Directly describes PDHA1&#39;s E1 catalytic reaction occurring in the mitochondrial
+      matrix.
+    supported_by:
+    - reference_id: Reactome:R-HSA-9861734
+      supporting_text: &gt;-
+        The E1 component of the pyruvate dehydrogenase complex (PDC, PDHC) catalyzes
+        the decarboxylation of pyruvate (PYR) with subsequent transfer of acetyl to the
+        E2 subunit (DLAT)
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: HDA
+  original_reference_id: PMID:21630459
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomic detection of PDHA1 in an isolated human sperm nucleus
+      preparation. This does not establish a nuclear function or a physiological nuclear
+      localization for the somatic E1alpha, which is an established mitochondrial matrix
+      protein; it likely reflects the specialized sperm proteome and/or preparation
+      carry-over.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Single high-throughput proteomic dataset in a specialized cell type; not
+      corroborated as a functional nuclear localization. The compartment of any
+      non-mitochondrial pool is unresolved. Retained (experimental HDA) but flagged as
+      over-annotation, not core.
+    supported_by:
+    - reference_id: PMID:21630459
+      supporting_text: &gt;-
+        sperm nuclei were obtained
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HDA
+  original_reference_id: PMID:20833797
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomic detection of PDHA1 in mitochondria isolated from human
+      skeletal muscle (a mitochondrial phosphoproteome). Supports mitochondrial
+      residence; less specific than matrix.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Consistent mitochondrial localization; parent of the matrix location.
+    supported_by:
+    - reference_id: PMID:20833797
+      supporting_text: &gt;-
+        mitochondria isolated from resting human
+        muscle
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: TAS
+  original_reference_id: PMID:3034892
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Traceable-author-statement mitochondrion localization from the original human
+      E1alpha cDNA characterization, which established the mitochondrial import leader
+      and matrix maturation of the protein.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct compartment; the same study establishes mitochondrial import, and matrix
+      is the precise location.
+    supported_by:
+    - reference_id: PMID:3034892
+      supporting_text: &gt;-
+        The protein is synthesized with a typical mitochondrial import leader
+core_functions:
+- description: &gt;-
+    Thiamine-pyrophosphate (TPP)- and Mg2+-dependent E1 alpha subunit of the pyruvate
+    dehydrogenase complex that, together with PDHB (E1beta), catalyzes the oxidative
+    decarboxylation of pyruvate and the reductive acetylation of the E2 lipoyl group,
+    the committed step converting pyruvate to acetyl-CoA and linking glycolysis to the
+    TCA cycle.
+  molecular_function:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  directly_involved_in:
+  - id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  in_complex:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  supported_by:
+  - reference_id: PMID:19081061
+    supporting_text: &gt;-
+      The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate
+      (Reaction 2) and the reductive acetylation of a lipoyl group
+  - reference_id: PMID:17474719
+    supporting_text: &gt;-
+      the
+      pyruvate dehydrogenase multienzyme complex (PDHc) catalyzes the oxidative
+      decarboxylation of pyruvate to acetyl-CoA
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:12651851
+  title: Structural basis for flip-flop action of thiamin pyrophosphate-dependent
+    enzymes revealed by human pyruvate dehydrogenase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Crystal structure of holo human E1 (alpha2beta2) with Mg2+ and TPP; establishes
+      the TPP/Mg2+ cofactor site and the alpha-beta heterotetramer. Interaction PMID for
+      the PDHA1-PDHB IntAct entry.
+- id: PMID:17474719
+  title: Phosphorylation of serine 264 impedes active site accessibility in the E1
+    component of the human pyruvate dehydrogenase multienzyme complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Kinetic + structural study of human E1 and the S264 phospho-variant; supports the
+      EXP pyruvate dehydrogenase activity annotation and phospho-regulation.
+- id: PMID:19081061
+  title: &#39;Structural basis for inactivation of the human pyruvate dehydrogenase complex
+    by phosphorylation: role of disordered phosphorylation loops.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text available; defines the E1p reactions, PDC overall reaction, matrix
+      context, phosphorylation sites, and Km for pyruvate. Primary support for MF/BP/CC
+      core annotations.
+- id: PMID:19240034
+  title: Subunit and catalytic component stoichiometries of an in vitro reconstituted
+    human pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reconstituted human PDC stoichiometry; supports PDHA1 (E1p heterotetramer) as part
+      of the assembled complex.
+- id: PMID:20833797
+  title: Phosphoproteome analysis of functional mitochondria isolated from resting
+    human muscle reveals extensive phosphorylation of inner membrane protein complexes
+    and enzymes.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Mitochondrial phosphoproteome of human muscle; supports mitochondrial localization
+      (HDA) but is high-throughput.
+- id: PMID:21630459
+  title: Proteomic characterization of the human sperm nucleus.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Sperm-nucleus proteome; the PDHA1 nucleus HDA is a single high-throughput
+      detection in a specialized cell type and does not establish a physiological nuclear
+      function for the mitochondrial matrix enzyme.
+- id: PMID:24534072
+  title: Component co-expression and purification of recombinant human pyruvate dehydrogenase
+    complex from baculovirus infected SF9 cells.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Functional recombinant human PDC; supports the pyruvate-to-acetyl-CoA process and
+      mitochondrial-enzyme identity.
+- id: PMID:29128334
+  title: A Map of Human Mitochondrial Protein Interactions Linked to Neurodegeneration
+    Reveals New Mechanisms of Redox Homeostasis and NF-κB Signaling.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale mitochondrial interactome; PDHA1 interactions (PDHB, IMMT) are
+      high-throughput and captured better as complex membership than as protein binding.
+- id: PMID:29568061
+  title: An AP-MS- and BioID-compatible MAC-tag enables comprehensive mapping of protein
+    interactions and subcellular localizations.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      AP-MS/BioID methods paper; PDHA1-PDK1 IntAct entry; high-throughput evidence for a
+      known regulatory contact.
+- id: PMID:3034892
+  title: The human pyruvate dehydrogenase complex. Isolation of cDNA clones for the
+    E1 alpha subunit, sequence analysis, and characterization of the mRNA.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Original human E1alpha cDNA/protein characterization; establishes EC 1.2.4.1
+      identity and mitochondrial import leader / matrix maturation.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale interactome (BioPlex); PDHA1-PDHB IntAct entry; high-throughput.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      MitoCoP high-confidence mitochondrial proteome; supports mitochondrial
+      localization (HTP).
+- id: PMID:35156780
+  title: CFTR interactome mapping using the mammalian membrane two-hybrid high-throughput
+    screening system.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Membrane two-hybrid CFTR screen; PDHA1-CFTR contact of uncertain physiological
+      relevance; uninformative protein-binding annotation.
+- id: PMID:36012204
+  title: Differential CFTR-Interactome Proximity Labeling Procedures Identify Enrichment
+    in Multiple SLC Transporters.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      CFTR proximity-labeling study; PDHA1-CFTR contact; high-throughput, uninformative
+      MF term.
+- id: PMID:7782287
+  title: Mutagenesis studies of the phosphorylation sites of recombinant human pyruvate
+    dehydrogenase. Site-specific regulation.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Mutagenesis of E1alpha phosphorylation sites; supports EXP pyruvate dehydrogenase
+      activity and phospho-regulation; also the PDHA1-PDK1 IntAct entry.
+- id: Reactome:R-HSA-203946
+  title: PDK isozymes phosphorylate PDHC subunit E1
+  findings: []
+- id: Reactome:R-HSA-204169
+  title: PDP1,2 dephosphorylate p-lipo-PDH
+  findings: []
+- id: Reactome:R-HSA-9838035
+  title: CLPXP binds mitochondrial matrix proteins
+  findings: []
+- id: Reactome:R-HSA-9838289
+  title: CLPXP degrades mitochondrial matrix proteins
+  findings: []
+- id: Reactome:R-HSA-9861616
+  title: DLD dimer dehydrogenates dihydrolipoyl
+  findings: []
+- id: Reactome:R-HSA-9861667
+  title: DLAT trimer transfers acetyl to CoA
+  findings: []
+- id: Reactome:R-HSA-9861734
+  title: PDH E1 decarboxylates PYR, transferring acetyl to DLAT
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PDHB/PDHB-ai-review.html
+++ b/genes/human/PDHB/PDHB-ai-review.html
@@ -1,0 +1,5236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PDHB - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PDHB</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P11177" target="_blank" class="term-link">
+                        P11177
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PDHB";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P11177" data-a="DESCRIPTION: PDHB encodes the beta subunit (E1beta) of the E1 (..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PDHB encodes the beta subunit (E1beta) of the E1 (pyruvate dehydrogenase) component of the mitochondrial pyruvate dehydrogenase complex (PDC). Together with PDHA1 (E1alpha) it forms the alpha2-beta2 heterotetrameric E1, a thiamine diphosphate (TPP)-dependent enzyme (EC 1.2.4.1) that catalyses the committed, oxidative decarboxylation of pyruvate and the reductive acetylation of the lipoyl group carried by the E2 (DLAT) core, the first two steps of the overall conversion of pyruvate to acetyl-CoA and CO2. Within the intact PDC the E1 heterotetramer, together with dihydrolipoamide acetyltransferase (E2/DLAT) and dihydrolipoamide dehydrogenase (E3/DLD) assembled on a dodecahedral E2/E3BP core, links cytosolic glycolysis to the mitochondrial tricarboxylic acid cycle and to fatty-acid biosynthesis. PDHB is a nuclear-encoded protein targeted to the mitochondrial matrix via a cleaved N-terminal transit peptide. Loss-of-function variants in PDHB cause the autosomal-recessive pyruvate dehydrogenase E1-beta deficiency (PDHBD), a form of PDC deficiency presenting with primary lactic acidosis, developmental delay, hypotonia, and neurological disease.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0006086" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PDHB, as the E1beta subunit of the PDC, participates in the oxidative decarboxylation of pyruvate to acetyl-CoA. This phylogenetically-inferred BP annotation is well supported by orthology, structural biology, and disease evidence, and represents a core biological process for the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and appropriately specific process term for the E1beta subunit of the PDC; consistent with experimental annotations to the same term and with the UniProt-curated function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human pyruvate dehydrogenase complex (PDC) catalyzes the oxidative decarboxylation of pyruvate to produce acetyl-CoA and NADH</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0045254" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PDHB is a structural component (E1beta) of the pyruvate dehydrogenase complex. This is a core, experimentally-corroborated cellular component annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHB is one of the two E1 subunits (alpha2-beta2) of the PDC; part_of the pyruvate dehydrogenase complex is the correct and specific component term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                                    GO:0004739
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase (acetyl-transferring) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0004739" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assertion of the E1 catalytic activity (EC 1.2.4.1; RHEA 19189), the defining molecular function of PDHB acting within the E1 heterotetramer. Corroborated by experimental IDA/TAS annotations to the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct molecular function mapping (InterPro IPR027110, EC 1.2.4.1, RHEA 19189). The activity is a property of the alpha2-beta2 heterotetramer to which PDHB contributes; core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PDHB localizes to the mitochondrial matrix, mapped from the UniProt Subcellular Location vocabulary. This is the correct, specific compartment for the PDC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matches the curated UniProt subcellular location (Mitochondrion matrix) and the PDC&#39;s known compartment; more specific than the bare mitochondrion annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0006086" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assertion (ARBA/InterPro/ortholog) of the core PDC process. Duplicate of the IBA/IDA annotations to the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core process term; consistent with the experimental and phylogenetic annotations to GO:0006086.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human pyruvate dehydrogenase complex (PDC) catalyzes the oxidative decarboxylation of pyruvate to produce acetyl-CoA and NADH</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12651851" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12651851
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for flip-flop action of thiamin pyrophospha...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005515" data-r="PMID:12651851" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI capturing the E1beta-E1alpha (PDHB-PDHA1, WITH UniProtKB P08559) interaction from the crystal structure of the alpha2-beta2 heterotetrameric human E1. The interaction is real and central (E1 heterotetramer assembly), but the term &#34;protein binding&#34; is uninformative; the functional content is better captured by the pyruvate dehydrogenase complex / E1 heterotetramer terms and by core_functions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental interaction with the E1alpha partner is genuine, so it is retained rather than removed; however bare GO:0005515 conveys no specific function and is redundant with the complex/heterotetramer annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12651851" target="_blank" class="term-link">
+                                        PMID:12651851
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">alpha2beta2-heterotetrameric human pyruvate dehydrogenase, this cofactor is used</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18206651" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18206651
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Binding of pyruvate dehydrogenase to the core of the human p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005515" data-r="PMID:18206651" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI for the E1beta-E2 (PDHB-DLAT, WITH UniProtKB P10515) interaction; this study scanned the E1beta C-terminal surface for residues binding the E2 (DLAT) core. The interaction is biologically meaningful (E1 docking onto the E2 core) but the GO term itself is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained because it reflects a real, characterized E1beta-E2 docking interaction, but bare protein binding is uninformative and better captured by the complex/core_functions annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18206651" target="_blank" class="term-link">
+                                        PMID:18206651
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The C-terminal surface of the E1beta subunit was scanned for the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29128334" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29128334
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A Map of Human Mitochondrial Protein Interactions Linked to ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005515" data-r="PMID:29128334" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (WITH UniProtKB P08559, PDHA1) from a large-scale mitochondrial protein-interaction map. Captures the PDHB-PDHA1 (E1 heterotetramer) interaction; the term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real interaction with the E1alpha partner, but bare protein binding adds no specific functional information beyond the complex annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29128334" target="_blank" class="term-link">
+                                        PMID:29128334
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A Map of Human Mitochondrial Protein Interactions Linked to Neurodegeneration</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI (WITH PDHA1 P08559 and DLAT P10515) from a proteome-scale interactome (BioPlex). Recovers the physiological E1alpha and E2 partners; the GO term itself is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Interactions with the known PDC partners are genuine, but bare protein binding provides no specific function beyond the complex/core annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24534072
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Component co-expression and purification of recombinant huma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005739" data-r="PMID:24534072" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS for mitochondrial localization, consistent with the PDC being a mitochondrial matrix enzyme. Correct but less specific than the mitochondrial matrix annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The broader mitochondrion term is correct but superseded by the more specific GO:0005759 mitochondrial matrix; retained as non-core supporting localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                                        PMID:24534072
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">plays a key role in the conversion of pyruvate to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19081061
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for inactivation of the human pyruvate dehy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0006086" data-r="PMID:19081061" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (ComplexPortal IDA) annotation to the core PDC process, from the crystallographic/functional analysis of the human E1 component. Core biological process for PDHB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strongly supported experimental annotation to the correct, specific process term; the paper directly characterizes E1-catalysed decarboxylation of pyruvate within the PDC.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24534072
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Component co-expression and purification of recombinant huma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0006086" data-r="PMID:24534072" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IDA to the core PDC process, based on recombinant human PDC (co-expressed components) shown to be functional in a pyruvate-to-acetyl-CoA assay. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental support for PDHB&#39;s participation in the conversion of pyruvate to acetyl-CoA within a reconstituted functional human PDC; correct and specific process term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                                        PMID:24534072
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">plays a key role in the conversion of pyruvate to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19081061
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for inactivation of the human pyruvate dehy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0045254" data-r="PMID:19081061" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (ComplexPortal IDA) evidence that PDHB is part of the pyruvate dehydrogenase complex, from structural analysis of the human E1 component. Core cellular component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHB (E1beta) is unambiguously part of the PDC; correct, specific component term with direct experimental support.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19240034
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subunit and catalytic component stoichiometries of an in vit...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0045254" data-r="PMID:19240034" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IPI (part_of PDC) from a study defining the subunit and catalytic-component stoichiometries of an in vitro reconstituted human PDC (40 E2p, 20 E3BP, 40 E1p, 20 E3). Confirms PDHB&#39;s incorporation into the assembled complex. Core cellular component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly demonstrates that E1 (of which PDHB is the beta subunit) is a stoichiometric component of the assembled human PDC; correct, specific term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human pyruvate dehydrogenase complex (PDC) is a 9.5-megadalton catalytic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HPA immunofluorescence IDA localizing PDHB to mitochondria. Correct but broader than the mitochondrial matrix annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the curated matrix localization; kept as non-core supporting evidence, superseded in specificity by GO:0005759.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    GO_REF:0000052
+
+                                </span>
+
+                                <div class="support-text">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity (ISS, WITH UniProtKB P26284, pig ortholog) transfer of mitochondrial matrix localization. Correct and specific; consistent with the curated UniProt location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The matrix location is well established for the PDC; ISS transfer from a characterized mammalian ortholog is appropriate and specific.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                                    GO:0004739
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase (acetyl-transferring) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18164639" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18164639
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations of the E1beta subunit gene (PDHB) in four families...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0004739" data-r="PMID:18164639" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI IDA (contributes_to) for E1 activity, from a study of PDHB mutations in PDC-deficient patients diagnosed by low PDC activity. The contributes_to qualifier correctly reflects that the acetyl-transferring activity is a property of the alpha2-beta2 heterotetramer to which PDHB contributes. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Loss-of-function PDHB variants reduce PDC (E1) activity, directly linking PDHB to the catalytic activity; contributes_to is the appropriate qualifier for a subunit of a multi-subunit enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18164639" target="_blank" class="term-link">
+                                        PMID:18164639
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All cases were diagnosed by low PDC activity, with normal E2 and E3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18164639" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18164639
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations of the E1beta subunit gene (PDHB) in four families...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0006086" data-r="PMID:18164639" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI IC (inferred from the GO:0004739 activity annotation) placing PDHB upstream of/within the pyruvate-to-acetyl-CoA process. Core process; consistent with the disease evidence that PDHB defects impair PDC flux.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reasonable curator inference from the E1 activity annotation; the process term is correct and central to PDHB function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18164639" target="_blank" class="term-link">
+                                        PMID:18164639
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">found four cases of PDHB mutations among 83 analyzed cases of PDC deficiency</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2295468" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2295468
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Isolation of tryptic fragment of antigen from mitochondrial ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005739" data-r="PMID:2295468" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt IDA (is_active_in mitochondrion). This is the paper from which UniProt curated direct protein sequencing of the mature PDHB N-terminus (residues 31-55); PDHB is a mitochondrial matrix enzyme, so is_active_in mitochondrion is appropriate. The abstract foregrounds an E2 subunit-binding domain, but the curator used the full data (direct PDHB protein sequence).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment but broader than the specific matrix location; retained as non-core. Not removed - this is an experimental annotation whose full data (direct protein sequencing of PDHB) was seen by the UniProt curator.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2295468" target="_blank" class="term-link">
+                                        PMID:2295468
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the subunit binding domain of the pyruvate dehydrogenase complex E2 from bovine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005739" data-r="PMID:34800366" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteome evidence for mitochondrial localization of PDHB. Correct but broader than the matrix annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the known matrix localization; retained as non-core supporting evidence, less specific than GO:0005759.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                                        PMID:34800366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Quantitative high-confidence human mitochondrial proteome and its dynamics</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                                    GO:0004739
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase (acetyl-transferring) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19081061
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for inactivation of the human pyruvate dehy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0004739" data-r="PMID:19081061" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt IDA (contributes_to) for the E1 catalytic activity, from the crystallographic/functional study of the human E1 component; the E1 subunit catalyses TPP-dependent decarboxylation of pyruvate and reductive acetylation of the E2 lipoyl group. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental characterization of E1 catalysis; contributes_to correctly reflects PDHB as one subunit of the catalytic alpha2-beta2 E1 heterotetramer.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reductive acetylation of a lipoyl group</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21630459
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteomic characterization of the human sperm nucleus.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005634" data-r="PMID:21630459" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Single high-throughput hit from a human sperm-nucleus proteomics dataset (403 proteins identified). PDHB is a mitochondrial matrix enzyme; a nuclear assignment for this TPP-dependent PDC subunit is best explained as a large-scale dataset contaminant/over-annotation rather than a genuine nuclear function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No mechanistic or corroborating evidence for a nuclear role of PDHB; inconsistent with its established mitochondrial-matrix localization and PDC function. Flagged as over-annotation of a proteomics screen rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
+                                        PMID:21630459
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">different proteins have been identified from the isolated sperm nuclei</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-203946
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="Reactome:R-HSA-203946" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing PDHB in the mitochondrial matrix, in the context of PDK phosphorylation of the PDC E1 subunit. Correct, specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct matrix localization consistent with the curated UniProt location and the PDC&#39;s compartment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-204169
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="Reactome:R-HSA-204169" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing PDHB in the mitochondrial matrix, in the context of PDP1/2 dephosphorylation of the PDC. Correct, specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct matrix localization; consistent with the curated location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9838035
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="Reactome:R-HSA-9838035" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for mitochondrial matrix localization, in a generic matrix-protein context (CLPXP binding matrix proteins). The compartment is correct; the reaction context is generic protein quality control, not PDC function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix localization is correct and consistent with the curated location, even though the source reaction is generic matrix-protein quality control rather than PDC-specific biology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9838081
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="Reactome:R-HSA-9838081" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for mitochondrial matrix localization, in a generic matrix-protein context (LONP1 degrading matrix proteins). Compartment correct; generic quality-control context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct matrix localization consistent with the curated location; source reaction is a generic degradation reaction rather than PDC function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9838093
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="Reactome:R-HSA-9838093" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for mitochondrial matrix localization, in a generic matrix-protein context (LONP1 binding matrix proteins). Compartment correct; generic quality-control context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct matrix localization consistent with the curated location; source reaction is a generic protein-binding/degradation reaction rather than PDC function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9838289
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="Reactome:R-HSA-9838289" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for mitochondrial matrix localization, in a generic matrix-protein context (CLPXP degrading matrix proteins). Compartment correct; generic quality-control context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct matrix localization consistent with the curated location; source reaction is a generic degradation reaction rather than PDC function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861616
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="Reactome:R-HSA-9861616" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for mitochondrial matrix localization, in the context of the PDC reaction cascade (DLD/E3 dehydrogenating dihydrolipoyl). Correct, specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct matrix localization within the PDC catalytic cascade context.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861667
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="Reactome:R-HSA-9861667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for mitochondrial matrix localization, in the context of the PDC reaction cascade (DLAT/E2 transferring acetyl to CoA). Correct, specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct matrix localization within the PDC catalytic cascade context.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the gate-keeper enzyme that strategically links glycolysis to the Krebs cycle and lipogenic pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861734
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0005759" data-r="Reactome:R-HSA-9861734" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for mitochondrial matrix localization, in the context of the PDC E1 reaction itself (PDH E1 decarboxylates pyruvate, transferring acetyl to DLAT). Directly relevant to PDHB function; correct, specific compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct matrix localization in the exact reaction (E1 decarboxylation) that PDHB participates in; strongly relevant.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                        PMID:19081061
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                                    GO:0004739
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase (acetyl-transferring) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2376596" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2376596
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of two cDNA clones for pyruvate dehydrogena...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0004739" data-r="PMID:2376596" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PINC/ProtInc TAS for the E1 acetyl-transferring activity, from the early characterization of human PDH E1beta cDNA. Core molecular function annotation (traceable author statement).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct molecular function for the E1beta subunit; consistent with the experimental IDA annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2376596" target="_blank" class="term-link">
+                                        PMID:2376596
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">beta subunit gene is not a member of a multigene family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006099" target="_blank" class="term-link">
+                                    GO:0006099
+                                </a>
+                            </span>
+                            <span class="term-label">tricarboxylic acid cycle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2376596" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2376596
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of two cDNA clones for pyruvate dehydrogena...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P11177" data-a="GO:0006099" data-r="PMID:2376596" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PINC/ProtInc TAS annotating PDHB to the tricarboxylic acid cycle. The PDC provides acetyl-CoA that feeds the TCA cycle, but the pyruvate-to-acetyl-CoA reaction is the entry step preceding the cycle, not part of the TCA cycle proper. The cited paper concerns E1beta cDNA and a TCA-cycle-deficient fibroblast line.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHB is the gateway feeding acetyl-CoA into the TCA cycle rather than a TCA-cycle enzyme; the more accurate process is pyruvate decarboxylation to acetyl-CoA (GO:0006086). Flagged as over-annotation of the general TCA-cycle term rather than removed, since PDC is metabolically adjacent to the cycle.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    pyruvate decarboxylation to acetyl-CoA
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2376596" target="_blank" class="term-link">
+                                        PMID:2376596
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">one tricarboxylic acid cycle deficient</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As the beta subunit of the E1 (pyruvate dehydrogenase) component, PDHB contributes to the TPP-dependent oxidative decarboxylation of pyruvate and reductive acetylation of the E2 lipoyl group (EC 1.2.4.1), the first, committed step of the pyruvate dehydrogenase complex that converts pyruvate to acetyl-CoA in the mitochondrial matrix.</h3>
+                <span class="vote-buttons" data-g="P11177" data-a="FUNCTION: As the beta subunit of the E1 (pyruvate dehydrogen..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004739" target="_blank" class="term-link">
+                            pyruvate dehydrogenase (acetyl-transferring) activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                pyruvate decarboxylation to acetyl-CoA
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                            pyruvate dehydrogenase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                                PMID:19081061
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The E1p component catalyzes the ThDP-mediated decarboxylation of pyruvate</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18164639" target="_blank" class="term-link">
+                                PMID:18164639
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">All cases were diagnosed by low PDC activity, with normal E2 and E3</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12651851" target="_blank" class="term-link">
+                            PMID:12651851
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for flip-flop action of thiamin pyrophosphate-dependent enzymes revealed by human pyruvate dehydrogenase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18164639" target="_blank" class="term-link">
+                            PMID:18164639
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations of the E1beta subunit gene (PDHB) in four families with pyruvate dehydrogenase deficiency.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18206651" target="_blank" class="term-link">
+                            PMID:18206651
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Binding of pyruvate dehydrogenase to the core of the human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19081061" target="_blank" class="term-link">
+                            PMID:19081061
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for inactivation of the human pyruvate dehydrogenase complex by phosphorylation: role of disordered phosphorylation loops.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                            PMID:19240034
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Subunit and catalytic component stoichiometries of an in vitro reconstituted human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
+                            PMID:21630459
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteomic characterization of the human sperm nucleus.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2295468" target="_blank" class="term-link">
+                            PMID:2295468
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Isolation of tryptic fragment of antigen from mitochondrial inner membrane proteins reacting with antimitochondrial antibody in sera of patients with primary biliary cirrhosis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2376596" target="_blank" class="term-link">
+                            PMID:2376596
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Characterization of two cDNA clones for pyruvate dehydrogenase E1 beta subunit and its regulation in tricarboxylic acid cycle-deficient fibroblast.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                            PMID:24534072
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Component co-expression and purification of recombinant human pyruvate dehydrogenase complex from baculovirus infected SF9 cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29128334" target="_blank" class="term-link">
+                            PMID:29128334
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A Map of Human Mitochondrial Protein Interactions Linked to Neurodegeneration Reveals New Mechanisms of Redox Homeostasis and NF-κB Signaling.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-203946
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDK isozymes phosphorylate PDHC subunit E1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-204169
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDP1,2 dephosphorylate p-lipo-PDH</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9838035
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CLPXP binds mitochondrial matrix proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9838081
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LONP1 degrades mitochondrial matrix proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9838093
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LONP1 binds mitochondrial matrix proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9838289
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CLPXP degrades mitochondrial matrix proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861616
+
+                    </span>
+                </div>
+
+                <div class="reference-title">DLD dimer dehydrogenates dihydrolipoyl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861667
+
+                    </span>
+                </div>
+
+                <div class="reference-title">DLAT trimer transfers acetyl to CoA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861734
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDH E1 decarboxylates PYR, transferring acetyl to DLAT</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the E1beta subunit contribute any catalytic residues to the E1 active site, or is its role primarily structural (heterotetramer assembly, K+/TPP binding, and E2 docking)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P11177" data-a="Q: Does the E1beta subunit contribute any catalytic r..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the functional consequence of the alternatively spliced isoforms (P11177-2 lacking residues 16-33 in the transit peptide; P11177-3 lacking residues 135-152) on mitochondrial import and PDC assembly?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P11177" data-a="Q: What is the functional consequence of the alternat..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute PDC E1 activity with recombinant PDHA1 plus wild-type versus PDHBD-variant PDHB (e.g. Y132C, C306R, D319V) and quantify each variant&#39;s effect on pyruvate decarboxylase activity, overall multienzyme PDC activity, and E1-E2 docking.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PDHBD variants impair PDC activity through distinct mechanisms (heterotetramer destabilization versus loss of E1-E2 docking) rather than a single shared mechanism.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P11177" data-a="EXPERIMENT: Reconstitute PDC E1 activity with recombinant PDHA..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform structural and kinetic analysis of the E1beta C-terminal E2-docking surface (e.g. D319 mutants) to dissect its contribution to complex assembly versus intrinsic E1 catalysis.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The E1beta C-terminal surface is required for docking E1 onto the E2 core but is dispensable for intrinsic pyruvate decarboxylase activity.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P11177" data-a="EXPERIMENT: Perform structural and kinetic analysis of the E1b..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PDHB-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P11177" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pdhb-human-review-notes">PDHB (human) review notes</h1>
+<p>UniProtKB:P11177 — Pyruvate dehydrogenase E1 component subunit beta, mitochondrial (ODPB_HUMAN).<br />
+Gene HGNC:8808 (PDHB; synonym PHE1B). EC 1.2.4.1.</p>
+<p>Deep research: <code>PDHB-deep-research-falcon.md</code> did not appear within the 8-min poll window;<br />
+review grounded in the UniProtKB entry, the seeded GOA TSV, the PDC-deficiency disorder KB<br />
+(<code>~/repos/dismech/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml</code>), and the cached<br />
+<code>publications/PMID_*.md</code>. NEVER fabricated a <code>-deep-research-*.md</code>.</p>
+<h2 id="verified-biology">Verified biology</h2>
+<ul>
+<li>PDHB is the <strong>E1 beta</strong> subunit. Together with PDHA1 (E1alpha) it forms the<br />
+  heterotetrameric (alpha2-beta2) E1 component of the mitochondrial pyruvate dehydrogenase<br />
+  complex (PDC). [UniProt FUNCTION: "Together with PDHA1 forms the heterotetrameric E1 subunit<br />
+  of the pyruvate dehydrogenase (PDH) complex"; SUBUNIT: "Heterotetramer of two PDHA1 and two<br />
+  PDHB subunits"].</li>
+<li>E1 catalyses the TPP (thiamine diphosphate)-dependent oxidative decarboxylation of pyruvate<br />
+  and the reductive acetylation of the E2 lipoyl group. EC 1.2.4.1; Rhea:19189.<br />
+  [PMID:19081061 full text: "The E1p component catalyzes the ThDP-mediated decarboxylation of<br />
+  pyruvate ... and the reductive acetylation of a lipoyl group"].</li>
+<li>Structure: alpha2beta2 heterotetramer; TPP-dependent; K+ structural sites in E1beta.<br />
+  [PMID:12651851 abstract: "In alpha2beta2-heterotetrameric human pyruvate dehydrogenase, this<br />
+  cofactor is used to cleave the Calpha-C(=O) bond of pyruvate followed by reductive acetyl<br />
+  transfer to lipoyl-dihydrolipoamide acetyltransferase"; crystal structure 1.95 A holo-form].</li>
+<li>Subcellular location: mitochondrial matrix. [UniProt SUBCELLULAR LOCATION: Mitochondrion<br />
+  matrix]. E1 heterotetramer binds the E2 (DLAT) core.</li>
+<li>The whole PDC links glycolysis to the TCA cycle (gateway/committed step, pyruvate -&gt;<br />
+  acetyl-CoA + CO2). [PMID:19081061: "the gate-keeper enzyme that strategically links<br />
+  glycolysis to the Krebs cycle and lipogenic pathways"].</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>PDHB variants cause <strong>pyruvate dehydrogenase E1-beta deficiency (PDHBD, MIM 614111;<br />
+  MONDO:0013580; ORPHA:255138)</strong>, an autosomal-recessive PDC-deficiency subtype (~10% as<br />
+  frequent as PDHA1) presenting with primary lactic acidosis, developmental delay, hypotonia.<br />
+  [PMID:18164639 abstract: "We have found four cases of PDHB mutations among 83 analyzed cases<br />
+  of PDC deficiency ... All cases were diagnosed by low PDC activity, with normal E2 and E3<br />
+  activities"]. Disorder KB: PDHB → MONDO:0013580, autosomal recessive.</li>
+</ul>
+<h2 id="annotation-notes-decisions">Annotation notes / decisions</h2>
+<ul>
+<li><strong>Core MF</strong>: GO:0004739 pyruvate dehydrogenase (acetyl-transferring) activity — verified<br />
+  (EC 1.2.4.1; Rhea:19189; UniProt CATALYTIC ACTIVITY from PubMed:19081061). Note the<br />
+<code>contributes_to</code> qualifier on IDA lines (18164639, 19081061) is correct: E1 activity is a<br />
+  property of the alpha2beta2 heterotetramer, to which PDHB contributes; TAS line (2376596)<br />
+  uses <code>enables</code>.</li>
+<li><strong>Core BP</strong>: GO:0006086 pyruvate decarboxylation to acetyl-CoA — verified (multiple IDA/IBA).</li>
+<li><strong>Core CC</strong>: GO:0045254 pyruvate dehydrogenase complex (part_of) and GO:0005759<br />
+  mitochondrial matrix — verified.</li>
+<li><strong>GO:0006099 tricarboxylic acid cycle (TAS, PMID:2376596)</strong>: PDC feeds the TCA cycle but is<br />
+  not itself part of the TCA cycle; keep as non-core (PDC is the entry gateway, upstream of the<br />
+  cycle proper). The cited paper is about E1beta cDNA and TCA-cycle-deficient fibroblasts.</li>
+<li><strong>GO:0005515 protein binding (IPI x4)</strong>: bare <code>protein binding</code> — do NOT remove experimental<br />
+  IPIs (policy). WITH/FROM shows biologically meaningful partners: PDHA1 (P08559; the E1<br />
+  heterotetramer partner) in 12651851, 29128334, 33961781; DLAT (P10515; the E2 core) in<br />
+  18206651 and 33961781. Mark as over-annotated (uninformative term) but note the real<br />
+  interactions are captured by the complex/heterotetramer terms and core_functions.</li>
+<li><strong>GO:0005634 nucleus (HDA, PMID:21630459)</strong>: single sperm-nucleus proteomics hit; a<br />
+  mitochondrial matrix enzyme. Contaminant/over-annotation of a large-scale dataset — MARK_AS_OVER_ANNOTATED.</li>
+<li><strong>GO:0005739 mitochondrion (multiple)</strong>: correct but less specific than mitochondrial matrix;<br />
+  keep, non-core / accept the broader localization.</li>
+<li>Reactome TAS mitochondrial-matrix lines (R-HSA-*): correct localization; several are generic<br />
+  matrix-protein degradation reactions (LONP1/CLPXP) rather than PDC function — accept as<br />
+  location evidence, non-core for the degradation-reaction ones.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P11177
+gene_symbol: PDHB
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PDHB encodes the beta subunit (E1beta) of the E1 (pyruvate dehydrogenase)
+  component of the mitochondrial pyruvate dehydrogenase complex (PDC). Together with
+  PDHA1 (E1alpha) it forms the alpha2-beta2 heterotetrameric E1, a thiamine
+  diphosphate (TPP)-dependent enzyme (EC 1.2.4.1) that catalyses the committed,
+  oxidative decarboxylation of pyruvate and the reductive acetylation of the lipoyl
+  group carried by the E2 (DLAT) core, the first two steps of the overall conversion
+  of pyruvate to acetyl-CoA and CO2. Within the intact PDC the E1 heterotetramer,
+  together with dihydrolipoamide acetyltransferase (E2/DLAT) and dihydrolipoamide
+  dehydrogenase (E3/DLD) assembled on a dodecahedral E2/E3BP core, links cytosolic
+  glycolysis to the mitochondrial tricarboxylic acid cycle and to fatty-acid
+  biosynthesis. PDHB is a nuclear-encoded protein targeted to the mitochondrial
+  matrix via a cleaved N-terminal transit peptide. Loss-of-function variants in PDHB
+  cause the autosomal-recessive pyruvate dehydrogenase E1-beta deficiency (PDHBD),
+  a form of PDC deficiency presenting with primary lactic acidosis, developmental
+  delay, hypotonia, and neurological disease.
+alternative_products:
+- name: &#39;1&#39;
+  id: P11177-1
+- name: &#39;2&#39;
+  id: P11177-2
+  sequence_note: VSP_012675
+- name: &#39;3&#39;
+  id: P11177-3
+  sequence_note: VSP_043364
+existing_annotations:
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: PDHB, as the E1beta subunit of the PDC, participates in the oxidative
+      decarboxylation of pyruvate to acetyl-CoA. This phylogenetically-inferred BP
+      annotation is well supported by orthology, structural biology, and disease
+      evidence, and represents a core biological process for the gene.
+    action: ACCEPT
+    reason: Correct and appropriately specific process term for the E1beta subunit
+      of the PDC; consistent with experimental annotations to the same term and with
+      the UniProt-curated function.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: The human pyruvate dehydrogenase complex (PDC) catalyzes the
+        oxidative decarboxylation of pyruvate to produce acetyl-CoA and NADH
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: PDHB is a structural component (E1beta) of the pyruvate dehydrogenase
+      complex. This is a core, experimentally-corroborated cellular component
+      annotation.
+    action: ACCEPT
+    reason: PDHB is one of the two E1 subunits (alpha2-beta2) of the PDC; part_of the
+      pyruvate dehydrogenase complex is the correct and specific component term.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: The E1p component catalyzes the ThDP-mediated decarboxylation
+        of pyruvate
+- term:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic assertion of the E1 catalytic activity (EC 1.2.4.1;
+      RHEA 19189), the defining molecular function of PDHB acting within the E1
+      heterotetramer. Corroborated by experimental IDA/TAS annotations to the same
+      term.
+    action: ACCEPT
+    reason: Correct molecular function mapping (InterPro IPR027110, EC 1.2.4.1,
+      RHEA 19189). The activity is a property of the alpha2-beta2 heterotetramer to
+      which PDHB contributes; core function.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: The E1p component catalyzes the ThDP-mediated decarboxylation
+        of pyruvate
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: PDHB localizes to the mitochondrial matrix, mapped from the UniProt
+      Subcellular Location vocabulary. This is the correct, specific compartment for
+      the PDC.
+    action: ACCEPT
+    reason: Matches the curated UniProt subcellular location (Mitochondrion matrix)
+      and the PDC&#39;s known compartment; more specific than the bare mitochondrion
+      annotations.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: the gate-keeper enzyme that strategically links glycolysis to
+        the Krebs cycle and lipogenic pathways
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic assertion (ARBA/InterPro/ortholog) of the core PDC process.
+      Duplicate of the IBA/IDA annotations to the same term.
+    action: ACCEPT
+    reason: Correct core process term; consistent with the experimental and
+      phylogenetic annotations to GO:0006086.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: The human pyruvate dehydrogenase complex (PDC) catalyzes the
+        oxidative decarboxylation of pyruvate to produce acetyl-CoA and NADH
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12651851
+  qualifier: enables
+  review:
+    summary: IntAct IPI capturing the E1beta-E1alpha (PDHB-PDHA1, WITH UniProtKB
+      P08559) interaction from the crystal structure of the alpha2-beta2
+      heterotetrameric human E1. The interaction is real and central (E1
+      heterotetramer assembly), but the term &#34;protein binding&#34; is uninformative; the
+      functional content is better captured by the pyruvate dehydrogenase complex /
+      E1 heterotetramer terms and by core_functions.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Experimental interaction with the E1alpha partner is genuine, so it is
+      retained rather than removed; however bare GO:0005515 conveys no specific
+      function and is redundant with the complex/heterotetramer annotations.
+    supported_by:
+    - reference_id: PMID:12651851
+      supporting_text: alpha2beta2-heterotetrameric human pyruvate dehydrogenase,
+        this cofactor is used
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18206651
+  qualifier: enables
+  review:
+    summary: IntAct IPI for the E1beta-E2 (PDHB-DLAT, WITH UniProtKB P10515)
+      interaction; this study scanned the E1beta C-terminal surface for residues
+      binding the E2 (DLAT) core. The interaction is biologically meaningful (E1
+      docking onto the E2 core) but the GO term itself is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Retained because it reflects a real, characterized E1beta-E2 docking
+      interaction, but bare protein binding is uninformative and better captured by
+      the complex/core_functions annotations.
+    supported_by:
+    - reference_id: PMID:18206651
+      supporting_text: The C-terminal surface of the E1beta subunit was scanned for
+        the
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:29128334
+  qualifier: enables
+  review:
+    summary: IntAct IPI (WITH UniProtKB P08559, PDHA1) from a large-scale
+      mitochondrial protein-interaction map. Captures the PDHB-PDHA1 (E1
+      heterotetramer) interaction; the term is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Real interaction with the E1alpha partner, but bare protein binding adds
+      no specific functional information beyond the complex annotations.
+    supported_by:
+    - reference_id: PMID:29128334
+      supporting_text: A Map of Human Mitochondrial Protein Interactions Linked to
+        Neurodegeneration
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: IntAct IPI (WITH PDHA1 P08559 and DLAT P10515) from a proteome-scale
+      interactome (BioPlex). Recovers the physiological E1alpha and E2 partners; the
+      GO term itself is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Interactions with the known PDC partners are genuine, but bare protein
+      binding provides no specific function beyond the complex/core annotations.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: Dual proteome-scale networks reveal cell-specific remodeling
+        of the human interactome
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: NAS
+  original_reference_id: PMID:24534072
+  qualifier: located_in
+  review:
+    summary: ComplexPortal NAS for mitochondrial localization, consistent with the
+      PDC being a mitochondrial matrix enzyme. Correct but less specific than the
+      mitochondrial matrix annotations.
+    action: KEEP_AS_NON_CORE
+    reason: The broader mitochondrion term is correct but superseded by the more
+      specific GO:0005759 mitochondrial matrix; retained as non-core supporting
+      localization.
+    supported_by:
+    - reference_id: PMID:24534072
+      supporting_text: plays a key role in the conversion of pyruvate to
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IDA
+  original_reference_id: PMID:19081061
+  qualifier: involved_in
+  review:
+    summary: Direct experimental (ComplexPortal IDA) annotation to the core PDC
+      process, from the crystallographic/functional analysis of the human E1
+      component. Core biological process for PDHB.
+    action: ACCEPT
+    reason: Strongly supported experimental annotation to the correct, specific
+      process term; the paper directly characterizes E1-catalysed decarboxylation of
+      pyruvate within the PDC.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: The E1p component catalyzes the ThDP-mediated decarboxylation
+        of pyruvate
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IDA
+  original_reference_id: PMID:24534072
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal IDA to the core PDC process, based on recombinant human
+      PDC (co-expressed components) shown to be functional in a pyruvate-to-acetyl-CoA
+      assay. Core biological process.
+    action: ACCEPT
+    reason: Experimental support for PDHB&#39;s participation in the conversion of
+      pyruvate to acetyl-CoA within a reconstituted functional human PDC; correct and
+      specific process term.
+    supported_by:
+    - reference_id: PMID:24534072
+      supporting_text: plays a key role in the conversion of pyruvate to
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IDA
+  original_reference_id: PMID:19081061
+  qualifier: part_of
+  review:
+    summary: Direct experimental (ComplexPortal IDA) evidence that PDHB is part of
+      the pyruvate dehydrogenase complex, from structural analysis of the human E1
+      component. Core cellular component.
+    action: ACCEPT
+    reason: PDHB (E1beta) is unambiguously part of the PDC; correct, specific
+      component term with direct experimental support.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: The E1p component catalyzes the ThDP-mediated decarboxylation
+        of pyruvate
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IPI
+  original_reference_id: PMID:19240034
+  qualifier: part_of
+  review:
+    summary: ComplexPortal IPI (part_of PDC) from a study defining the subunit and
+      catalytic-component stoichiometries of an in vitro reconstituted human PDC
+      (40 E2p, 20 E3BP, 40 E1p, 20 E3). Confirms PDHB&#39;s incorporation into the
+      assembled complex. Core cellular component.
+    action: ACCEPT
+    reason: Directly demonstrates that E1 (of which PDHB is the beta subunit) is a
+      stoichiometric component of the assembled human PDC; correct, specific term.
+    supported_by:
+    - reference_id: PMID:19240034
+      supporting_text: The human pyruvate dehydrogenase complex (PDC) is a
+        9.5-megadalton catalytic
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: HPA immunofluorescence IDA localizing PDHB to mitochondria. Correct but
+      broader than the mitochondrial matrix annotations.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with the curated matrix localization; kept as non-core
+      supporting evidence, superseded in specificity by GO:0005759.
+    supported_by:
+    - reference_id: GO_REF:0000052
+      supporting_text: Gene Ontology annotation based on curation of immunofluorescence
+        data
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: Sequence-similarity (ISS, WITH UniProtKB P26284, pig ortholog) transfer
+      of mitochondrial matrix localization. Correct and specific; consistent with the
+      curated UniProt location.
+    action: ACCEPT
+    reason: The matrix location is well established for the PDC; ISS transfer from a
+      characterized mammalian ortholog is appropriate and specific.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: the gate-keeper enzyme that strategically links glycolysis to
+        the Krebs cycle and lipogenic pathways
+- term:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  evidence_type: IDA
+  original_reference_id: PMID:18164639
+  qualifier: contributes_to
+  review:
+    summary: MGI IDA (contributes_to) for E1 activity, from a study of PDHB mutations
+      in PDC-deficient patients diagnosed by low PDC activity. The contributes_to
+      qualifier correctly reflects that the acetyl-transferring activity is a property
+      of the alpha2-beta2 heterotetramer to which PDHB contributes. Core molecular
+      function.
+    action: ACCEPT
+    reason: Loss-of-function PDHB variants reduce PDC (E1) activity, directly linking
+      PDHB to the catalytic activity; contributes_to is the appropriate qualifier for
+      a subunit of a multi-subunit enzyme.
+    supported_by:
+    - reference_id: PMID:18164639
+      supporting_text: All cases were diagnosed by low PDC activity, with normal E2
+        and E3
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IC
+  original_reference_id: PMID:18164639
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: MGI IC (inferred from the GO:0004739 activity annotation) placing PDHB
+      upstream of/within the pyruvate-to-acetyl-CoA process. Core process; consistent
+      with the disease evidence that PDHB defects impair PDC flux.
+    action: ACCEPT
+    reason: Reasonable curator inference from the E1 activity annotation; the process
+      term is correct and central to PDHB function.
+    supported_by:
+    - reference_id: PMID:18164639
+      supporting_text: found four cases of PDHB mutations among 83 analyzed cases of
+        PDC deficiency
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:2295468
+  qualifier: is_active_in
+  review:
+    summary: UniProt IDA (is_active_in mitochondrion). This is the paper from which
+      UniProt curated direct protein sequencing of the mature PDHB N-terminus
+      (residues 31-55); PDHB is a mitochondrial matrix enzyme, so is_active_in
+      mitochondrion is appropriate. The abstract foregrounds an E2 subunit-binding
+      domain, but the curator used the full data (direct PDHB protein sequence).
+    action: KEEP_AS_NON_CORE
+    reason: Correct compartment but broader than the specific matrix location; retained
+      as non-core. Not removed - this is an experimental annotation whose full data
+      (direct protein sequencing of PDHB) was seen by the UniProt curator.
+    supported_by:
+    - reference_id: PMID:2295468
+      supporting_text: the subunit binding domain of the pyruvate dehydrogenase
+        complex E2 from bovine
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: High-throughput mitochondrial proteome evidence for mitochondrial
+      localization of PDHB. Correct but broader than the matrix annotations.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with the known matrix localization; retained as non-core
+      supporting evidence, less specific than GO:0005759.
+    supported_by:
+    - reference_id: PMID:34800366
+      supporting_text: Quantitative high-confidence human mitochondrial proteome and
+        its dynamics
+- term:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  evidence_type: IDA
+  original_reference_id: PMID:19081061
+  qualifier: contributes_to
+  review:
+    summary: UniProt IDA (contributes_to) for the E1 catalytic activity, from the
+      crystallographic/functional study of the human E1 component; the E1 subunit
+      catalyses TPP-dependent decarboxylation of pyruvate and reductive acetylation
+      of the E2 lipoyl group. Core molecular function.
+    action: ACCEPT
+    reason: Direct experimental characterization of E1 catalysis; contributes_to
+      correctly reflects PDHB as one subunit of the catalytic alpha2-beta2 E1
+      heterotetramer.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: reductive acetylation of a lipoyl group
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: HDA
+  original_reference_id: PMID:21630459
+  qualifier: located_in
+  review:
+    summary: Single high-throughput hit from a human sperm-nucleus proteomics dataset
+      (403 proteins identified). PDHB is a mitochondrial matrix enzyme; a nuclear
+      assignment for this TPP-dependent PDC subunit is best explained as a
+      large-scale dataset contaminant/over-annotation rather than a genuine nuclear
+      function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: No mechanistic or corroborating evidence for a nuclear role of PDHB;
+      inconsistent with its established mitochondrial-matrix localization and PDC
+      function. Flagged as over-annotation of a proteomics screen rather than removed.
+    supported_by:
+    - reference_id: PMID:21630459
+      supporting_text: different proteins have been identified from the isolated sperm
+        nuclei
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-203946
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing PDHB in the mitochondrial matrix, in the context of
+      PDK phosphorylation of the PDC E1 subunit. Correct, specific compartment.
+    action: ACCEPT
+    reason: Correct matrix localization consistent with the curated UniProt location
+      and the PDC&#39;s compartment.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: the gate-keeper enzyme that strategically links glycolysis to
+        the Krebs cycle and lipogenic pathways
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-204169
+  qualifier: located_in
+  review:
+    summary: Reactome TAS placing PDHB in the mitochondrial matrix, in the context of
+      PDP1/2 dephosphorylation of the PDC. Correct, specific compartment.
+    action: ACCEPT
+    reason: Correct matrix localization; consistent with the curated location.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: the gate-keeper enzyme that strategically links glycolysis to
+        the Krebs cycle and lipogenic pathways
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9838035
+  qualifier: located_in
+  review:
+    summary: Reactome TAS for mitochondrial matrix localization, in a generic
+      matrix-protein context (CLPXP binding matrix proteins). The compartment is
+      correct; the reaction context is generic protein quality control, not PDC
+      function.
+    action: ACCEPT
+    reason: Matrix localization is correct and consistent with the curated location,
+      even though the source reaction is generic matrix-protein quality control
+      rather than PDC-specific biology.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: the gate-keeper enzyme that strategically links glycolysis to
+        the Krebs cycle and lipogenic pathways
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9838081
+  qualifier: located_in
+  review:
+    summary: Reactome TAS for mitochondrial matrix localization, in a generic
+      matrix-protein context (LONP1 degrading matrix proteins). Compartment correct;
+      generic quality-control context.
+    action: ACCEPT
+    reason: Correct matrix localization consistent with the curated location; source
+      reaction is a generic degradation reaction rather than PDC function.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: the gate-keeper enzyme that strategically links glycolysis to
+        the Krebs cycle and lipogenic pathways
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9838093
+  qualifier: located_in
+  review:
+    summary: Reactome TAS for mitochondrial matrix localization, in a generic
+      matrix-protein context (LONP1 binding matrix proteins). Compartment correct;
+      generic quality-control context.
+    action: ACCEPT
+    reason: Correct matrix localization consistent with the curated location; source
+      reaction is a generic protein-binding/degradation reaction rather than PDC
+      function.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: the gate-keeper enzyme that strategically links glycolysis to
+        the Krebs cycle and lipogenic pathways
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9838289
+  qualifier: located_in
+  review:
+    summary: Reactome TAS for mitochondrial matrix localization, in a generic
+      matrix-protein context (CLPXP degrading matrix proteins). Compartment correct;
+      generic quality-control context.
+    action: ACCEPT
+    reason: Correct matrix localization consistent with the curated location; source
+      reaction is a generic degradation reaction rather than PDC function.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: the gate-keeper enzyme that strategically links glycolysis to
+        the Krebs cycle and lipogenic pathways
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861616
+  qualifier: located_in
+  review:
+    summary: Reactome TAS for mitochondrial matrix localization, in the context of the
+      PDC reaction cascade (DLD/E3 dehydrogenating dihydrolipoyl). Correct, specific
+      compartment.
+    action: ACCEPT
+    reason: Correct matrix localization within the PDC catalytic cascade context.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: the gate-keeper enzyme that strategically links glycolysis to
+        the Krebs cycle and lipogenic pathways
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861667
+  qualifier: located_in
+  review:
+    summary: Reactome TAS for mitochondrial matrix localization, in the context of the
+      PDC reaction cascade (DLAT/E2 transferring acetyl to CoA). Correct, specific
+      compartment.
+    action: ACCEPT
+    reason: Correct matrix localization within the PDC catalytic cascade context.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: the gate-keeper enzyme that strategically links glycolysis to
+        the Krebs cycle and lipogenic pathways
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861734
+  qualifier: located_in
+  review:
+    summary: Reactome TAS for mitochondrial matrix localization, in the context of the
+      PDC E1 reaction itself (PDH E1 decarboxylates pyruvate, transferring acetyl to
+      DLAT). Directly relevant to PDHB function; correct, specific compartment.
+    action: ACCEPT
+    reason: Correct matrix localization in the exact reaction (E1 decarboxylation)
+      that PDHB participates in; strongly relevant.
+    supported_by:
+    - reference_id: PMID:19081061
+      supporting_text: The E1p component catalyzes the ThDP-mediated decarboxylation
+        of pyruvate
+- term:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  evidence_type: TAS
+  original_reference_id: PMID:2376596
+  qualifier: enables
+  review:
+    summary: PINC/ProtInc TAS for the E1 acetyl-transferring activity, from the early
+      characterization of human PDH E1beta cDNA. Core molecular function annotation
+      (traceable author statement).
+    action: ACCEPT
+    reason: Correct molecular function for the E1beta subunit; consistent with the
+      experimental IDA annotations to the same term.
+    supported_by:
+    - reference_id: PMID:2376596
+      supporting_text: beta subunit gene is not a member of a multigene family
+- term:
+    id: GO:0006099
+    label: tricarboxylic acid cycle
+  evidence_type: TAS
+  original_reference_id: PMID:2376596
+  qualifier: involved_in
+  review:
+    summary: PINC/ProtInc TAS annotating PDHB to the tricarboxylic acid cycle. The
+      PDC provides acetyl-CoA that feeds the TCA cycle, but the pyruvate-to-acetyl-CoA
+      reaction is the entry step preceding the cycle, not part of the TCA cycle
+      proper. The cited paper concerns E1beta cDNA and a TCA-cycle-deficient
+      fibroblast line.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PDHB is the gateway feeding acetyl-CoA into the TCA cycle rather than a
+      TCA-cycle enzyme; the more accurate process is pyruvate decarboxylation to
+      acetyl-CoA (GO:0006086). Flagged as over-annotation of the general TCA-cycle
+      term rather than removed, since PDC is metabolically adjacent to the cycle.
+    proposed_replacement_terms:
+    - id: GO:0006086
+      label: pyruvate decarboxylation to acetyl-CoA
+    supported_by:
+    - reference_id: PMID:2376596
+      supporting_text: one tricarboxylic acid cycle deficient
+core_functions:
+- description: As the beta subunit of the E1 (pyruvate dehydrogenase) component,
+    PDHB contributes to the TPP-dependent oxidative decarboxylation of pyruvate and
+    reductive acetylation of the E2 lipoyl group (EC 1.2.4.1), the first, committed
+    step of the pyruvate dehydrogenase complex that converts pyruvate to acetyl-CoA
+    in the mitochondrial matrix.
+  molecular_function:
+    id: GO:0004739
+    label: pyruvate dehydrogenase (acetyl-transferring) activity
+  directly_involved_in:
+  - id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  in_complex:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  supported_by:
+  - reference_id: PMID:19081061
+    supporting_text: The E1p component catalyzes the ThDP-mediated decarboxylation
+      of pyruvate
+  - reference_id: PMID:18164639
+    supporting_text: All cases were diagnosed by low PDC activity, with normal E2
+      and E3
+proposed_new_terms: []
+suggested_questions:
+- question: Does the E1beta subunit contribute any catalytic residues to the E1
+    active site, or is its role primarily structural (heterotetramer assembly,
+    K+/TPP binding, and E2 docking)?
+- question: What is the functional consequence of the alternatively spliced isoforms
+    (P11177-2 lacking residues 16-33 in the transit peptide; P11177-3 lacking
+    residues 135-152) on mitochondrial import and PDC assembly?
+suggested_experiments:
+- description: Reconstitute PDC E1 activity with recombinant PDHA1 plus wild-type
+    versus PDHBD-variant PDHB (e.g. Y132C, C306R, D319V) and quantify each variant&#39;s
+    effect on pyruvate decarboxylase activity, overall multienzyme PDC activity, and
+    E1-E2 docking.
+  hypothesis: PDHBD variants impair PDC activity through distinct mechanisms
+    (heterotetramer destabilization versus loss of E1-E2 docking) rather than a
+    single shared mechanism.
+- description: Perform structural and kinetic analysis of the E1beta C-terminal
+    E2-docking surface (e.g. D319 mutants) to dissect its contribution to complex
+    assembly versus intrinsic E1 catalysis.
+  hypothesis: The E1beta C-terminal surface is required for docking E1 onto the E2
+    core but is dispensable for intrinsic pyruvate decarboxylase activity.
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:12651851
+  title: Structural basis for flip-flop action of thiamin pyrophosphate-dependent
+    enzymes revealed by human pyruvate dehydrogenase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Crystal structure of the alpha2beta2 human E1 (PDB 1NI4); establishes
+      the TPP-dependent, heterotetrameric E1 that PDHB forms with PDHA1. Verbatim quote
+      confirmed in cached abstract.
+- id: PMID:18164639
+  title: Mutations of the E1beta subunit gene (PDHB) in four families with pyruvate
+    dehydrogenase deficiency.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Directly ties PDHB loss-of-function variants to reduced PDC activity
+      in PDC-deficiency patients; supports the E1 activity and disease link. Abstract-only
+      cache but the assayed gene is PDHB.
+- id: PMID:18206651
+  title: Binding of pyruvate dehydrogenase to the core of the human pyruvate dehydrogenase
+    complex.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Maps the E1beta C-terminal surface residues that dock E1 onto the E2
+      (DLAT) core; supports the E1beta-E2 interaction underlying the protein-binding IPI.
+- id: PMID:19081061
+  title: &#39;Structural basis for inactivation of the human pyruvate dehydrogenase complex
+    by phosphorylation: role of disordered phosphorylation loops.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Full-text source establishing E1-catalysed TPP-dependent decarboxylation
+      of pyruvate and reductive acetylation of the E2 lipoyl group; PDC as the gateway
+      linking glycolysis to the TCA cycle. Anchors core_functions.
+- id: PMID:19240034
+  title: Subunit and catalytic component stoichiometries of an in vitro reconstituted
+    human pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Defines PDC subunit and catalytic stoichiometry (40 E2p, 20 E3BP,
+      40 E1p, 20 E3); demonstrates E1 (PDHB-containing) incorporation into the
+      assembled complex.
+- id: PMID:21630459
+  title: Proteomic characterization of the human sperm nucleus.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Large-scale sperm-nucleus proteomics; the single PDHB hit underlies
+      the nucleus annotation, best interpreted as dataset over-annotation for this
+      mitochondrial matrix enzyme.
+- id: PMID:2295468
+  title: Isolation of tryptic fragment of antigen from mitochondrial inner membrane
+    proteins reacting with antimitochondrial antibody in sera of patients with primary
+    biliary cirrhosis.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: UniProt cites this paper for direct protein sequencing of mature PDHB
+      (residues 31-55) and the mitochondrion is_active_in IDA; the cached abstract
+      foregrounds an E2 subunit-binding domain, but the curated PDHB protein sequence
+      is the load-bearing evidence.
+- id: PMID:2376596
+  title: Characterization of two cDNA clones for pyruvate dehydrogenase E1 beta subunit
+    and its regulation in tricarboxylic acid cycle-deficient fibroblast.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Early characterization of human PDH E1beta cDNA; source of the E1
+      activity TAS and (over-broad) TCA-cycle TAS annotations.
+- id: PMID:24534072
+  title: Component co-expression and purification of recombinant human pyruvate dehydrogenase
+    complex from baculovirus infected SF9 cells.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Recombinant functional human PDC (all components co-expressed);
+      supports PDHB&#39;s role in the pyruvate-to-acetyl-CoA reaction within the assembled
+      complex.
+- id: PMID:29128334
+  title: A Map of Human Mitochondrial Protein Interactions Linked to Neurodegeneration
+    Reveals New Mechanisms of Redox Homeostasis and NF-κB Signaling.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Large-scale mitochondrial interactome; recovers the PDHB-PDHA1
+      interaction underlying one protein-binding IPI. Not specific to PDHB function.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: BioPlex proteome-scale interactome; recovers PDHB interactions with
+      PDHA1 and DLAT underlying two protein-binding IPIs. Background/contextual for
+      gene function.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput mitochondrial proteome; corroborates mitochondrial
+      localization of PDHB but at low specificity.
+- id: Reactome:R-HSA-203946
+  title: PDK isozymes phosphorylate PDHC subunit E1
+  findings: []
+- id: Reactome:R-HSA-204169
+  title: PDP1,2 dephosphorylate p-lipo-PDH
+  findings: []
+- id: Reactome:R-HSA-9838035
+  title: CLPXP binds mitochondrial matrix proteins
+  findings: []
+- id: Reactome:R-HSA-9838081
+  title: LONP1 degrades mitochondrial matrix proteins
+  findings: []
+- id: Reactome:R-HSA-9838093
+  title: LONP1 binds mitochondrial matrix proteins
+  findings: []
+- id: Reactome:R-HSA-9838289
+  title: CLPXP degrades mitochondrial matrix proteins
+  findings: []
+- id: Reactome:R-HSA-9861616
+  title: DLD dimer dehydrogenates dihydrolipoyl
+  findings: []
+- id: Reactome:R-HSA-9861667
+  title: DLAT trimer transfers acetyl to CoA
+  findings: []
+- id: Reactome:R-HSA-9861734
+  title: PDH E1 decarboxylates PYR, transferring acetyl to DLAT
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PDHX/PDHX-ai-review.html
+++ b/genes/human/PDHX/PDHX-ai-review.html
@@ -1,0 +1,5377 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PDHX - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PDHX</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O00330" target="_blank" class="term-link">
+                        O00330
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PDHX";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O00330" data-a="DESCRIPTION: PDHX (component X / E3-binding protein, E3BP) is a..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PDHX (component X / E3-binding protein, E3BP) is a structural, non-catalytic subunit of the mitochondrial pyruvate dehydrogenase complex (PDC), which catalyses the oxidative decarboxylation of pyruvate to acetyl-CoA linking glycolysis to the TCA cycle. PDHX has a segmented multidomain architecture analogous to the E2 component (DLAT): an N-terminal lipoyl domain (lipoylated at Lys97), a peripheral subunit-binding / E3-binding domain, and a C-terminal E2-like inner-core (I&#39;) domain that packs into the dodecahedral E2 (DLAT) core. Its established function is to bind and anchor the E3 dihydrolipoyl dehydrogenase (DLD) to the E2 core, positioning E3 to reoxidise the reduced lipoyl arms; this tethering is essential for a functional PDC. Unlike E2, the catalytic-site histidine of the inner-core acyltransferase fold is replaced by serine in human E3BP, so PDHX does not itself catalyse acetyl-CoA formation. PDHX resides in the mitochondrial matrix. Its lipoyl-Lys97 is a substrate of the SIRT4 lipoamidase, providing a regulatory input to PDC activity. Loss-of-function variants cause pyruvate dehydrogenase E3-binding protein deficiency (a form of PDC deficiency with congenital lactic acidosis, hypotonia and psychomotor retardation).</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PDHX is a mitochondrial matrix protein and subunit of the mitochondrial PDC. Phylogenetic (IBA) placement in the mitochondrion is correct, though less specific than mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records subcellular location &#34;Mitochondrion matrix&#34; and a cleavable mitochondrial transit peptide (residues 1-53). The term is correct; the more specific GO:0005759 (mitochondrial matrix) annotation is also present.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHX/PDHX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0045254" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PDHX is a bona fide subunit of the pyruvate dehydrogenase complex, constituting part of the E2/E3BP inner core. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental and structural evidence establishes PDHX as part of the PDC inner core; the IBA phylogenetic annotation is consistent with this.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a noncatalytic component, E3-binding protein (E3BP), which specifically tethers E3 dimers to the PDC.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004742" target="_blank" class="term-link">
+                                    GO:0004742
+                                </a>
+                            </span>
+                            <span class="term-label">dihydrolipoyllysine-residue acetyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0004742" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is a homology/family-based electronic annotation propagated from the E2 (acetyltransferase) fold that PDHX shares. However, human E3BP is not a functional acetyltransferase: the catalytic-site histidine of the inner-core acyltransferase domain is replaced by a serine, so CoA acetylation by this protein is unlikely.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHX retains the E2-like inner-core fold (hence the ARBA family mapping) but lacks the catalytic histidine required for transacetylase activity; it is a structural/E3-anchoring subunit, not a catalytic acyltransferase. The annotation reflects fold similarity, not true molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                        PMID:9242632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The putative catalytic site histidine residue present in the inner core domains of all dihydrolipoamide acyltransferases is replaced by a serine residue in human E3BP; thus, catalysis of coenzyme A acetylation by this protein is unlikely.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a noncatalytic component, E3-binding protein (E3BP), which specifically tethers E3 dimers to the PDC.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and the most specific localization for PDHX; matches the UniProt subcellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt SubCell mapping (SL-0170) to mitochondrial matrix is consistent with the curated UniProt location and with PDHX being an assembled subunit of the matrix-resident PDC.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHX/PDHX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0006086" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PDHX is a required structural subunit of the PDC, which performs the oxidative decarboxylation of pyruvate to acetyl-CoA. As part_of the complex it is legitimately &#34;involved_in&#34; this process even though it is not itself catalytic.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Anchoring E3 to the E2 core is essential for a functional PDC; loss of PDHX causes PDC deficiency. The BP annotation captures the pathway role of the subunit and is corroborated by the ComplexPortal IDA (PMID:24534072) and the IC annotation (PMID:9242632).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                        PMID:9242632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Protein X, recently renamed dihydrolipoamide dehydrogenase-binding protein (E3BP), is required for anchoring dihydrolipoamide dehydrogenase (E3) to the dihydrolipoamide transacetylase (E2) core of the pyruvate dehydrogenase complexes of eukaryotes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016746" target="_blank" class="term-link">
+                                    GO:0016746
+                                </a>
+                            </span>
+                            <span class="term-label">acyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0016746" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad acyltransferase MF mapped from InterPro domains of the shared E2-like fold. As with the more specific GO:0004742, PDHX does not catalyse acyl transfer (catalytic His-&gt;Ser), so this is a fold-based over-annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro signatures (2-oxoacid_DH acyltransferase, E2/Pdx1) reflect the E2-like inner-core fold that PDHX possesses structurally; the catalytic residue is absent and no acyltransferase activity has been demonstrated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                        PMID:9242632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The putative catalytic site histidine residue present in the inner core domains of all dihydrolipoamide acyltransferases is replaced by a serine residue in human E3BP; thus, catalysis of coenzyme A acetylation by this protein is unlikely.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0045254" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) part_of PDC annotation, duplicating the well-supported experimental/IBA annotations. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with all other evidence that PDHX is a subunit of the PDC inner core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16263718" target="_blank" class="term-link">
+                                        PMID:16263718
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The dihydrolipoamide dehydrogenase-binding protein (E3BP) and the dihydrolipoamide acetyltransferase (E2) component enzyme form the structural core of the human pyruvate dehydrogenase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16263718" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16263718
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    How dihydrolipoamide dehydrogenase-binding protein binds dih...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005515" data-r="PMID:16263718" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI interaction with DLD (E3, P09622) from the crystal structure of the E3BP E3-binding domain in complex with E3. This is the key biological interaction of PDHX, but the bare &#34;protein binding&#34; term is uninformative; the specific E3-anchoring/adaptor role is captured in core_functions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, bare GO:0005515 &#34;protein binding&#34; adds no functional information. The underlying DLD interaction is real and central, but is better represented by the E3-anchoring adaptor function (GO:0030674) in core_functions rather than by this generic term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16263718" target="_blank" class="term-link">
+                                        PMID:16263718
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">How dihydrolipoamide dehydrogenase-binding protein binds dihydrolipoamide dehydrogenase in the human pyruvate dehydrogenase complex.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16442803" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16442803
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural insight into interactions between dihydrolipoamid...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005515" data-r="PMID:16442803" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI interaction with DLD (E3, P09622) from a second crystal structure of the E3-binding domain in complex with E3, including hot-spot mutagenesis. Real but bare/uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Meaningful DLD interaction but recorded as generic protein binding; the specific anchoring/adaptor function is captured in core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16442803" target="_blank" class="term-link">
+                                        PMID:16442803
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">utilizes the specific dihydrolipoamide dehydrogenase (E3) binding protein (E3BP) to tether the essential E3 component to the 60-meric core of the complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21516116
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Next-generation sequencing to generate interactome datasets.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005515" data-r="PMID:21516116" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction with AGTRAP (Q6RW13) from a high-throughput next-generation sequencing interactome (Y2H) screen. No established biological role of PDHX involves AGTRAP; a bare, high-throughput protein-binding hit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein-binding annotation from a proteome-scale screen with no functional context for PDHX; uninformative for the gene&#39;s function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link">
+                                        PMID:21516116
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Next-generation sequencing to generate interactome datasets.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction with AGTRAP (Q6RW13) from a proteome-scale binary interactome map. High-throughput, bare protein-binding hit with no functional context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding from a large-scale interactome screen.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                                        PMID:25416956
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A proteome-scale map of the human interactome network.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25525879
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Sirtuin 4 is a lipoamidase regulating pyruvate dehydrogenase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005515" data-r="PMID:25525879" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI interaction with SIRT4 (Q9Y6E7). SIRT4 is a lipoamidase that removes the lipoyl modification from PDHX (Lys97) and DLAT to regulate PDC activity, so this is a biologically meaningful interaction, but bare &#34;protein binding&#34; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The SIRT4 interaction is functionally relevant (regulatory delipoylation), but as recorded it is a generic protein-binding term; the regulatory relationship is better captured as PTM/regulation, not as a core MF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" target="_blank" class="term-link">
+                                        PMID:25525879
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">SIRT4 removed lipoamide from DLAT and PDHX peptides</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction with DLD (P09622) captured in a large-scale AP-MS interactome (BioPlex). Consistent with the biological E3(DLD) interaction, but a bare, uninformative protein-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput DLD interaction; real but generic. Anchoring function is in core_functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                                        PMID:28514442
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31515488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive disruption of protein interactions by genetic vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005515" data-r="PMID:31515488" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction with AGTRAP (Q6RW13) from a variant/interaction disruption study. High-throughput, bare protein-binding hit with no functional role for PDHX.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein-binding from a large-scale interaction screen; uninformative.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                                        PMID:31515488
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interactions with DLD (P09622) and CIDEB (Q9UHD4) from a reference binary interactome map (HuRI). The DLD hit is consistent with biology; CIDEB has no established role with PDHX. Bare protein-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mixed high-throughput hits recorded as generic protein binding; the DLD interaction is real (anchoring, in core_functions) and CIDEB is an uncharacterized screen hit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A reference map of the human binary protein interactome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction with DLD (P09622) from a cell-specific AP-MS interactome (BioPlex 3.0). Consistent with the biological E3(DLD) interaction, but bare.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput DLD interaction; real but recorded as generic protein binding.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24534072
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Component co-expression and purification of recombinant huma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005739" data-r="PMID:24534072" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable statement of mitochondrial localization (ComplexPortal), consistent with the well-established matrix localization. Correct but less specific than mitochondrial matrix.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHX is a matrix-resident PDC subunit; the mitochondrion annotation is correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHX/PDHX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24534072
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Component co-expression and purification of recombinant huma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0006086" data-r="PMID:24534072" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IDA: reconstituted recombinant human PDC (including E3BP) was shown to be functional in producing acetyl-CoA. PDHX participates as a required structural subunit. Correct as involved_in.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A well-defined recombinant human PDC containing PDHX was assembled and shown catalytically competent, supporting the subunit&#39;s involvement in pyruvate decarboxylation to acetyl-CoA (as part of the complex, not as a catalyst).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                                        PMID:24534072
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mammalian pyruvate dehydrogenase complex (PDC) is a multi-component mitochondrial enzyme that plays a key role in the conversion of pyruvate to acetyl-CoA connecting glycolysis to the citric acid cycle.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19240034
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subunit and catalytic component stoichiometries of an in vit...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0045254" data-r="PMID:19240034" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IPI) part_of PDC from stoichiometry/reconstitution work establishing PDHX as ~20 copies (40/20 model) within the E2/E3BP core. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct biophysical characterization places E3BP within the PDC core and shows it tethers E3 to the complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                        PMID:19240034
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human PDC is organized around a 60-meric dodecahedral core comprising the C-terminal domains of E2p and a noncatalytic component, E3-binding protein (E3BP), which specifically tethers E3 dimers to the PDC.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Immunofluorescence (HPA) localization to mitochondrion. Consistent with the established matrix localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct imaging evidence of mitochondrial localization; correct though less specific than mitochondrial matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHX/PDHX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004742" target="_blank" class="term-link">
+                                    GO:0004742
+                                </a>
+                            </span>
+                            <span class="term-label">dihydrolipoyllysine-residue acetyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9242632
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dihydrolipoamide dehydrogenase-binding protein of the human ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0004742" data-r="PMID:9242632" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Legacy IDA (MGI) assigning transacetylase activity, but the same primary paper explicitly concludes that CoA acetylation by human E3BP is unlikely because the catalytic-site histidine is replaced by serine. This MF should not be treated as a genuine catalytic function of PDHX.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited paper reconstituted a functional PDC using E3BP but attributes the acetyltransferase catalysis to E2; it states the E3BP inner-core domain lacks the catalytic histidine and is unlikely to catalyse acetylation. PDHX is a structural (E3-anchoring) subunit, so this catalytic MF is an over-annotation of the fold rather than a demonstrated activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                        PMID:9242632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The putative catalytic site histidine residue present in the inner core domains of all dihydrolipoamide acyltransferases is replaced by a serine residue in human E3BP; thus, catalysis of coenzyme A acetylation by this protein is unlikely.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006086" target="_blank" class="term-link">
+                                    GO:0006086
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9242632
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dihydrolipoamide dehydrogenase-binding protein of the human ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0006086" data-r="PMID:9242632" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator inference (IC) that PDHX participates in pyruvate decarboxylation to acetyl-CoA, based on its role in reconstituting a functional PDC. Consistent with the subunit&#39;s essential contribution to the pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHX is required for a functional PDC; its involvement in the pyruvate-&gt;acetyl-CoA conversion is a reasonable curator inference and is supported by reconstitution of the complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                        PMID:9242632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Coexpression of cDNAs for E3BP and E2 resulted in the formation of an E2.E3BP subcomplex that spontaneously reconstituted the pyruvate dehydrogenase complex in the presence of native E3 and recombinant pyruvate decarboxylase (E1).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005739" data-r="PMID:34800366" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteome localization. Consistent with the established matrix localization of PDHX.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborates mitochondrial localization; less specific than mitochondrial matrix but correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                                        PMID:34800366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9242632
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dihydrolipoamide dehydrogenase-binding protein of the human ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0045254" data-r="PMID:9242632" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) part_of PDC from reconstitution of the E2.E3BP subcomplex and functional PDC. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PDHX (E3BP) was shown to assemble into the PDC core with E2 and reconstitute a functional complex, directly demonstrating it is part of the PDC.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                        PMID:9242632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Coexpression of cDNAs for E3BP and E2 resulted in the formation of an E2.E3BP subcomplex that spontaneously reconstituted the pyruvate dehydrogenase complex in the presence of native E3 and recombinant pyruvate decarboxylase (E1).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                                    GO:0045254
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate dehydrogenase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25525879
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Sirtuin 4 is a lipoamidase regulating pyruvate dehydrogenase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0045254" data-r="PMID:25525879" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA part_of PDC (UniProt), consistent with PDHX being a structural subunit of the PDH complex characterized in the SIRT4 study. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The study describes PDHX as a structural subunit of the PDH complex and immuno-isolates it as part of the complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" target="_blank" class="term-link">
+                                        PMID:25525879
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a structural subunit (PDH-binding component X, PDHX)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-203946
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005759" data-r="Reactome:R-HSA-203946" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to mitochondrial matrix (PDH regulation reaction context). Correct and matches the UniProt subcellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the curated matrix localization of PDHX as a PDC subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHX/PDHX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-204169
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005759" data-r="Reactome:R-HSA-204169" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to mitochondrial matrix. Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the curated matrix localization of PDHX.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHX/PDHX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861616
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005759" data-r="Reactome:R-HSA-9861616" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to mitochondrial matrix (DLD dehydrogenation reaction context). Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the curated matrix localization of PDHX.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHX/PDHX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861667
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005759" data-r="Reactome:R-HSA-9861667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to mitochondrial matrix (DLAT acetyl transfer reaction context). Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the curated matrix localization of PDHX.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHX/PDHX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861734
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005759" data-r="Reactome:R-HSA-9861734" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to mitochondrial matrix (E1 decarboxylation reaction context). Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the curated matrix localization of PDHX.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PDHX/PDHX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Mitochondrion matrix.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                                    GO:0030674
+                                </a>
+                            </span>
+                            <span class="term-label">protein-macromolecule adaptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16263718" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16263718
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    How dihydrolipoamide dehydrogenase-binding protein binds dih...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0030674" data-r="PMID:16263718" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed molecular function capturing PDHX&#39;s established E3-anchoring role: PDHX acts as an adaptor that tethers the E3 (DLD) dimer to the E2 (DLAT) core of the PDC. Supported by two crystal structures of the E3BP E3-binding domain bound to E3 and by mutagenesis of the interface hot-spot residues.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The bare GO:0005515 protein-binding IPIs and the mis-attributed catalytic MF terms fail to capture what PDHX actually does molecularly. Its function is a protein-macromolecule adaptor/anchoring activity tethering E3 to the E2 core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16263718" target="_blank" class="term-link">
+                                        PMID:16263718
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The dihydrolipoamide dehydrogenase-binding protein (E3BP) and the dihydrolipoamide acetyltransferase (E2) component enzyme form the structural core of the human pyruvate dehydrogenase complex</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                        PMID:9242632
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Protein X, recently renamed dihydrolipoamide dehydrogenase-binding protein (E3BP), is required for anchoring dihydrolipoamide dehydrogenase (E3) to the dihydrolipoamide transacetylase (E2) core of the pyruvate dehydrogenase complexes of eukaryotes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                                    GO:0005198
+                                </a>
+                            </span>
+                            <span class="term-label">structural molecule activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16263718" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16263718
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    How dihydrolipoamide dehydrogenase-binding protein binds dih...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O00330" data-a="GO:0005198" data-r="PMID:16263718" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed molecular function reflecting PDHX&#39;s role as a structural constituent of the PDC inner core: together with E2 (DLAT) it forms the dodecahedral scaffold that binds the peripheral E1 and E3 catalytic components. PDHX itself is non-catalytic.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Captures the structural/scaffolding contribution of PDHX to the PDC core, complementing the adaptor (E3-anchoring) function and replacing the fold-based catalytic over-annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16263718" target="_blank" class="term-link">
+                                        PMID:16263718
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The dihydrolipoamide dehydrogenase-binding protein (E3BP) and the dihydrolipoamide acetyltransferase (E2) component enzyme form the structural core of the human pyruvate dehydrogenase complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Anchors the E3 dihydrolipoyl dehydrogenase (DLD) dimer to the E2 (DLAT) core of the pyruvate dehydrogenase complex via its E3-binding (peripheral subunit-binding) domain, acting as a molecular adaptor that tethers the catalytic E3 to the assembled complex; this structural role is essential for a functional PDC.</h3>
+                <span class="vote-buttons" data-g="O00330" data-a="FUNCTION: Anchors the E3 dihydrolipoyl dehydrogenase (DLD) d..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                            protein-macromolecule adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                            pyruvate dehydrogenase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                                PMID:19240034
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">a noncatalytic component, E3-binding protein (E3BP), which specifically tethers E3 dimers to the PDC.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                PMID:9242632
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Protein X, recently renamed dihydrolipoamide dehydrogenase-binding protein (E3BP), is required for anchoring dihydrolipoamide dehydrogenase (E3) to the dihydrolipoamide transacetylase (E2) core of the pyruvate dehydrogenase complexes of eukaryotes.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Serves as a structural constituent of the pyruvate dehydrogenase complex inner core, integrating (together with E2/DLAT) into the dodecahedral core that provides the scaffold binding the peripheral E1 and E3 catalytic components; PDHX itself is non-catalytic (its E2-like inner-core fold lacks the catalytic histidine).</h3>
+                <span class="vote-buttons" data-g="O00330" data-a="FUNCTION: Serves as a structural constituent of the pyruvate..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                            structural molecule activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045254" target="_blank" class="term-link">
+                            pyruvate dehydrogenase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16263718" target="_blank" class="term-link">
+                                PMID:16263718
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The dihydrolipoamide dehydrogenase-binding protein (E3BP) and the dihydrolipoamide acetyltransferase (E2) component enzyme form the structural core of the human pyruvate dehydrogenase complex</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                                PMID:9242632
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The putative catalytic site histidine residue present in the inner core domains of all dihydrolipoamide acyltransferases is replaced by a serine residue in human E3BP; thus, catalysis of coenzyme A acetylation by this protein is unlikely.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16263718" target="_blank" class="term-link">
+                            PMID:16263718
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">How dihydrolipoamide dehydrogenase-binding protein binds dihydrolipoamide dehydrogenase in the human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16442803" target="_blank" class="term-link">
+                            PMID:16442803
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural insight into interactions between dihydrolipoamide dehydrogenase (E3) and E3 binding protein of human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" target="_blank" class="term-link">
+                            PMID:19240034
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Subunit and catalytic component stoichiometries of an in vitro reconstituted human pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link">
+                            PMID:21516116
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Next-generation sequencing to generate interactome datasets.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24534072" target="_blank" class="term-link">
+                            PMID:24534072
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Component co-expression and purification of recombinant human pyruvate dehydrogenase complex from baculovirus infected SF9 cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" target="_blank" class="term-link">
+                            PMID:25525879
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Sirtuin 4 is a lipoamidase regulating pyruvate dehydrogenase complex activity.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                            PMID:31515488
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" target="_blank" class="term-link">
+                            PMID:9242632
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dihydrolipoamide dehydrogenase-binding protein of the human pyruvate dehydrogenase complex. DNA-derived amino acid sequence, expression, and reconstitution of the pyruvate dehydrogenase complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-203946
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDK isozymes phosphorylate PDHC subunit E1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-204169
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDP1,2 dephosphorylate p-lipo-PDH</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861616
+
+                    </span>
+                </div>
+
+                <div class="reference-title">DLD dimer dehydrogenates dihydrolipoyl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861667
+
+                    </span>
+                </div>
+
+                <div class="reference-title">DLAT trimer transfers acetyl to CoA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861734
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PDH E1 decarboxylates PYR, transferring acetyl to DLAT</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PDHX/PDHX-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry O00330 (ODPX_HUMAN), Pyruvate dehydrogenase protein X component, mitochondrial</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Beyond its structural E3-anchoring role, does the lipoyl domain of PDHX (lipoylated at Lys97) participate directly in the reductive acetylation / lipoyl-arm shuttling cycle of the PDC, or is it functionally redundant with the DLAT lipoyl domains?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O00330" data-a="Q: Beyond its structural E3-anchoring role, does the ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the physiological significance of SIRT4-mediated delipoylation of PDHX Lys97 relative to delipoylation of DLAT for regulating PDC flux?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O00330" data-a="Q: What is the physiological significance of SIRT4-me..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute human PDC with lipoyl-null (K97) PDHX to test whether the PDHX lipoyl group is catalytically required or purely structural.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The PDHX lipoyl group is dispensable for PDC catalysis, consistent with a purely structural/anchoring role.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O00330" data-a="EXPERIMENT: Reconstitute human PDC with lipoyl-null (K97) PDHX..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Assay purified human E3BP/PDHX inner-core domain for any residual transacetylase activity to confirm the loss of acyltransferase function implied by the His-&gt;Ser substitution.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The PDHX inner-core domain has no detectable dihydrolipoyllysine-residue acetyltransferase activity because it lacks the catalytic histidine.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O00330" data-a="EXPERIMENT: Assay purified human E3BP/PDHX inner-core domain f..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PDHX-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O00330" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pdhx-human-o00330-review-notes">PDHX (human, O00330) review notes</h1>
+<h2 id="deep-research-status">Deep research status</h2>
+<p><code>just deep-research-falcon human PDHX</code> FAILED in this worktree: the wrapper<br />
+<code>scripts/deep_research_wrapper.py</code> hits a runtime <code>TypeError: unsupported operand
+type(s) for |: 'type' and 'NoneType'</code> at line ~158 (a <code>dict | None</code> default<br />
+annotation evaluated at runtime under an incompatible interpreter). No<br />
+<code>-deep-research-falcon.md</code> was produced. Per project policy I did NOT fabricate a<br />
+<code>-deep-research-*.md</code>. This review is grounded in the UniProt record<br />
+(PDHX-uniprot.txt), the seeded GOA, cached publications/PMID_*.md, and the<br />
+disorder KB <code>~/repos/dismech/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml</code>.</p>
+<h2 id="core-biology">Core biology</h2>
+<p>PDHX = "component X" / E3-binding protein (E3BP). A <strong>structural, non-catalytic</strong><br />
+subunit of the mitochondrial pyruvate dehydrogenase complex (PDC). Built into the<br />
+E2 (DLAT) dodecahedral inner core; its established function is to <strong>bind and anchor<br />
+the E3 dihydrolipoyl dehydrogenase (DLD)</strong> to the E2 core, positioning E3 to<br />
+reoxidise the lipoyl arms. Segmented multidomain architecture like E2: N-terminal<br />
+lipoyl(-binding) domain (lipoylated at K97), a peripheral subunit-binding domain<br />
+(PSBD; the E3-binding domain, residues ~183-220), and a C-terminal E2-like inner<br />
+core (I') domain that packs into the E2 60-mer core.</p>
+<h3 id="key-evidence">Key evidence</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/9242632" title="Protein X, recently renamed dihydrolipoamide dehydrogenase-binding   protein (E3BP), is required for anchoring dihydrolipoamide dehydrogenase (E3) to   the dihydrolipoamide transacetylase (E2) core of the pyruvate dehydrogenase   complexes of eukaryotes.">PMID:9242632</a></li>
+<li><strong>NOT a functional acetyltransferase</strong>: <a href="https://pubmed.ncbi.nlm.nih.gov/9242632" title="the putative catalytic   site histidine residue present in the inner core domains of all dihydrolipoamide   acyltransferases is replaced by a serine residue in human E3BP; thus, catalysis   of coenzyme A acetylation by this protein is unlikely.">PMID:9242632</a> =&gt; GO:0004742<br />
+  (dihydrolipoyllysine-residue acetyltransferase activity) and GO:0016746<br />
+  (acyltransferase activity) are homology/family over-annotations. The catalytic<br />
+  His is absent -&gt; MARK_AS_OVER_ANNOTATED (not REMOVE for the IDA; keep as<br />
+  over-annotated). The IEA family maps =&gt; REMOVE-worthy in principle, but per<br />
+  policy for IEA I mark over-annotated / modify to the structural role; I use<br />
+  MARK_AS_OVER_ANNOTATED for the catalytic MF terms because they are family-fold<br />
+  correct but not the true function.</li>
+<li>Structural core: <a href="https://pubmed.ncbi.nlm.nih.gov/16263718" title="The dihydrolipoamide dehydrogenase-binding   protein (E3BP) and the dihydrolipoamide acetyltransferase (E2) component enzyme   form the structural core of the human pyruvate dehydrogenase complex by providing   the binding sites for two other component proteins, dihydrolipoamide dehydrogenase   (E3) and pyruvate dehydrogenase (E1)">PMID:16263718</a></li>
+<li>Tethers E3: <a href="https://pubmed.ncbi.nlm.nih.gov/19240034" title="a noncatalytic component, E3-binding protein (E3BP),   which specifically tethers E3 dimers to the PDC.">PMID:19240034</a> — this is the strongest single<br />
+  statement: E3BP is explicitly "noncatalytic".</li>
+<li>E3-binding domain / DLD interaction, mutagenesis hot spot: <a href="https://pubmed.ncbi.nlm.nih.gov/16442803" title="utilizes the specific dihydrolipoamide dehydrogenase (E3) binding protein (E3BP)   to tether the essential E3 component to the 60-meric core of the complex">PMID:16442803</a>.</li>
+<li>Core stoichiometry ~48 E2 + 12 E3BP (or 40/20 reconstituted model): PMID:14638692,<br />
+  PMID:19240034, PMID:20361979 (uncached), UniProt SUBUNIT.</li>
+<li>PDHX is a "structural subunit": <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" title="a structural subunit (PDH-binding   component X, PDHX)">PMID:25525879</a>.</li>
+<li>PDHX is lipoylated at K97 and is a SIRT4 lipoamidase substrate: <a href="https://pubmed.ncbi.nlm.nih.gov/25525879" title="42% for PDHX">PMID:25525879</a> (SIRT4 removes lipoyl from PDHX peptide); UniProt MOD_RES 97<br />
+  N6-lipoyllysine; PTM "Delipoylated at Lys-97 by SIRT4".</li>
+</ul>
+<h3 id="interactions-ipi-go0005515-protein-binding">Interactions (IPI GO:0005515 protein binding)</h3>
+<ul>
+<li>Biologically meaningful: DLD/E3 (P09622) — the anchoring partner; SIRT4 (Q9Y6E7)<br />
+  — lipoamidase regulator. These are the real functional interactions but bare<br />
+  "protein binding" is uninformative; per curation policy avoid bare protein binding<br />
+  and prefer a specific MF. Mark the DLD-supported ones as over-annotated (the<br />
+  specific "E3 anchoring" role is captured better by core_functions / structural<br />
+  constituent term).</li>
+<li>High-throughput screen hits with no established biological role for PDHX:<br />
+  AGTRAP (Q6RW13; PMID:21516116, PMID:25416956, PMID:31515488), CIDEB (Q9UHD4;<br />
+  PMID:32296183). These are proteome-scale Y2H / AP-MS maps (PMID:28514442,<br />
+  PMID:32296183, PMID:33961781). MARK_AS_OVER_ANNOTATED per policy (not REMOVE for<br />
+  IPI experimental).</li>
+</ul>
+<h3 id="localization">Localization</h3>
+<p>Mitochondrial matrix (UniProt SUBCELLULAR LOCATION: Mitochondrion matrix; TRANSIT<br />
+1..53). GO:0005739 mitochondrion (IBA/NAS/IDA/HTP) and GO:0005759 mitochondrial<br />
+matrix (IEA/TAS) all correct. Matrix is more specific and accurate.</p>
+<h3 id="disease">Disease</h3>
+<p>Pyruvate dehydrogenase E3-binding protein deficiency (PDHXD, MIM:245349;<br />
+MONDO:0009503; ORPHA:255182): PDC deficiency with normal E1/E2/E3 activities,<br />
+congenital lactic acidosis, hypotonia, psychomotor retardation. Disease gene per<br />
+Orphanet [ORPHA:255182 "PDHX | pyruvate dehydrogenase complex component X |<br />
+hgnc:21350 | Disease-causing germline mutation(s) in"].</p>
+<h2 id="annotation-decisions-summary">Annotation decisions summary</h2>
+<ul>
+<li>GO:0045254 pyruvate dehydrogenase complex (part_of) — ACCEPT (all copies). Core.</li>
+<li>GO:0005759 mitochondrial matrix (located_in) — ACCEPT (most specific CC).</li>
+<li>GO:0005739 mitochondrion — ACCEPT (correct, less specific than matrix); keep.</li>
+<li>GO:0006086 pyruvate decarboxylation to acetyl-CoA — ACCEPT as involved_in/BP<br />
+  (PDHX is a required structural subunit of the complex that performs this; IC/IDA<br />
+  reasonable). The IEA involved_in and the ComplexPortal IDA are fine.</li>
+<li>GO:0004742 acetyltransferase activity (IDA MGI + IEA ARBA) — MARK_AS_OVER_ANNOTATED:<br />
+  catalytic His-&gt;Ser, catalysis unlikely (PMID:9242632); E3BP is noncatalytic<br />
+  (PMID:19240034). The IDA is likely a legacy family/reconstitution annotation.</li>
+<li>GO:0016746 acyltransferase activity (IEA InterPro) — MARK_AS_OVER_ANNOTATED (same<br />
+  reason; broad family term, no catalysis).</li>
+<li>GO:0005515 protein binding (IPI x many) — MARK_AS_OVER_ANNOTATED (bare, uninformative;<br />
+  the meaningful DLD/SIRT4 interactions are better captured by structural role).</li>
+</ul>
+<h2 id="core-function-mfrole">Core function (MF/role)</h2>
+<p>Best MF/role term: PDHX acts as a structural constituent that anchors E3(DLD) to the<br />
+E2 core. Candidate GO terms:<br />
+- GO:0098918 structural constituent of synapse — NO (wrong).<br />
+- GO:0005198 structural molecule activity — generic MF, defensible for a scaffold<br />
+  subunit; check branch.<br />
+- "protein-macromolecule adaptor activity" GO:0030674 — anchoring/adaptor MF for<br />
+  tethering E3 to E2; strong candidate for the "anchor E3 to E2" function.<br />
+Will use GO:0030674 (protein-macromolecule adaptor activity) as the MF capturing the<br />
+E3-anchoring/scaffold role, plus in_complex GO:0045254, locations GO:0005759.<br />
+Verify labels via OLS before finalizing.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O00330
+gene_symbol: PDHX
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PDHX (component X / E3-binding protein, E3BP) is a structural, non-catalytic
+  subunit of the mitochondrial pyruvate dehydrogenase complex (PDC), which
+  catalyses the oxidative decarboxylation of pyruvate to acetyl-CoA linking
+  glycolysis to the TCA cycle. PDHX has a segmented multidomain architecture
+  analogous to the E2 component (DLAT): an N-terminal lipoyl domain (lipoylated at
+  Lys97), a peripheral subunit-binding / E3-binding domain, and a C-terminal
+  E2-like inner-core (I&#39;) domain that packs into the dodecahedral E2 (DLAT) core.
+  Its established function is to bind and anchor the E3 dihydrolipoyl dehydrogenase
+  (DLD) to the E2 core, positioning E3 to reoxidise the reduced lipoyl arms; this
+  tethering is essential for a functional PDC. Unlike E2, the catalytic-site
+  histidine of the inner-core acyltransferase fold is replaced by serine in human
+  E3BP, so PDHX does not itself catalyse acetyl-CoA formation. PDHX resides in the
+  mitochondrial matrix. Its lipoyl-Lys97 is a substrate of the SIRT4 lipoamidase,
+  providing a regulatory input to PDC activity. Loss-of-function variants cause
+  pyruvate dehydrogenase E3-binding protein deficiency (a form of PDC deficiency
+  with congenital lactic acidosis, hypotonia and psychomotor retardation).
+alternative_products:
+- name: &#39;1&#39;
+  id: O00330-1
+- name: &#39;2&#39;
+  id: O00330-2
+  sequence_note: VSP_045271
+- name: &#39;3&#39;
+  id: O00330-3
+  sequence_note: VSP_053817
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      PDHX is a mitochondrial matrix protein and subunit of the mitochondrial PDC.
+      Phylogenetic (IBA) placement in the mitochondrion is correct, though less
+      specific than mitochondrial matrix.
+    action: ACCEPT
+    reason: &gt;-
+      UniProt records subcellular location &#34;Mitochondrion matrix&#34; and a
+      cleavable mitochondrial transit peptide (residues 1-53). The term is
+      correct; the more specific GO:0005759 (mitochondrial matrix) annotation is
+      also present.
+    supported_by:
+    - reference_id: file:human/PDHX/PDHX-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion matrix.&#34;
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      PDHX is a bona fide subunit of the pyruvate dehydrogenase complex,
+      constituting part of the E2/E3BP inner core. Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental and structural evidence establishes PDHX as part of the
+      PDC inner core; the IBA phylogenetic annotation is consistent with this.
+    supported_by:
+    - reference_id: PMID:19240034
+      supporting_text: &gt;-
+        a noncatalytic component, E3-binding protein (E3BP), which specifically
+        tethers E3 dimers to the PDC.
+- term:
+    id: GO:0004742
+    label: dihydrolipoyllysine-residue acetyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This is a homology/family-based electronic annotation propagated from the
+      E2 (acetyltransferase) fold that PDHX shares. However, human E3BP is not a
+      functional acetyltransferase: the catalytic-site histidine of the inner-core
+      acyltransferase domain is replaced by a serine, so CoA acetylation by this
+      protein is unlikely.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      PDHX retains the E2-like inner-core fold (hence the ARBA family mapping) but
+      lacks the catalytic histidine required for transacetylase activity; it is a
+      structural/E3-anchoring subunit, not a catalytic acyltransferase. The
+      annotation reflects fold similarity, not true molecular function.
+    supported_by:
+    - reference_id: PMID:9242632
+      supporting_text: &gt;-
+        The putative catalytic site histidine residue present in the inner core
+        domains of all dihydrolipoamide acyltransferases is replaced by a serine
+        residue in human E3BP; thus, catalysis of coenzyme A acetylation by this
+        protein is unlikely.
+    - reference_id: PMID:19240034
+      supporting_text: &gt;-
+        a noncatalytic component, E3-binding protein (E3BP), which specifically
+        tethers E3 dimers to the PDC.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Correct and the most specific localization for PDHX; matches the UniProt
+      subcellular location.
+    action: ACCEPT
+    reason: &gt;-
+      UniProt SubCell mapping (SL-0170) to mitochondrial matrix is consistent with
+      the curated UniProt location and with PDHX being an assembled subunit of the
+      matrix-resident PDC.
+    supported_by:
+    - reference_id: file:human/PDHX/PDHX-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion matrix.&#34;
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      PDHX is a required structural subunit of the PDC, which performs the
+      oxidative decarboxylation of pyruvate to acetyl-CoA. As part_of the complex
+      it is legitimately &#34;involved_in&#34; this process even though it is not itself
+      catalytic.
+    action: ACCEPT
+    reason: &gt;-
+      Anchoring E3 to the E2 core is essential for a functional PDC; loss of PDHX
+      causes PDC deficiency. The BP annotation captures the pathway role of the
+      subunit and is corroborated by the ComplexPortal IDA (PMID:24534072) and the
+      IC annotation (PMID:9242632).
+    supported_by:
+    - reference_id: PMID:9242632
+      supporting_text: &gt;-
+        Protein X, recently renamed dihydrolipoamide dehydrogenase-binding protein
+        (E3BP), is required for anchoring dihydrolipoamide dehydrogenase (E3) to
+        the dihydrolipoamide transacetylase (E2) core of the pyruvate dehydrogenase
+        complexes of eukaryotes.
+- term:
+    id: GO:0016746
+    label: acyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Broad acyltransferase MF mapped from InterPro domains of the shared E2-like
+      fold. As with the more specific GO:0004742, PDHX does not catalyse acyl
+      transfer (catalytic His-&gt;Ser), so this is a fold-based over-annotation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The InterPro signatures (2-oxoacid_DH acyltransferase, E2/Pdx1) reflect the
+      E2-like inner-core fold that PDHX possesses structurally; the catalytic
+      residue is absent and no acyltransferase activity has been demonstrated.
+    supported_by:
+    - reference_id: PMID:9242632
+      supporting_text: &gt;-
+        The putative catalytic site histidine residue present in the inner core
+        domains of all dihydrolipoamide acyltransferases is replaced by a serine
+        residue in human E3BP; thus, catalysis of coenzyme A acetylation by this
+        protein is unlikely.
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Electronic (IEA) part_of PDC annotation, duplicating the well-supported
+      experimental/IBA annotations. Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with all other evidence that PDHX is a subunit of the PDC inner
+      core.
+    supported_by:
+    - reference_id: PMID:16263718
+      supporting_text: &gt;-
+        The dihydrolipoamide dehydrogenase-binding protein (E3BP) and the
+        dihydrolipoamide acetyltransferase (E2) component enzyme form the
+        structural core of the human pyruvate dehydrogenase complex
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16263718
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI interaction with DLD (E3, P09622) from the crystal structure of the
+      E3BP E3-binding domain in complex with E3. This is the key biological
+      interaction of PDHX, but the bare &#34;protein binding&#34; term is uninformative;
+      the specific E3-anchoring/adaptor role is captured in core_functions.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation guidelines, bare GO:0005515 &#34;protein binding&#34; adds no functional
+      information. The underlying DLD interaction is real and central, but is
+      better represented by the E3-anchoring adaptor function (GO:0030674) in
+      core_functions rather than by this generic term.
+    supported_by:
+    - reference_id: PMID:16263718
+      supporting_text: &gt;-
+        How dihydrolipoamide dehydrogenase-binding protein binds dihydrolipoamide
+        dehydrogenase in the human pyruvate dehydrogenase complex.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16442803
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI interaction with DLD (E3, P09622) from a second crystal structure of the
+      E3-binding domain in complex with E3, including hot-spot mutagenesis. Real
+      but bare/uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Meaningful DLD interaction but recorded as generic protein binding; the
+      specific anchoring/adaptor function is captured in core_functions.
+    supported_by:
+    - reference_id: PMID:16442803
+      supporting_text: &gt;-
+        utilizes the specific dihydrolipoamide dehydrogenase (E3) binding protein
+        (E3BP) to tether the essential E3 component to the 60-meric core of the
+        complex
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21516116
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction with AGTRAP (Q6RW13) from a high-throughput next-generation
+      sequencing interactome (Y2H) screen. No established biological role of PDHX
+      involves AGTRAP; a bare, high-throughput protein-binding hit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic protein-binding annotation from a proteome-scale screen with no
+      functional context for PDHX; uninformative for the gene&#39;s function.
+    supported_by:
+    - reference_id: PMID:21516116
+      supporting_text: Next-generation sequencing to generate interactome datasets.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction with AGTRAP (Q6RW13) from a proteome-scale binary interactome
+      map. High-throughput, bare protein-binding hit with no functional context.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative generic protein-binding from a large-scale interactome screen.
+    supported_by:
+    - reference_id: PMID:25416956
+      supporting_text: A proteome-scale map of the human interactome network.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25525879
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI interaction with SIRT4 (Q9Y6E7). SIRT4 is a lipoamidase that removes the
+      lipoyl modification from PDHX (Lys97) and DLAT to regulate PDC activity, so
+      this is a biologically meaningful interaction, but bare &#34;protein binding&#34; is
+      uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The SIRT4 interaction is functionally relevant (regulatory delipoylation),
+      but as recorded it is a generic protein-binding term; the regulatory
+      relationship is better captured as PTM/regulation, not as a core MF.
+    supported_by:
+    - reference_id: PMID:25525879
+      supporting_text: &gt;-
+        SIRT4 removed lipoamide from DLAT and PDHX peptides
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction with DLD (P09622) captured in a large-scale AP-MS interactome
+      (BioPlex). Consistent with the biological E3(DLD) interaction, but a bare,
+      uninformative protein-binding term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput DLD interaction; real but generic. Anchoring function is in
+      core_functions.
+    supported_by:
+    - reference_id: PMID:28514442
+      supporting_text: &gt;-
+        Architecture of the human interactome defines protein communities and
+        disease networks.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction with AGTRAP (Q6RW13) from a variant/interaction disruption study.
+      High-throughput, bare protein-binding hit with no functional role for PDHX.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic protein-binding from a large-scale interaction screen; uninformative.
+    supported_by:
+    - reference_id: PMID:31515488
+      supporting_text: &gt;-
+        Extensive disruption of protein interactions by genetic variants across
+        the allele frequency spectrum in human populations.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interactions with DLD (P09622) and CIDEB (Q9UHD4) from a reference binary
+      interactome map (HuRI). The DLD hit is consistent with biology; CIDEB has no
+      established role with PDHX. Bare protein-binding term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Mixed high-throughput hits recorded as generic protein binding; the DLD
+      interaction is real (anchoring, in core_functions) and CIDEB is an
+      uncharacterized screen hit.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: A reference map of the human binary protein interactome.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction with DLD (P09622) from a cell-specific AP-MS interactome
+      (BioPlex 3.0). Consistent with the biological E3(DLD) interaction, but bare.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput DLD interaction; real but recorded as generic protein
+      binding.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: &gt;-
+        Dual proteome-scale networks reveal cell-specific remodeling of the human
+        interactome.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: NAS
+  original_reference_id: PMID:24534072
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Non-traceable statement of mitochondrial localization (ComplexPortal),
+      consistent with the well-established matrix localization. Correct but less
+      specific than mitochondrial matrix.
+    action: ACCEPT
+    reason: &gt;-
+      PDHX is a matrix-resident PDC subunit; the mitochondrion annotation is
+      correct.
+    supported_by:
+    - reference_id: file:human/PDHX/PDHX-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion matrix.&#34;
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IDA
+  original_reference_id: PMID:24534072
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ComplexPortal IDA: reconstituted recombinant human PDC (including E3BP) was
+      shown to be functional in producing acetyl-CoA. PDHX participates as a
+      required structural subunit. Correct as involved_in.
+    action: ACCEPT
+    reason: &gt;-
+      A well-defined recombinant human PDC containing PDHX was assembled and shown
+      catalytically competent, supporting the subunit&#39;s involvement in pyruvate
+      decarboxylation to acetyl-CoA (as part of the complex, not as a catalyst).
+    supported_by:
+    - reference_id: PMID:24534072
+      supporting_text: &gt;-
+        The mammalian pyruvate dehydrogenase complex (PDC) is a multi-component
+        mitochondrial enzyme that plays a key role in the conversion of pyruvate to
+        acetyl-CoA connecting glycolysis to the citric acid cycle.
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IPI
+  original_reference_id: PMID:19240034
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Experimental (IPI) part_of PDC from stoichiometry/reconstitution work
+      establishing PDHX as ~20 copies (40/20 model) within the E2/E3BP core.
+      Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      Direct biophysical characterization places E3BP within the PDC core and shows
+      it tethers E3 to the complex.
+    supported_by:
+    - reference_id: PMID:19240034
+      supporting_text: &gt;-
+        The human PDC is organized around a 60-meric dodecahedral core comprising
+        the C-terminal domains of E2p and a noncatalytic component, E3-binding
+        protein (E3BP), which specifically tethers E3 dimers to the PDC.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Immunofluorescence (HPA) localization to mitochondrion. Consistent with the
+      established matrix localization.
+    action: ACCEPT
+    reason: &gt;-
+      Direct imaging evidence of mitochondrial localization; correct though less
+      specific than mitochondrial matrix.
+    supported_by:
+    - reference_id: file:human/PDHX/PDHX-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion matrix.&#34;
+- term:
+    id: GO:0004742
+    label: dihydrolipoyllysine-residue acetyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:9242632
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Legacy IDA (MGI) assigning transacetylase activity, but the same primary
+      paper explicitly concludes that CoA acetylation by human E3BP is unlikely
+      because the catalytic-site histidine is replaced by serine. This MF should
+      not be treated as a genuine catalytic function of PDHX.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The cited paper reconstituted a functional PDC using E3BP but attributes the
+      acetyltransferase catalysis to E2; it states the E3BP inner-core domain lacks
+      the catalytic histidine and is unlikely to catalyse acetylation. PDHX is a
+      structural (E3-anchoring) subunit, so this catalytic MF is an over-annotation
+      of the fold rather than a demonstrated activity.
+    supported_by:
+    - reference_id: PMID:9242632
+      supporting_text: &gt;-
+        The putative catalytic site histidine residue present in the inner core
+        domains of all dihydrolipoamide acyltransferases is replaced by a serine
+        residue in human E3BP; thus, catalysis of coenzyme A acetylation by this
+        protein is unlikely.
+- term:
+    id: GO:0006086
+    label: pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IC
+  original_reference_id: PMID:9242632
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: &gt;-
+      Curator inference (IC) that PDHX participates in pyruvate decarboxylation to
+      acetyl-CoA, based on its role in reconstituting a functional PDC. Consistent
+      with the subunit&#39;s essential contribution to the pathway.
+    action: ACCEPT
+    reason: &gt;-
+      PDHX is required for a functional PDC; its involvement in the
+      pyruvate-&gt;acetyl-CoA conversion is a reasonable curator inference and is
+      supported by reconstitution of the complex.
+    supported_by:
+    - reference_id: PMID:9242632
+      supporting_text: &gt;-
+        Coexpression of cDNAs for E3BP and E2 resulted in the formation of an
+        E2.E3BP subcomplex that spontaneously reconstituted the pyruvate
+        dehydrogenase complex in the presence of native E3 and recombinant pyruvate
+        decarboxylase (E1).
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial proteome localization. Consistent with the
+      established matrix localization of PDHX.
+    action: ACCEPT
+    reason: &gt;-
+      Corroborates mitochondrial localization; less specific than mitochondrial
+      matrix but correct.
+    supported_by:
+    - reference_id: PMID:34800366
+      supporting_text: &gt;-
+        Quantitative high-confidence human mitochondrial proteome and its dynamics
+        in cellular context.
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IDA
+  original_reference_id: PMID:9242632
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct experimental (IDA) part_of PDC from reconstitution of the E2.E3BP
+      subcomplex and functional PDC. Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      PDHX (E3BP) was shown to assemble into the PDC core with E2 and reconstitute
+      a functional complex, directly demonstrating it is part of the PDC.
+    supported_by:
+    - reference_id: PMID:9242632
+      supporting_text: &gt;-
+        Coexpression of cDNAs for E3BP and E2 resulted in the formation of an
+        E2.E3BP subcomplex that spontaneously reconstituted the pyruvate
+        dehydrogenase complex in the presence of native E3 and recombinant pyruvate
+        decarboxylase (E1).
+- term:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  evidence_type: IDA
+  original_reference_id: PMID:25525879
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IDA part_of PDC (UniProt), consistent with PDHX being a structural subunit of
+      the PDH complex characterized in the SIRT4 study. Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      The study describes PDHX as a structural subunit of the PDH complex and
+      immuno-isolates it as part of the complex.
+    supported_by:
+    - reference_id: PMID:25525879
+      supporting_text: a structural subunit (PDH-binding component X, PDHX)
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-203946
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to mitochondrial matrix (PDH regulation reaction
+      context). Correct and matches the UniProt subcellular location.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the curated matrix localization of PDHX as a PDC subunit.
+    supported_by:
+    - reference_id: file:human/PDHX/PDHX-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion matrix.&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-204169
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to mitochondrial matrix. Correct.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the curated matrix localization of PDHX.
+    supported_by:
+    - reference_id: file:human/PDHX/PDHX-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion matrix.&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861616
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to mitochondrial matrix (DLD dehydrogenation
+      reaction context). Correct.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the curated matrix localization of PDHX.
+    supported_by:
+    - reference_id: file:human/PDHX/PDHX-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion matrix.&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861667
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to mitochondrial matrix (DLAT acetyl transfer
+      reaction context). Correct.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the curated matrix localization of PDHX.
+    supported_by:
+    - reference_id: file:human/PDHX/PDHX-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion matrix.&#34;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861734
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to mitochondrial matrix (E1 decarboxylation
+      reaction context). Correct.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the curated matrix localization of PDHX.
+    supported_by:
+    - reference_id: file:human/PDHX/PDHX-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Mitochondrion matrix.&#34;
+- term:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  evidence_type: IDA
+  original_reference_id: PMID:16263718
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed molecular function capturing PDHX&#39;s established E3-anchoring role:
+      PDHX acts as an adaptor that tethers the E3 (DLD) dimer to the E2 (DLAT)
+      core of the PDC. Supported by two crystal structures of the E3BP E3-binding
+      domain bound to E3 and by mutagenesis of the interface hot-spot residues.
+    action: NEW
+    reason: &gt;-
+      The bare GO:0005515 protein-binding IPIs and the mis-attributed catalytic MF
+      terms fail to capture what PDHX actually does molecularly. Its function is a
+      protein-macromolecule adaptor/anchoring activity tethering E3 to the E2 core.
+    supported_by:
+    - reference_id: PMID:16263718
+      supporting_text: &gt;-
+        The dihydrolipoamide dehydrogenase-binding protein (E3BP) and the
+        dihydrolipoamide acetyltransferase (E2) component enzyme form the
+        structural core of the human pyruvate dehydrogenase complex
+    - reference_id: PMID:9242632
+      supporting_text: &gt;-
+        Protein X, recently renamed dihydrolipoamide dehydrogenase-binding protein
+        (E3BP), is required for anchoring dihydrolipoamide dehydrogenase (E3) to
+        the dihydrolipoamide transacetylase (E2) core of the pyruvate dehydrogenase
+        complexes of eukaryotes.
+- term:
+    id: GO:0005198
+    label: structural molecule activity
+  evidence_type: IDA
+  original_reference_id: PMID:16263718
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Proposed molecular function reflecting PDHX&#39;s role as a structural
+      constituent of the PDC inner core: together with E2 (DLAT) it forms the
+      dodecahedral scaffold that binds the peripheral E1 and E3 catalytic
+      components. PDHX itself is non-catalytic.
+    action: NEW
+    reason: &gt;-
+      Captures the structural/scaffolding contribution of PDHX to the PDC core,
+      complementing the adaptor (E3-anchoring) function and replacing the
+      fold-based catalytic over-annotations.
+    supported_by:
+    - reference_id: PMID:16263718
+      supporting_text: &gt;-
+        The dihydrolipoamide dehydrogenase-binding protein (E3BP) and the
+        dihydrolipoamide acetyltransferase (E2) component enzyme form the
+        structural core of the human pyruvate dehydrogenase complex
+core_functions:
+- description: &gt;-
+    Anchors the E3 dihydrolipoyl dehydrogenase (DLD) dimer to the E2 (DLAT) core
+    of the pyruvate dehydrogenase complex via its E3-binding (peripheral
+    subunit-binding) domain, acting as a molecular adaptor that tethers the
+    catalytic E3 to the assembled complex; this structural role is essential for a
+    functional PDC.
+  molecular_function:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  in_complex:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:19240034
+    supporting_text: &gt;-
+      a noncatalytic component, E3-binding protein (E3BP), which specifically
+      tethers E3 dimers to the PDC.
+  - reference_id: PMID:9242632
+    supporting_text: &gt;-
+      Protein X, recently renamed dihydrolipoamide dehydrogenase-binding protein
+      (E3BP), is required for anchoring dihydrolipoamide dehydrogenase (E3) to the
+      dihydrolipoamide transacetylase (E2) core of the pyruvate dehydrogenase
+      complexes of eukaryotes.
+- description: &gt;-
+    Serves as a structural constituent of the pyruvate dehydrogenase complex
+    inner core, integrating (together with E2/DLAT) into the dodecahedral core
+    that provides the scaffold binding the peripheral E1 and E3 catalytic
+    components; PDHX itself is non-catalytic (its E2-like inner-core fold lacks the
+    catalytic histidine).
+  molecular_function:
+    id: GO:0005198
+    label: structural molecule activity
+  in_complex:
+    id: GO:0045254
+    label: pyruvate dehydrogenase complex
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: PMID:16263718
+    supporting_text: &gt;-
+      The dihydrolipoamide dehydrogenase-binding protein (E3BP) and the
+      dihydrolipoamide acetyltransferase (E2) component enzyme form the structural
+      core of the human pyruvate dehydrogenase complex
+  - reference_id: PMID:9242632
+    supporting_text: &gt;-
+      The putative catalytic site histidine residue present in the inner core
+      domains of all dihydrolipoamide acyltransferases is replaced by a serine
+      residue in human E3BP; thus, catalysis of coenzyme A acetylation by this
+      protein is unlikely.
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Beyond its structural E3-anchoring role, does the lipoyl domain of PDHX
+    (lipoylated at Lys97) participate directly in the reductive acetylation /
+    lipoyl-arm shuttling cycle of the PDC, or is it functionally redundant with
+    the DLAT lipoyl domains?
+- question: &gt;-
+    What is the physiological significance of SIRT4-mediated delipoylation of PDHX
+    Lys97 relative to delipoylation of DLAT for regulating PDC flux?
+suggested_experiments:
+- hypothesis: &gt;-
+    The PDHX lipoyl group is dispensable for PDC catalysis, consistent with a
+    purely structural/anchoring role.
+  description: &gt;-
+    Reconstitute human PDC with lipoyl-null (K97) PDHX to test whether the PDHX
+    lipoyl group is catalytically required or purely structural.
+- hypothesis: &gt;-
+    The PDHX inner-core domain has no detectable dihydrolipoyllysine-residue
+    acetyltransferase activity because it lacks the catalytic histidine.
+  description: &gt;-
+    Assay purified human E3BP/PDHX inner-core domain for any residual
+    transacetylase activity to confirm the loss of acyltransferase function
+    implied by the His-&gt;Ser substitution.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:16263718
+  title: How dihydrolipoamide dehydrogenase-binding protein binds dihydrolipoamide
+    dehydrogenase in the human pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Crystal structure of the E3BP E3-binding domain with DLD (E3); directly
+      establishes the E3-anchoring/structural-core function. PubMed-verified.
+- id: PMID:16442803
+  title: Structural insight into interactions between dihydrolipoamide dehydrogenase
+    (E3) and E3 binding protein of human pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Second crystal structure + hot-spot mutagenesis of the E3BP/E3 interface;
+      supports the tethering function. PubMed-verified.
+- id: PMID:19240034
+  title: Subunit and catalytic component stoichiometries of an in vitro reconstituted
+    human pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Explicitly describes E3BP as a &#34;noncatalytic component&#34; that tethers E3
+      dimers to the PDC; key evidence for the non-catalytic structural role.
+- id: PMID:21516116
+  title: Next-generation sequencing to generate interactome datasets.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Methods paper for a high-throughput Y2H interactome; source of an
+      uninformative AGTRAP protein-binding hit.
+- id: PMID:24534072
+  title: Component co-expression and purification of recombinant human pyruvate dehydrogenase
+    complex from baculovirus infected SF9 cells.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Recombinant reconstitution of functional human PDC (including E3BP);
+      supports involvement in pyruvate decarboxylation as a complex subunit.
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale binary interactome; source of an uninformative AGTRAP hit.
+- id: PMID:25525879
+  title: Sirtuin 4 is a lipoamidase regulating pyruvate dehydrogenase complex activity.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes PDHX as a lipoylated structural subunit and SIRT4 lipoamidase
+      substrate (Lys97); relevant to regulation, not to a catalytic MF.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex AP-MS interactome; captures the DLD interaction as a generic hit.
+- id: PMID:31515488
+  title: Extensive disruption of protein interactions by genetic variants across the
+    allele frequency spectrum in human populations.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Variant/interaction-disruption screen; source of an uninformative AGTRAP hit.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      HuRI reference interactome; DLD hit consistent with biology, CIDEB
+      uncharacterized.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex 3.0 interactome; captures the DLD interaction as a generic hit.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-confidence mitochondrial proteome; corroborates mitochondrial
+      localization.
+- id: PMID:9242632
+  title: Dihydrolipoamide dehydrogenase-binding protein of the human pyruvate dehydrogenase
+    complex. DNA-derived amino acid sequence, expression, and reconstitution of the
+    pyruvate dehydrogenase complex.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary characterization: E3BP anchors E3 to the E2 core; catalytic His
+      replaced by Ser so acetyltransferase catalysis is unlikely. Foundational.
+- id: Reactome:R-HSA-203946
+  title: PDK isozymes phosphorylate PDHC subunit E1
+  findings: []
+- id: Reactome:R-HSA-204169
+  title: PDP1,2 dephosphorylate p-lipo-PDH
+  findings: []
+- id: Reactome:R-HSA-9861616
+  title: DLD dimer dehydrogenates dihydrolipoyl
+  findings: []
+- id: Reactome:R-HSA-9861667
+  title: DLAT trimer transfers acetyl to CoA
+  findings: []
+- id: Reactome:R-HSA-9861734
+  title: PDH E1 decarboxylates PYR, transferring acetyl to DLAT
+  findings: []
+- id: file:human/PDHX/PDHX-uniprot.txt
+  title: UniProtKB entry O00330 (ODPX_HUMAN), Pyruvate dehydrogenase protein X component,
+    mitochondrial
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/modules/cuproptosis.html
+++ b/pages/modules/cuproptosis.html
@@ -586,12 +586,12 @@ Design intent: the module is organized as an upstream copper-homeostasis layer t
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(2/16 grounded genes reviewed)</span>
+                    <span class="muted small">(5/16 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        2 complete review(s) &middot;
+                        5 complete review(s) &middot;
                         2 with deep research &middot;
-                        14 missing review &middot;
-                        0 reviewed but lacking deep research
+                        11 missing review &middot;
+                        3 reviewed but lacking deep research
                     </p>
                     <table class="qc-table small">
                         <thead>
@@ -614,6 +614,12 @@ Design intent: the module is organized as an upstream copper-homeostasis layer t
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>DLAT
+                                        <span class="muted term-id">P10515</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
                                 </tr>                                <tr>
                                     <td>DLD
                                         <span class="muted term-id">P09622</span></td>
@@ -645,26 +651,8 @@ Design intent: the module is organized as an upstream copper-homeostasis layer t
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>PDHA1
-                                        <span class="muted term-id">P08559</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
                                     <td>FDX1
                                         <span class="muted term-id">P10109</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>DLAT
-                                        <span class="muted term-id">P10515</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>PDHB
-                                        <span class="muted term-id">P11177</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>
@@ -674,6 +662,18 @@ Design intent: the module is organized as an upstream copper-homeostasis layer t
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>
+                                </tr>                                <tr>
+                                    <td>PDHA1
+                                        <span class="muted term-id">P08559</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PDHB
+                                        <span class="muted term-id">P11177</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
                                 </tr>                                <tr>
                                     <td>ATP7A
                                         <span class="muted term-id">Q04656</span></td>

--- a/pages/modules/gluconeogenesis_human.html
+++ b/pages/modules/gluconeogenesis_human.html
@@ -590,12 +590,12 @@
             </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(0/7 grounded genes reviewed)</span>
+                    <span class="muted small">(1/7 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        0 complete review(s) &middot;
+                        1 complete review(s) &middot;
                         0 with deep research &middot;
-                        7 missing review &middot;
-                        0 reviewed but lacking deep research
+                        6 missing review &middot;
+                        1 reviewed but lacking deep research
                     </p>
                     <table class="qc-table small">
                         <thead>
@@ -625,12 +625,6 @@
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>PC (pyruvate carboxylase)
-                                        <span class="muted term-id">P11498</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
                                     <td>PCK1 (cytosolic PEPCK)
                                         <span class="muted term-id">P35558</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
@@ -642,6 +636,12 @@
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>
+                                </tr>                                <tr>
+                                    <td>PC
+                                        <span class="muted term-id">P11498</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
                                 </tr>                                <tr>
                                     <td>PCK2 (mitochondrial PEPCK)
                                         <span class="muted term-id">Q16822</span></td>

--- a/pages/modules/gluconeogenesis_human_substrates.html
+++ b/pages/modules/gluconeogenesis_human_substrates.html
@@ -584,12 +584,12 @@
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(0/13 grounded genes reviewed)</span>
+                    <span class="muted small">(1/13 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        0 complete review(s) &middot;
+                        1 complete review(s) &middot;
                         0 with deep research &middot;
-                        13 missing review &middot;
-                        0 reviewed but lacking deep research
+                        12 missing review &middot;
+                        1 reviewed but lacking deep research
                     </p>
                     <table class="qc-table small">
                         <thead>
@@ -631,12 +631,6 @@
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>
                                 </tr>                                <tr>
-                                    <td>PC (pyruvate carboxylase)
-                                        <span class="muted term-id">P11498</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
                                     <td>GPD1 (glycerol-3-phosphate dehydrogenase)
                                         <span class="muted term-id">P21695</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
@@ -666,6 +660,12 @@
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>
+                                </tr>                                <tr>
+                                    <td>PC
+                                        <span class="muted term-id">P11498</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
                                 </tr>                                <tr>
                                     <td>PCK2 (mitochondrial PEPCK)
                                         <span class="muted term-id">Q16822</span></td>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -285,7 +285,7 @@
 
     <section class="toolbar">
         <input class="search" type="search" placeholder="Filter modules" data-module-search>
-        <div class="count"><span data-visible-count>102</span> / 102 modules</div>
+        <div class="count"><span data-visible-count>103</span> / 103 modules</div>
     </section>
 
     <div class="table-wrap">
@@ -718,8 +718,8 @@ Design intent: the module is organized as an upstream copper-homeostasis layer t
                     <td class="num">6</td>
                     <td class="num">0</td>
                     <td class="num">0</td>
-                    <td class="num">8</td>                    <td class="num" data-sort-value="2">
-                        2/16
+                    <td class="num">8</td>                    <td class="num" data-sort-value="5">
+                        5/16
                     </td>
                     <td class="num" data-sort-value="1">
                         1
@@ -1525,8 +1525,8 @@ Unlike molecular-function-tiered motifs (e.g. the MAPK relay, where every realiz
                     <td class="num">10</td>
                     <td class="num">6</td>
                     <td class="num">12</td>
-                    <td class="num">0</td>                    <td class="num" data-sort-value="0">
-                        0/13
+                    <td class="num">0</td>                    <td class="num" data-sort-value="1">
+                        1/13
                     </td>
                     <td class="num" data-sort-value="0">
                         0
@@ -1548,8 +1548,8 @@ Unlike molecular-function-tiered motifs (e.g. the MAPK relay, where every realiz
                     <td class="num">7</td>
                     <td class="num">2</td>
                     <td class="num">4</td>
-                    <td class="num">4</td>                    <td class="num" data-sort-value="0">
-                        0/7
+                    <td class="num">4</td>                    <td class="num" data-sort-value="1">
+                        1/7
                     </td>
                     <td class="num" data-sort-value="1">
                         1
@@ -2040,6 +2040,29 @@ The regulatory structure is transcribed from the biosustain Maud kinetic model `
                         0
                     </td>
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/fatty_acid_beta_oxidation.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="Mitochondrial pyruvate fates — pyruvate dehydrogenase complex and pyruvate carboxylase">
+                        <a class="module-name" href="pyruvate_metabolism.html">Mitochondrial pyruvate fates — pyruvate dehydrogenase complex and pyruvate carboxylase</a><span class="module-id">MODULE:pyruvate_metabolism</span>                        <span class="module-desc">The two committed mitochondrial fates of pyruvate (imported from glycolysis via the mitochondrial pyruvate carrier). (1) Oxidative decarboxylation...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">The two committed mitochondrial fates of pyruvate (imported from glycolysis via the mitochondrial pyruvate carrier). (1) Oxidative decarboxylation by the pyruvate dehydrogenase complex (PDC) links glycolysis to the TCA cycle: pyruvate + CoA + NAD+ -&gt; acetyl-CoA + CO2 + NADH. The PDC is a giant mitochondrial-matrix multienzyme machine built on a 60-mer E2 (DLAT) core, with the thiamine-pyrophosphate-dependent E1 decarboxylase (an alpha2-beta2 heterotetramer of PDHA1 and PDHB), the E3-binding structural subunit PDHX (component X) that anchors the shared E3 dihydrolipoyl dehydrogenase (DLD), and DLD itself which reoxidises the lipoyl arms (passing electrons to NAD+). PDC flux is switched off by phosphorylation of E1alpha (by the pyruvate dehydrogenase kinases PDK1-4) and on by dephosphorylation (by the phosphatases PDP1/2). (2) Carboxylation by the biotin-dependent pyruvate carboxylase (PC): pyruvate + HCO3- + ATP -&gt; oxaloacetate, the principal anaplerotic reaction replenishing TCA-cycle oxaloacetate and the committed first step of gluconeogenesis from pyruvate/lactate; PC is allosterically activated by acetyl-CoA (the PDC product), coordinating the two fates. Inherited defects cause severe lactic acidosis and neurological disease: PDHA1 (X-linked, the commonest), PDHB, DLAT and PDHX deficiencies cause pyruvate dehydrogenase complex deficiency (Leigh syndrome spectrum), and PC deficiency causes lactic acidosis with hypoglycemia; DLD deficiency (the shared E3) gives a combined phenotype (see the BCAA and homocysteine/cobalamin contexts).</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">pyruvate metabolic process</span>                        </div>                    </td>
+                    <td class="num">3</td>
+                    <td class="num">6</td>
+                    <td class="num">2</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">1</td>                    <td class="num" data-sort-value="6">
+                        6/6
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/pyruvate_metabolism.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="NLR signaling pathway module">
                         <a class="module-name" href="nlr_signaling.html">NLR signaling pathway module</a><span class="module-id">MODULE:nlr_signaling</span>                        <span class="module-desc">Nucleotide-binding leucine-rich-repeat receptors detect intracellular perturbations and assemble RIPK-, ASC-, or caspase-containing signaling...</span>                        <details class="module-desc-more">

--- a/pages/modules/pyruvate_metabolism.html
+++ b/pages/modules/pyruvate_metabolism.html
@@ -1,0 +1,912 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mitochondrial pyruvate fates — pyruvate dehydrogenase complex and pyruvate carboxylase - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / Mitochondrial pyruvate fates — pyruvate dehydrogenase complex and pyruvate carboxylase
+    </nav>
+
+    <header class="header">
+        <h1>Mitochondrial pyruvate fates — pyruvate dehydrogenase complex and pyruvate carboxylase</h1>            <p class="description">The two committed mitochondrial fates of pyruvate (imported from glycolysis via the mitochondrial pyruvate carrier). (1) Oxidative decarboxylation by the pyruvate dehydrogenase complex (PDC) links glycolysis to the TCA cycle: pyruvate + CoA + NAD+ -&gt; acetyl-CoA + CO2 + NADH. The PDC is a giant mitochondrial-matrix multienzyme machine built on a 60-mer E2 (DLAT) core, with the thiamine-pyrophosphate-dependent E1 decarboxylase (an alpha2-beta2 heterotetramer of PDHA1 and PDHB), the E3-binding structural subunit PDHX (component X) that anchors the shared E3 dihydrolipoyl dehydrogenase (DLD), and DLD itself which reoxidises the lipoyl arms (passing electrons to NAD+). PDC flux is switched off by phosphorylation of E1alpha (by the pyruvate dehydrogenase kinases PDK1-4) and on by dephosphorylation (by the phosphatases PDP1/2). (2) Carboxylation by the biotin-dependent pyruvate carboxylase (PC): pyruvate + HCO3- + ATP -&gt; oxaloacetate, the principal anaplerotic reaction replenishing TCA-cycle oxaloacetate and the committed first step of gluconeogenesis from pyruvate/lactate; PC is allosterically activated by acetyl-CoA (the PDC product), coordinating the two fates. Inherited defects cause severe lactic acidosis and neurological disease: PDHA1 (X-linked, the commonest), PDHB, DLAT and PDHX deficiencies cause pyruvate dehydrogenase complex deficiency (Leigh syndrome spectrum), and PC deficiency causes lactic acidosis with hypoglycemia; DLD deficiency (the shared E3) gives a combined phenotype (see the BCAA and homocysteine/cobalamin contexts).</p>        <div class="meta-row"><span class="pill">MODULE:pyruvate_metabolism</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/pyruvate_metabolism.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>pyruvate metabolic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006090" target="_blank" rel="noopener">GO:0006090</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006090" target="_blank" rel="noopener">GO:0006090</a><div><strong>pyruvate metabolic process</strong></div><div>The module is grounded in the GO pyruvate metabolic process (GO:0006090), covering the oxidative-decarboxylation (PDC) and carboxylation (PC) fates.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-70268</span><div><strong>Pyruvate metabolism</strong></div><div>Reaction stoichiometries follow the human Reactome pyruvate-metabolism reactions R-HSA-9861559 (PDC synthesizes acetyl-CoA from pyruvate) and R-HSA-70501 (PC carboxylates pyruvate to oxaloacetate).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PDHA1/PDHA1-ai-review.yaml</span><div><strong>PDHA1 gene review (human)</strong></div><div>The PDC E1-alpha grounding (UniProtKB:P08559, GO:0004739 pyruvate dehydrogenase (acetyl-transferring) activity, GO:0045254 complex) matches the completed human PDHA1 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PDHB/PDHB-ai-review.yaml</span><div><strong>PDHB gene review (human)</strong></div><div>The PDC E1-beta grounding (UniProtKB:P11177, GO:0004739, GO:0045254) matches the completed human PDHB review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/DLAT/DLAT-ai-review.yaml</span><div><strong>DLAT gene review (human)</strong></div><div>The PDC E2 core grounding (UniProtKB:P10515, GO:0004742 dihydrolipoyllysine- residue acetyltransferase activity, GO:0045254) matches the completed human DLAT review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PDHX/PDHX-ai-review.yaml</span><div><strong>PDHX gene review (human)</strong></div><div>The E3-binding structural subunit grounding (UniProtKB:O00330, GO:0030674 protein-macromolecule adaptor activity, GO:0045254) matches the completed human PDHX review (a non-catalytic scaffold anchoring DLD).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/DLD/DLD-ai-review.yaml</span><div><strong>DLD gene review (human)</strong></div><div>The shared E3 grounding (UniProtKB:P09622, GO:0004148 dihydrolipoyl dehydrogenase (NADH) activity) matches the completed human DLD review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PC/PC-ai-review.yaml</span><div><strong>PC gene review (human)</strong></div><div>The pyruvate carboxylase grounding (UniProtKB:P11498, GO:0004736 pyruvate carboxylase activity) matches the completed human PC review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">1</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:pyruvate_metabolism</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(6/6 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        6 complete review(s) &middot;
+                        1 with deep research &middot;
+                        0 missing review &middot;
+                        5 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>DLAT
+                                        <span class="muted term-id">P10515</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>DLD
+                                        <span class="muted term-id">P09622</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>PC
+                                        <span class="muted term-id">P11498</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PDHA1
+                                        <span class="muted term-id">P08559</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PDHB
+                                        <span class="muted term-id">P11177</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PDHX
+                                        <span class="muted term-id">O00330</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pyruvate_metabolism">Mitochondrial pyruvate metabolism (PDC + pyruvate carboxylase)</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">pyruvate_metabolism</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. oxidative decarboxylation to acetyl-CoA (glycolysis-to-TCA gateway)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pdc_step">pyruvate + CoA + NAD+ to acetyl-CoA + CO2 + NADH (pyruvate dehydrogenase complex)</a><span class="pill type">Protein Complex</span><span class="tree-id">pdc_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pdha1_activity">PDHA1: PDC E1 alpha (TPP decarboxylase)</a>
+                                <span class="tree-id">Family: Pyruvate dehydrogenase E1 alpha family (PDHA1)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pdhb_activity">PDHB: PDC E1 beta</a>
+                                <span class="tree-id">Family: Pyruvate dehydrogenase E1 beta / transketolase-like family (PDHB)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-dlat_activity">DLAT: PDC E2 (dihydrolipoyl acetyltransferase core)</a>
+                                <span class="tree-id">Family: 2-oxoacid dehydrogenase E2 (dihydrolipoyl acyltransferase) family (DLAT)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pdhx_activity">PDHX: PDC component X / E3-binding protein (structural)</a>
+                                <span class="tree-id">Family: 2-oxoacid dehydrogenase E3-binding-protein family (PDHX)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-dld_activity">DLD: shared E3 (dihydrolipoyl dehydrogenase)</a>
+                                <span class="tree-id">Family: Dihydrolipoyl dehydrogenase / pyridine-nucleotide-disulphide oxidoreductase family (DLD)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. anaplerotic / gluconeogenic carboxylation to oxaloacetate</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pc_step">pyruvate + HCO3- + ATP to oxaloacetate + ADP + Pi</a><span class="pill type">Reaction</span><span class="tree-id">pc_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pc_activity">PC: pyruvate carboxylase (biotin-dependent)</a>
+                                <span class="tree-id">Family: Pyruvate carboxylase family (PC)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-pyruvate_metabolism">
+        <div class="node-heading">
+            <span class="node-title">Mitochondrial pyruvate metabolism (PDC + pyruvate carboxylase)</span><span class="pill type">Metabolic Pathway</span><span class="pill">pyruvate_metabolism</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>pyruvate metabolic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006090" target="_blank" rel="noopener">GO:0006090</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>
+
+            </div>
+        <p class="muted small">The two committed mitochondrial fates of pyruvate, grounded to the human enzymes of the pyruvate dehydrogenase complex — PDHA1 (UniProtKB:P08559) and PDHB (P11177) of E1 (GO:0004739, EC 1.2.4.1), the E2 core DLAT (P10515, GO:0004742, EC 2.3.1.12), the E3-binding structural subunit PDHX (O00330, GO:0030674) and the shared E3 DLD (P09622, GO:0004148, EC 1.8.1.4), assembled as GO:0045254 — and pyruvate carboxylase PC (P11498, GO:0004736, EC 6.4.1.1). GO molecular-function/cellular-component terms were taken from the human GOA records; Reactome reaction ids and titles were verified against the local reactome cache. Each step uses a PANTHER family selector (generic over paralogs and orthologs) plus a concrete human representative member; the PDC is modelled as a PROTEIN_COMPLEX node with its five subunit types. PDHX is deliberately grounded as a non-catalytic adaptor (its E2-type catalytic His is replaced by Ser); DLD is the shared E3 of multiple 2-oxoacid dehydrogenase complexes. Upstream, pyruvate comes from glycolysis (via the mitochondrial pyruvate carrier); downstream, PDC-derived acetyl-CoA and PC-derived oxaloacetate feed the TCA cycle, and PC also feeds gluconeogenesis. PDC activity is phospho-regulated by the PDK kinases / PDP phosphatases (not modelled here).</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pdc_step">pdc_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pc_step">pc_step</a>                            <span class="pill">Positively Regulates</span></div>                        <div class="muted">Acetyl-CoA produced by the PDC is the obligate allosteric activator of pyruvate carboxylase, coordinating the oxidative and anaplerotic fates of pyruvate (and, together, supplying acetyl-CoA + oxaloacetate for citrate synthesis / the TCA cycle).</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: oxidative decarboxylation to acetyl-CoA (glycolysis-to-TCA gateway)</div>
+                <section class="node-detail depth-1" id="node-pdc_step">
+        <div class="node-heading">
+            <span class="node-title">pyruvate + CoA + NAD+ to acetyl-CoA + CO2 + NADH (pyruvate dehydrogenase complex)</span><span class="pill type">Protein Complex</span><span class="pill">pdc_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pdha1_activity">
+        <div class="annoton-title">PDHA1: PDC E1 alpha (TPP decarboxylase)</div>
+        <div class="small muted">pdha1_activity</div>            <div class="small"><strong>Participant:</strong> Family: Pyruvate dehydrogenase E1 alpha family (PDHA1)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Pyruvate dehydrogenase E1 alpha family (PDHA1)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11516" target="_blank" rel="noopener">PANTHER:PTHR11516</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PDHA1 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P08559/entry" target="_blank" rel="noopener">UniProtKB:P08559</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>pyruvate dehydrogenase (acetyl-transferring) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004739" target="_blank" rel="noopener">GO:0004739</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>pyruvate</span></span>                            <span class="descriptor">
+            <span>thiamine diphosphate (cofactor)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>(hydroxyethyl-TPP intermediate)</span></span>                            <span class="descriptor">
+            <span>carbon dioxide</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">TPP-dependent decarboxylase; with PDHB forms the alpha2-beta2 E1 that decarboxylates pyruvate and reductively acetylates the E2 lipoyl arm. The phosphoregulated subunit (PDK off / PDP on). X-linked; commonest PDC deficiency.</p></article>                    <article class="annoton-card" id="annoton-pdhb_activity">
+        <div class="annoton-title">PDHB: PDC E1 beta</div>
+        <div class="small muted">pdhb_activity</div>            <div class="small"><strong>Participant:</strong> Family: Pyruvate dehydrogenase E1 beta / transketolase-like family (PDHB)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Pyruvate dehydrogenase E1 beta / transketolase-like family (PDHB)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11624" target="_blank" rel="noopener">PANTHER:PTHR11624</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PDHB (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P11177/entry" target="_blank" rel="noopener">UniProtKB:P11177</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>pyruvate dehydrogenase (acetyl-transferring) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004739" target="_blank" rel="noopener">GO:0004739</a></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Beta subunit of the E1 heterotetramer; completes the TPP-binding active site with PDHA1. Deficiency causes PDC (E1-beta) deficiency.</p></article>                    <article class="annoton-card" id="annoton-dlat_activity">
+        <div class="annoton-title">DLAT: PDC E2 (dihydrolipoyl acetyltransferase core)</div>
+        <div class="small muted">dlat_activity</div>            <div class="small"><strong>Participant:</strong> Family: 2-oxoacid dehydrogenase E2 (dihydrolipoyl acyltransferase) family (DLAT)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>2-oxoacid dehydrogenase E2 (dihydrolipoyl acyltransferase) family (DLAT)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR23151" target="_blank" rel="noopener">PANTHER:PTHR23151</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>DLAT (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P10515/entry" target="_blank" rel="noopener">UniProtKB:P10515</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dihydrolipoyllysine-residue acetyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004742" target="_blank" rel="noopener">GO:0004742</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>S-acetyl-dihydrolipoyl intermediate</span></span>                            <span class="descriptor">
+            <span>coenzyme A</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>acetyl-CoA</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Lipoyl-bearing E2 subunit forming the 60-mer structural core of the PDC; transfers the acetyl group from the lipoyl arm to CoA, yielding acetyl-CoA. Deficiency causes PDC (E2) deficiency; also a primary biliary cholangitis autoantigen.</p></article>                    <article class="annoton-card" id="annoton-pdhx_activity">
+        <div class="annoton-title">PDHX: PDC component X / E3-binding protein (structural)</div>
+        <div class="small muted">pdhx_activity</div>            <div class="small"><strong>Participant:</strong> Family: 2-oxoacid dehydrogenase E3-binding-protein family (PDHX)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>2-oxoacid dehydrogenase E3-binding-protein family (PDHX)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR23151" target="_blank" rel="noopener">PANTHER:PTHR23151</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PDHX (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/O00330/entry" target="_blank" rel="noopener">UniProtKB:O00330</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>protein-macromolecule adaptor activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0030674" target="_blank" rel="noopener">GO:0030674</a></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Structural E3-binding subunit (component X): built into the E2 core, it binds and positions the shared E3 (DLD). Not a classic enzyme (catalytically dead). Deficiency causes PDC (E3BP) deficiency.</p></article>                    <article class="annoton-card" id="annoton-dld_activity">
+        <div class="annoton-title">DLD: shared E3 (dihydrolipoyl dehydrogenase)</div>
+        <div class="small muted">dld_activity</div>            <div class="small"><strong>Participant:</strong> Family: Dihydrolipoyl dehydrogenase / pyridine-nucleotide-disulphide oxidoreductase family (DLD)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Dihydrolipoyl dehydrogenase / pyridine-nucleotide-disulphide oxidoreductase family (DLD)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR22912" target="_blank" rel="noopener">PANTHER:PTHR22912</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>DLD (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P09622/entry" target="_blank" rel="noopener">UniProtKB:P09622</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dihydrolipoyl dehydrogenase (NADH) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004148" target="_blank" rel="noopener">GO:0004148</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>dihydrolipoyl-E2 (reduced lipoyl arm)</span></span>                            <span class="descriptor">
+            <span>NAD+</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>lipoyl-E2 (reoxidised)</span></span>                            <span class="descriptor">
+            <span>NADH</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">FAD-dependent E3 that reoxidises the dihydrolipoyl arm, passing electrons to NAD+. The common E3 shared with the 2-oxoglutarate and branched-chain 2-oxoacid dehydrogenase complexes and the glycine cleavage system (see the BCAA catabolism module).</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: anaplerotic / gluconeogenic carboxylation to oxaloacetate</div>
+                <section class="node-detail depth-1" id="node-pc_step">
+        <div class="node-heading">
+            <span class="node-title">pyruvate + HCO3- + ATP to oxaloacetate + ADP + Pi</span><span class="pill type">Reaction</span><span class="pill">pc_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pc_activity">
+        <div class="annoton-title">PC: pyruvate carboxylase (biotin-dependent)</div>
+        <div class="small muted">pc_activity</div>            <div class="small"><strong>Participant:</strong> Family: Pyruvate carboxylase family (PC)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Pyruvate carboxylase family (PC)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43778" target="_blank" rel="noopener">PANTHER:PTHR43778</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PC (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P11498/entry" target="_blank" rel="noopener">UniProtKB:P11498</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>pyruvate carboxylase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004736" target="_blank" rel="noopener">GO:0004736</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>pyruvate</span></span>                            <span class="descriptor">
+            <span>hydrogencarbonate</span></span>                            <span class="descriptor">
+            <span>ATP</span></span>                            <span class="descriptor">
+            <span>biotin (covalent cofactor)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>oxaloacetate</span></span>                            <span class="descriptor">
+            <span>ADP</span></span>                            <span class="descriptor">
+            <span>phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>mitochondrial matrix</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005759" target="_blank" rel="noopener">GO:0005759</a></span>        </div>            <p class="role-description">Biotin-dependent homotetramer; the principal anaplerotic reaction (replenishing TCA oxaloacetate) and the committed first step of gluconeogenesis from pyruvate/lactate. Allosterically activated by acetyl-CoA (the PDC product). Deficiency causes pyruvate carboxylase deficiency (severe lactic acidosis, hypoglycemia).</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/projects/CUPROPTOSIS.html
+++ b/pages/projects/CUPROPTOSIS.html
@@ -381,7 +381,7 @@
 direct binding of copper to <strong>lipoylated</strong> proteins of the mitochondrial<br />
 tricarboxylic acid (TCA) cycle. It is mechanistically distinct from apoptosis,<br />
 necroptosis, ferroptosis, and pyroptosis. When intracellular Cu²⁺ is reduced to<br />
-Cu⁺ by the ferredoxin <strong>FDX1</strong>, copper binds lipoylated <strong>DLAT</strong> (the E2<br />
+Cu⁺ by the ferredoxin <strong>FDX1</strong>, copper binds lipoylated <strong><a href="../../genes/human/DLAT/DLAT-ai-review.html">DLAT</a></strong> (the E2<br />
 component of the pyruvate dehydrogenase complex), triggering its disulfide-bond–<br />
 dependent oligomerization/aggregation, alongside destabilization of Fe–S cluster<br />
 proteins. The resulting proteotoxic stress kills the cell. Because cuproptosis<br />
@@ -422,9 +422,9 @@ exporters and chaperones set the threshold:<br />
 - <strong><a href="../../genes/human/DLD/DLD-ai-review.html">DLD</a></strong> — dihydrolipoamide dehydrogenase (E3; shared component)</p>
 <h3 id="4-lipoylated-targets-the-death-effectors">4. Lipoylated Targets — the Death Effectors</h3>
 <ul>
-<li><strong>DLAT</strong> — dihydrolipoamide S-acetyltransferase (PDH E2); copper-bound<br />
-  lipoylated DLAT oligomerizes/aggregates — a hallmark of cuproptosis</li>
-<li><strong>PDHA1</strong> / <strong>PDHB</strong> — pyruvate dehydrogenase E1 α/β subunits</li>
+<li><strong><a href="../../genes/human/DLAT/DLAT-ai-review.html">DLAT</a></strong> — dihydrolipoamide S-acetyltransferase (PDH E2); copper-bound<br />
+  lipoylated <a href="../../genes/human/DLAT/DLAT-ai-review.html">DLAT</a> oligomerizes/aggregates — a hallmark of cuproptosis</li>
+<li><strong><a href="../../genes/human/PDHA1/PDHA1-ai-review.html">PDHA1</a></strong> / <strong><a href="../../genes/human/PDHB/PDHB-ai-review.html">PDHB</a></strong> — pyruvate dehydrogenase E1 α/β subunits</li>
 <li><strong>GCSH</strong> — glycine cleavage system H protein (lipoylated)</li>
 </ul>
 <h3 id="5-regulators-and-specificity-controls">5. Regulators and Specificity Controls</h3>
@@ -468,17 +468,17 @@ exporters and chaperones set the threshold:<br />
 <td>Dihydrolipoamide dehydrogenase (E3)</td>
 </tr>
 <tr>
-<td>DLAT</td>
+<td><a href="../../genes/human/DLAT/DLAT-ai-review.html">DLAT</a></td>
 <td>P10515</td>
 <td>Lipoylated PDH E2; copper-induced aggregation effector</td>
 </tr>
 <tr>
-<td>PDHA1</td>
+<td><a href="../../genes/human/PDHA1/PDHA1-ai-review.html">PDHA1</a></td>
 <td>P08559</td>
 <td>Pyruvate dehydrogenase E1 alpha</td>
 </tr>
 <tr>
-<td>PDHB</td>
+<td><a href="../../genes/human/PDHB/PDHB-ai-review.html">PDHB</a></td>
 <td>P11177</td>
 <td>Pyruvate dehydrogenase E1 beta</td>
 </tr>
@@ -565,7 +565,7 @@ exporters and chaperones set the threshold:<br />
    regulated cell death.</li>
 <li><strong>Definition of cuproptosis</strong> (Tsvetkov et al., <em>Science</em> 2022,<br />
    PMID:35298263; erratum PMID:36356160) — genome-wide CRISPR screens identified<br />
-   FDX1 and the lipoylation pathway; showed copper binds lipoylated DLAT causing<br />
+   FDX1 and the lipoylation pathway; showed copper binds lipoylated <a href="../../genes/human/DLAT/DLAT-ai-review.html">DLAT</a> causing<br />
    aggregation and Fe–S cluster protein loss.</li>
 <li><strong>Mechanistic/therapeutic syntheses</strong> (e.g. Tang, Chen &amp; Kang, <em>Mol Cell</em><br />
    2022, PMID:35594843) — placed cuproptosis among regulated-cell-death pathways<br />
@@ -588,7 +588,7 @@ exporters and chaperones set the threshold:<br />
   analogous to <a href="http://amigo.geneontology.org/amigo/term/GO:0097707">GO:0097707</a> <em>ferroptosis</em>? Scope the ontology gap.</li>
 <li>Are FDX1's two roles (Cu²⁺ reduction vs. promoting protein lipoylation)<br />
   captured by distinct, appropriately specific MF/BP terms, or over-/under-annotated?</li>
-<li>DLAT: distinguish its canonical acetyltransferase MF from its<br />
+<li><a href="../../genes/human/DLAT/DLAT-ai-review.html">DLAT</a>: distinguish its canonical acetyltransferase MF from its<br />
   cuproptosis-effector behavior (copper-induced aggregation) — the latter is a<br />
   process role, not a new MF.</li>
 <li>Watch for over-annotation of every lipoylation/TCA gene with a generic<br />

--- a/pages/projects/FUNCTION_KNOWLEDGE_GAPS.html
+++ b/pages/projects/FUNCTION_KNOWLEDGE_GAPS.html
@@ -539,6 +539,11 @@ GTPase-activity review, the missing GEF/GAP).</p>
 <code>reports/knowledge_gaps.tsv</code>. The prose worked-entries below remain the curated narrative; the<br />
 register is their queryable, schema-backed counterpart and will grow as gaps are recorded in the<br />
 YAML.</p>
+<p><strong>Curation highlights from the dark-gene campaigns:</strong> the batched reviews of understudied genes<br />
+(50 <em>C. elegans</em>, 50 <em>S. cerevisiae</em>, 20 <em>S. pombe</em>) that populate this register also surfaced<br />
+recurring, generalizable curation findings — identity corrections, pseudoenzyme calls, and<br />
+family over-propagations caught before they became annotations. These are written up in<br />
+<a href="FUNCTION_KNOWLEDGE_GAPS/dark-gene-curation-highlights.html">Dark-Gene Batch Reviews: Curation Highlights</a>.</p>
 <h2 id="worked-example-the-cfap300-molecular-function-gap">Worked example: the <a href="../../genes/human/CFAP300/CFAP300-ai-review.html">CFAP300</a> molecular-function gap</h2>
 <p><a href="../../genes/human/CFAP300/CFAP300-ai-review.html">CFAP300</a> (formerly C11orf70) is a dynein axonemal assembly factor; loss-of-function causes<br />
 primary ciliary dyskinesia (PCD). It is in the KB (<code>genes/human/CFAP300/</code>) and is an ideal<br />

--- a/pages/projects/FUNCTION_KNOWLEDGE_GAPS/dark-gene-curation-highlights.html
+++ b/pages/projects/FUNCTION_KNOWLEDGE_GAPS/dark-gene-curation-highlights.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dark-Gene Batch Reviews: Curation Highlights - AI Gene Review Projects</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-primary: #3498db;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .breadcrumb {
+            margin-bottom: 1.5rem;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .breadcrumb a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        h2 {
+            font-size: 1.75rem;
+            font-weight: 600;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: #374151;
+        }
+
+        h4 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+            color: #4b5563;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Gene symbol links */
+        .content a[href*="/genes/"] {
+            background-color: #dbeafe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-weight: 500;
+        }
+
+        .content a[href*="/genes/"]:hover {
+            background-color: #bfdbfe;
+        }
+
+        ul, ol {
+            margin-bottom: 1rem;
+            padding-left: 2rem;
+        }
+
+        li {
+            margin-bottom: 0.25rem;
+        }
+
+        code {
+            background: #f4f4f4;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875em;
+        }
+
+        pre {
+            background: #1f2937;
+            color: #f9fafb;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+
+        pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--color-primary);
+            margin-left: 0;
+            padding-left: 1.5rem;
+            color: #4b5563;
+            font-style: italic;
+            margin-bottom: 1rem;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+        }
+
+        th, td {
+            border: 1px solid var(--border-color);
+            padding: 0.75rem;
+            text-align: left;
+        }
+
+        th {
+            background-color: var(--bg-light);
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f9fafb;
+        }
+
+        tr:hover {
+            background-color: #f3f4f6;
+        }
+
+        /* Mermaid diagrams */
+        .mermaid {
+            text-align: center;
+            margin: 2rem 0;
+            background: white;
+            padding: 1.5rem;
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+        }
+
+        .mermaid svg {
+            max-width: 100%;
+            height: auto;
+        }
+
+        /* Warnings section */
+        .warnings {
+            background-color: #fef3c7;
+            border: 1px solid #fde68a;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 2rem;
+        }
+
+        .warnings h3 {
+            color: #92400e;
+            margin-top: 0;
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+        }
+
+        .warnings ul {
+            margin-bottom: 0;
+            color: #78350f;
+        }
+
+        /* Task lists (checkboxes) */
+        li input[type="checkbox"] {
+            margin-right: 0.5rem;
+        }
+
+        /* Status badges */
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.625rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .badge-success {
+            background-color: #d1fae5;
+            color: #065f46;
+        }
+
+        .badge-warning {
+            background-color: #fef3c7;
+            color: #92400e;
+        }
+
+        .badge-info {
+            background-color: #dbeafe;
+            color: #1e40af;
+        }
+
+        /* Project meta: maturity + tag badges */
+        .project-meta { margin-bottom: 0.5rem; }
+        .project-meta .badge { margin: 0 0.25rem 0.25rem 0; }
+        .gene-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.375rem;
+            margin-bottom: 1rem;
+        }
+        .gene-list a,
+        .gene-list span {
+            background-color: #dbeafe;
+            border-radius: 0.25rem;
+            color: #1e40af;
+            display: inline-block;
+            font-weight: 500;
+            padding: 0.125rem 0.375rem;
+        }
+        .gene-list a:hover {
+            background-color: #bfdbfe;
+            text-decoration: none;
+        }
+        .m-SCOPING     { background: #fef3c7; color: #92400e; }
+        .m-IN_PROGRESS { background: #dbeafe; color: #1e40af; }
+        .m-MATURE      { background: #dcfce7; color: #166534; }
+        .m-COMPLETE    { background: #d1fae5; color: #065f46; }
+        .m-ARCHIVED    { background: #f3f4f6; color: #6b7280; }
+        .badge.tag { text-transform: none; }
+        .t-FLAGSHIP       { background: #fae8ff; color: #86198f; }
+        .t-BIOLOGY_DOMAIN { background: #e0f2fe; color: #075985; }
+        .t-PIPELINE       { background: #ede9fe; color: #5b21b6; }
+        .t-OBSOLETION     { background: #fee2e2; color: #991b1b; }
+
+        /* Manual reviews */
+        .manual-reviews {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem 1.25rem;
+            margin-bottom: 2rem;
+        }
+        .manual-reviews h3 { margin-top: 0; margin-bottom: 0.75rem; font-size: 1rem; }
+        .manual-reviews .review { padding: 0.5rem 0; }
+        .manual-reviews .review + .review { border-top: 1px dashed var(--border-color); }
+        .manual-reviews .review-head { margin-bottom: 0.25rem; }
+        .manual-reviews .review-head .badge { margin-right: 0.5rem; }
+        .manual-reviews .review-head .who { font-weight: 600; }
+        .manual-reviews .review-head .when { color: var(--text-muted); font-size: 0.85rem; margin-left: 0.5rem; }
+        .manual-reviews .review-notes { margin: 0.25rem 0; }
+        .manual-reviews .review-todos { margin: 0.25rem 0 0.5rem; }
+        .badge.r-READY             { background: #dcfce7; color: #166534; }
+        .badge.r-CHANGES_REQUESTED { background: #fee2e2; color: #991b1b; }
+
+        /* Content wrapper */
+        .content {
+            margin-bottom: 2rem;
+        }
+
+        /* Footer */
+        footer {
+            margin-top: 3rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border-color);
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-align: center;
+        }
+
+        footer small {
+            display: block;
+        }
+    </style>
+    <!-- Mermaid.js for diagram rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>
+        mermaid.initialize({
+            startOnLoad: true,
+            theme: 'default',
+            themeVariables: {
+                primaryColor: '#3498db',
+                primaryTextColor: '#fff',
+                primaryBorderColor: '#2c3e50',
+                lineColor: '#333',
+                secondaryColor: '#ecf0f1',
+                tertiaryColor: '#f39c12'
+            },
+            flowchart: {
+                htmlLabels: true,
+                curve: 'basis'
+            }
+        });
+    </script>
+</head>
+<body>
+    <nav class="breadcrumb">
+        <a href="../index.html">Home</a> &raquo;
+        <a href="index.html">Projects</a> &raquo;
+        Dark-Gene Batch Reviews: Curation Highlights
+    </nav>
+
+    <header class="header">
+        <h1>Dark-Gene Batch Reviews: Curation Highlights</h1>
+
+        <p class="project-meta">
+            <span class="badge m-IN_PROGRESS">IN_PROGRESS</span>
+            <span class="badge tag t-PIPELINE">PIPELINE</span>
+        </p>
+
+
+        <p><strong>Species:</strong> worm, yeast</p>
+
+
+    </header>
+
+
+
+
+
+    <div class="content">
+        <h1 id="dark-gene-batch-reviews-curation-highlights">Dark-Gene Batch Reviews: Curation Highlights</h1>
+<p>Three batched review campaigns targeted deliberately <em>understudied</em> genes — the population<br />
+where function knowledge gaps concentrate — rather than the well-annotated core:</p>
+<table>
+<thead>
+<tr>
+<th>Campaign</th>
+<th>Organism</th>
+<th>Genes</th>
+<th>Selection basis</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CAEEL</td>
+<td><em>C. elegans</em> (<code>worm</code>)</td>
+<td>50</td>
+<td>Unreviewed members of the flagship CAEEL pathway projects (cilia/IFT, mitophagy, proteostasis, UPR, surveillance immunity, P-granule)</td>
+</tr>
+<tr>
+<td>YEAST</td>
+<td><em>S. cerevisiae</em> (<code>yeast</code>)</td>
+<td>50</td>
+<td>Named-but-dark genes from the SGD GAF: standard gene name, <strong>zero experimental-evidence annotations</strong>, few informative GO terms</td>
+</tr>
+<tr>
+<td>POMBE</td>
+<td><em>S. pombe</em> (<code>SCHPO</code>)</td>
+<td>20</td>
+<td>Named-but-dark genes from the PomBase GAF, same darkness filter</td>
+</tr>
+</tbody>
+</table>
+<p>Each gene received a full annotation review plus a literature-grounded <code>knowledge_gaps</code><br />
+section (the point of the exercise — see the <a href="../FUNCTION_KNOWLEDGE_GAPS.html">parent project</a>).<br />
+Beyond the gap records themselves, the reviews surfaced recurring, generalizable curation<br />
+findings. Those patterns are collected here because they are the concrete argument for <em>why</em><br />
+dark genes need human-grade review rather than electronic propagation.</p>
+<h2 id="1-identity-correction-before-curation">1. Identity correction before curation</h2>
+<p>Dark genes are disproportionately mislabeled — a "standard name" or a family hint can point at<br />
+the wrong biology. Grounding every review in the actual UniProt/PomBase record (not the symbol<br />
+or a prior assumption) caught several outright misassignments <em>before</em> they could drive wrong<br />
+annotations:</p>
+<ul>
+<li><strong><code>sel0</code> (pombe, SPAC20G4.05c)</strong> — not a Sel1-repeat / SEL1L ERAD protein as the name suggests,<br />
+  but <strong>Selenoprotein O</strong>, a mitochondrial protein AMPylase / adenylyltransferase (SELO family,<br />
+  pseudokinase fold). Entire review reframed around AMPylation.</li>
+<li><strong><code>mtl3</code> (pombe, SPBC215.13)</strong> — not the Mtr4-like MTREC RNA helicase (that is <code>mtl1</code>), but a<br />
+<strong>Mid2-like GPI-anchored plasma-membrane cell-wall stress sensor</strong> with no catalytic domain.</li>
+<li><strong><code>spa1</code> (pombe, SPBC577.14c)</strong> — not the mammalian Rap-GAP SIPA1/SPA1 despite the shared<br />
+  symbol, but <strong>ornithine decarboxylase antizyme</strong> (an ODC inhibitor).</li>
+<li><strong><code>knh4</code> (pombe, SPBC1E8.05)</strong> — not a Knr4/Smi1 protein, but a <strong>Kre9/Knh1-family β-glucan<br />
+  cell-wall glycoprotein</strong>.</li>
+<li><strong><code>MNN14</code> (yeast, YJR061W)</strong> — not a GT15/MNN1 α-1,3-mannosyltransferase, but a <strong>LicD-family<br />
+  mannosyl-phosphate transferase</strong> (activity later added from primary literature; see §4).</li>
+<li><strong><code>ppgn-1</code> (worm)</strong> — the flagship-project framing implied an immunity effector; the record<br />
+  shows the <strong>paraplegin / SPG7 m-AAA protease</strong> (a reproducible motif scan confirmed intact<br />
+  catalytic residues).</li>
+<li><strong><code>MCO14</code> (yeast)</strong> — <code>fetch-gene</code> failed on the symbol; resolved via SGD to <strong>YHL018W</strong>, a<br />
+  PCD/DCoH-family protein. (Yeast/pombe standard names frequently are not in UniProt's gene<br />
+  line — the pipeline now falls back to the systematic name + <code>--uniprot-id</code>.)</li>
+</ul>
+<h2 id="2-pseudoenzyme-detection">2. Pseudoenzyme detection</h2>
+<p>A conserved catalytic <em>fold</em> is routinely over-annotated with the ancestral catalytic <em>activity</em><br />
+even when the catalytic residues have degenerated. Inline domain analysis (reading the UniProt<br />
+features and checking the specific catalytic motif) flagged several:</p>
+<ul>
+<li><strong><code>KDX1</code> (yeast)</strong> — protein-kinase fold but activation-loop <strong>DFG→NFG</strong> and catalytic-loop<br />
+<strong>HRD→HCD</strong>; a catalytically inactive <strong>pseudokinase</strong>. Nine propagated catalytic-kinase MF/BP<br />
+  terms marked as over-annotations; its real role is a non-catalytic Swi4/Rlm1 scaffold.</li>
+<li><strong><code>OCA6</code> (yeast)</strong> — PTP/DSP fold but the invariant CX5R catalytic arginine is replaced (→Ile);<br />
+  a likely <strong>pseudophosphatase</strong>; the "protein tyrosine phosphatase activity" IEA flagged.</li>
+<li><strong><code>GPM3</code> (yeast)</strong> — retains the phosphoglycerate-mutase histidines yet is experimentally<br />
+<strong>inactive as a mutase</strong>; glycolysis/mutase terms demoted with <code>propagation_review</code>.</li>
+<li><strong><code>wago-4</code> (worm)</strong> — an Argonaute lacking the catalytic tetrad; the endonuclease/"slicer" term<br />
+  removed on biological grounds, <code>miRNA binding</code> corrected to <code>siRNA binding</code> (binds 22G-RNAs).</li>
+</ul>
+<h2 id="3-family-over-propagation-removed-or-demoted">3. Family over-propagation removed or demoted</h2>
+<p>The dominant false-positive class for dark genes is IBA/ISS transfer from a characterized<br />
+paralog or distant ortholog whose function does not hold for the target:</p>
+<ul>
+<li><strong><code>fis-1</code> (worm)</strong> — contrary to the FIS1 family's fission-receptor reputation, worm FIS-1 is<br />
+<strong>not required</strong> for mitochondrial or peroxisomal fission (LOF is silent); family fission<br />
+  terms kept non-core, and its supported role (mitophagy coupling) added as NEW.</li>
+<li><strong><code>ILT1</code> (yeast)</strong> — PQ-loop transporter annotated as a <em>vacuolar</em> basic-amino-acid transporter<br />
+  by propagation from Ypq1/2; ILT1 is experimentally <strong>plasma-membrane</strong> and in a distinct<br />
+  uncharacterized subfamily — vacuolar terms removed.</li>
+<li><strong><code>LEE1</code> (yeast)</strong> — makorin-family; ubiquitin-ligase activity propagated from RING-containing<br />
+  metazoan makorins, but LEE1 has <strong>no RING domain</strong> (confirmed by direct InterPro query) —<br />
+  ligase terms marked over-annotated; only its CCCH zinc-finger zinc-binding kept.</li>
+<li><strong><code>NVJ3</code> (yeast)</strong> — PI3P-binding transferred from paralog Mdm1, but NVJ3 shares only the PXA<br />
+  domain and <strong>lacks the PX domain</strong> that carries the activity — removed.</li>
+<li><strong><code>AAD3</code> (yeast)</strong> — aryl-alcohol dehydrogenase activity propagated from a lignin-degrader<br />
+  enzyme; the AAD deletants are phenotype-null and budding yeast is not a lignin degrader —<br />
+  demoted to the honest superfamily-level oxidoreductase term.</li>
+<li><strong><code>THI22</code> (yeast)</strong> — HMP-P kinase activity: the one direct assay found <strong>no activity</strong> for<br />
+  THI22, so the propagated kinase term was marked over-annotated (residues intact → not a<br />
+  pseudoenzyme, but activity unproven).</li>
+<li><strong><code>gpa-12</code> (worm)</strong> — Gα subunit carrying propagated Gs/Gi adenylate-cyclase-modulating and<br />
+  D5-dopamine-receptor-binding terms wrong for the G12/13 subfamily — removed.</li>
+</ul>
+<p>In every case the annotation was flagged as electronic over-propagation with a structured<br />
+<code>propagation_review</code>, <strong>not</strong> by overruling an experimental annotation.</p>
+<h2 id="4-evidence-grounded-upgrades">4. Evidence-grounded upgrades</h2>
+<p>Dark-gene review is not only subtractive; deep reading also finds well-supported functions<br />
+<em>missing</em> from GOA:</p>
+<ul>
+<li><strong><code>MNN14</code> (yeast)</strong> — a falcon-surfaced, PubMed-verified paper (Kang et al. 2021) shows<br />
+  recombinant Mnn14 transfers mannose-phosphate from GDP-mannose to high-mannose N-glycans;<br />
+<code>mannosylphosphate transferase activity</code> (<a href="http://amigo.geneontology.org/amigo/term/GO:0000031">GO:0000031</a>) added as an evidence-backed NEW MF.</li>
+<li><strong><code>spa1</code> (pombe)</strong> — ornithine-decarboxylase-inhibitor activity confirmed directly for the<br />
+  fission-yeast protein (recombinant Spa1 inhibits <em>S. pombe</em> ODC) and kept as the core function.</li>
+</ul>
+<h2 id="5-fabrication-guardrails-held">5. Fabrication guardrails held</h2>
+<p>The <code>supporting_text</code>-must-be-verbatim rule and independent fact-checking caught deep-research<br />
+errors before they entered a review:</p>
+<ul>
+<li><strong><code>tin-44</code> (worm)</strong> — a falcon report's "RNAi extended lifespan 11.1%" was a hallucination; the<br />
+  cached full text actually groups tin-44 among lifespan-<em>shortening</em> import knockdowns. Removed.</li>
+<li><strong><code>NIT1</code> (yeast, YIL164C)</strong> — a falcon report conflated NIT1 with its dGSH-amidase paralog<br />
+  NIT2/YJL126W; the misattributed activity claim was fact-checked out (catalytic-residue numbering<br />
+  mismatch) and the reference flagged <code>MISCITED</code>.</li>
+<li><strong><code>prg-2</code> (worm)</strong> — correctly <strong>failed</strong> rather than being fabricated: it is a WormBase<br />
+  pseudogene with no UniProt entry and zero GO annotations; substituted with another gene.</li>
+<li><strong><code>LPX2</code> (yeast)</strong> — a rebase accident degraded a protected publication cache to abstract-only,<br />
+  which had let the review claim the Ploier 2013 full text was "inaccessible." Restoring the<br />
+  full text showed that paper <em>tested</em> Ykl050c and found <strong>no</strong> in-vivo lipolytic activity —<br />
+  correcting the review and strengthening its MF-unknown conclusion.</li>
+</ul>
+<h2 id="why-this-matters">Why this matters</h2>
+<p>Across 120 dark genes, the value was rarely a brand-new function statement; it was (a) getting the<br />
+protein's <em>identity</em> right, (b) refusing to inherit a paralog's activity through a degenerate fold<br />
+or a wrong-subfamily transfer, and (c) writing down, with provenance, exactly what remains unknown.<br />
+That is the raw material the <a href="../FUNCTION_KNOWLEDGE_GAPS.html">Function Knowledge Gaps</a> register is<br />
+built from.</p>
+    </div>
+
+    <footer>
+        <small>Generated from dark-gene-curation-highlights.md</small>
+        <small>AI Gene Review Project</small>
+    </footer>
+</body>
+</html>

--- a/pages/projects/all-projects.html
+++ b/pages/projects/all-projects.html
@@ -844,7 +844,7 @@
                 <td><span class="tag t-PIPELINE">PIPELINE</span><span class="tag t-FLAGSHIP">FLAGSHIP</span></td>
                 <td><span class="muted">&mdash;</span></td>
                 <td><span class="muted">&mdash;</span></td>
-                <td>1</td>
+                <td>2</td>
             </tr>
 
             <tr


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3069 |
| Gene review HTML pages | 3069 |
| Project pages | 1109 |
| Module pages | 104 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
