### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/BPGM/BPGM-ai-review.html
+++ b/genes/human/BPGM/BPGM-ai-review.html
@@ -1,0 +1,3235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BPGM - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>BPGM</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P07738" target="_blank" class="term-link">
+                        P07738
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "BPGM";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P07738" data-a="DESCRIPTION: Bisphosphoglycerate mutase (BPGM) is the enzyme of..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Bisphosphoglycerate mutase (BPGM) is the enzyme of the Rapoport-Luebering shunt, a branch of glycolysis that is prominently expressed in erythrocytes. It is a cytosolic homodimeric, trifunctional member of the cofactor-dependent (histidine) phosphoglycerate mutase family and uses a phospho-histidine catalytic intermediate. Its principal 2,3-bisphosphoglycerate synthase / bisphosphoglycerate mutase activity (EC 5.4.2.4) converts 1,3-bisphosphoglycerate to 2,3-bisphosphoglycerate (2,3-BPG); it additionally has a 2,3-BPG phosphatase activity that degrades 2,3-BPG to 3-phosphoglycerate and a weak phosphoglycerate mutase activity (EC 5.4.2.11). 2,3-BPG is the major allosteric effector of hemoglobin: it binds preferentially to deoxyhemoglobin and lowers hemoglobin oxygen affinity, promoting oxygen delivery to tissues. By routing 1,3-bisphosphoglycerate through the shunt, BPGM also bypasses the ATP-generating phosphoglycerate kinase (PGK1) step of glycolysis. Loss-of-function causes bisphosphoglycerate mutase deficiency (familial erythrocytosis type 8), characterized by low 2,3-BPG, increased hemoglobin-oxygen affinity, and secondary erythrocytosis.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004082" target="_blank" class="term-link">
+                                    GO:0004082
+                                </a>
+                            </span>
+                            <span class="term-label">bisphosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0004082" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred bisphosphoglycerate mutase activity. This is the principal, experimentally established molecular function of BPGM (EC 5.4.2.4; synthesis of 2,3-bisphosphoglycerate from 1,3-bisphosphoglycerate) and the core function of the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IBA is correct and at the appropriate level of specificity. It matches the enzyme&#39;s defining catalytic activity, established biochemically and structurally in human BPGM.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/BPGM/BPGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Plays a major role in regulating hemoglobin oxygen affinity</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2542247" target="_blank" class="term-link">
+                                        PMID:2542247
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is a trifunctional enzyme which</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred cytosolic localization. BPGM is a soluble cytosolic enzyme of the erythrocyte, consistent with its role in glycolysis / the Rapoport-Luebering shunt.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization. Family members are cytosolic and BPGM is a soluble erythrocyte enzyme with no membrane or organelle-targeting features.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/BPGM/BPGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Expressed in red blood cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003824" target="_blank" class="term-link">
+                                    GO:0003824
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0003824" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based mapping to the root-level &#34;catalytic activity&#34; term. BPGM is an enzyme, so this is not wrong, but it is far less informative than the specific bisphosphoglycerate mutase activity already annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is an uninformative high-level parent of the specific molecular function GO:0004082, which is independently annotated. It adds no functional information.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004082" target="_blank" class="term-link">
+                                    GO:0004082
+                                </a>
+                            </span>
+                            <span class="term-label">bisphosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0004082" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt/RHEA/EC 5.4.2.4) assertion of bisphosphoglycerate mutase activity, duplicating the IBA and experimental annotations for the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function, consistent with the RHEA:17765 / EC 5.4.2.4 reaction recorded in UniProt. Duplicate of the IBA/TAS annotations, which is acceptable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/BPGM/BPGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">controlling the levels of its allosteric effector 2,3-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004619" target="_blank" class="term-link">
+                                    GO:0004619
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0004619" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (EC 5.4.2.11 / RHEA:15901) assertion of phosphoglycerate mutase activity. BPGM does exhibit a weak/secondary phosphoglycerate mutase activity in addition to its principal bisphosphoglycerate mutase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a genuine but secondary/minor activity of BPGM (UniProt records EC 5.4.2.11 in addition to the principal EC 5.4.2.4), so it is correct but not the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/BPGM/BPGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Also exhibits mutase (EC 5.4.2.11)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0006096" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assertion that BPGM is involved in the glycolytic process. BPGM operates in the Rapoport-Luebering shunt, a branch of glycolysis, acting on the glycolytic intermediate 1,3-bisphosphoglycerate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct: the Rapoport-Luebering shunt is a glycolytic branch and BPGM acts on/around the 1,3-bisphosphoglycerate node of glycolysis (bypassing the PGK1 ATP-generating step). No more specific &#34;2,3-BPG metabolic process&#34; term exists in GO, so this is the best-fitting BP.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016868" target="_blank" class="term-link">
+                                    GO:0016868
+                                </a>
+                            </span>
+                            <span class="term-label">intramolecular phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0016868" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based mapping to intramolecular phosphotransferase activity, the parent class that captures the mutase/isomerase mechanism (phospho-group transfer within a molecule via a phospho-histidine intermediate).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct branch and mechanistically accurate, but it is a less-informative parent of the specific bisphosphoglycerate mutase activity (GO:0004082) that is already annotated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from a large-scale interactome/affinity-purification study (WITH/FROM UniProtKB:P15259, PGAM2). This term conveys no specific molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;protein binding&#34; (GO:0005515) is uninformative per curation guidelines. The interaction (with PGAM2, a paralogous phosphoglycerate mutase) is from a high-throughput interactome screen and does not establish a specific functional role; retained but flagged rather than used as a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from a high-throughput binary interactome map (HuRI; WITH/FROM UniProtKB:P15259, PGAM2). Uninformative as a molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same rationale as the other protein-binding IPI annotations: GO:0005515 is uninformative and derives from a genome-scale interactome screen; kept but marked as over-annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from a proteome-scale affinity-purification network (BioPlex; WITH/FROM UniProtKB:P15259, PGAM2). Uninformative as a molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same rationale as the other protein-binding IPI annotations: GO:0005515 is uninformative and derives from a high-throughput interactome screen; kept but marked as over-annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901136" target="_blank" class="term-link">
+                                    GO:1901136
+                                </a>
+                            </span>
+                            <span class="term-label">carbohydrate derivative catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798335
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:1901136" data-r="Reactome:R-HSA-6798335" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable involvement in a carbohydrate-derivative catabolic process, reflecting BPGM consuming/isomerising the sugar-phosphate 1,3-bisphosphoglycerate (and the phosphatase breakdown of 2,3-BPG) within the Rapoport-Luebering shunt.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A defensible but broad process description of BPGM&#39;s action on phosphorylated glycerate intermediates; the more specific and central process is the glycolytic Rapoport-Luebering shunt (glycolytic process). Kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-6798335
+
+                                </span>
+
+                                <div class="support-text">One of its functions is the isomerisation of 1,3-bisphosphoglycerate (1,3BPG)  to 2,3-bisphosphoglycerate (2,3BPG)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004082" target="_blank" class="term-link">
+                                    GO:0004082
+                                </a>
+                            </span>
+                            <span class="term-label">bisphosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798335
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0004082" data-r="Reactome:R-HSA-6798335" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable assertion of bisphosphoglycerate mutase activity (isomerisation of 1,3-BPG to 2,3-BPG). This is the core molecular function of BPGM.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function with a traceable Reactome reaction (BPGM dimer isomerises 1,3BPG to 2,3BPG). Duplicate of the IBA/IEA annotations for GO:0004082, which is acceptable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-6798335
+
+                                </span>
+
+                                <div class="support-text">Bisphosphoglycerate mutase (BPGM) is an erythrocyte-specific trifunctional enzyme.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798335
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0005829" data-r="Reactome:R-HSA-6798335" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable cytosolic localization, consistent with the soluble erythrocyte Rapoport-Luebering shunt.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization, corroborating the IBA cytosol annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23533145
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In-depth proteomic analyses of exosomes isolated from expres...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0070062" data-r="PMID:23533145" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mass-spectrometry detection of BPGM in urinary/prostatic-secretion exosome preparations. This is a proteome-inventory observation, not the functional site of BPGM, which acts as a soluble cytosolic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Exosome/secretome mass-spec inventories frequently capture abundant cytosolic enzymes as passengers. There is no evidence that BPGM functions in the extracellular exosome; its catalytic role is cytosolic. Retained but flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                                        PMID:23533145
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">exosome preparations were</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005975" target="_blank" class="term-link">
+                                    GO:0005975
+                                </a>
+                            </span>
+                            <span class="term-label">carbohydrate metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2542247" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2542247
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Isolation, characterization, and structure of a mutant 89 Ar...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0005975" data-r="PMID:2542247" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated (NAS) involvement in carbohydrate metabolism, reflecting BPGM&#39;s action on glycerate-phosphate intermediates of glycolysis / the Rapoport-Luebering shunt.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A broad parent process; correct but less informative than the glycolytic process annotation. Kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2542247" target="_blank" class="term-link">
+                                        PMID:2542247
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is a trifunctional enzyme which</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004082" target="_blank" class="term-link">
+                                    GO:0004082
+                                </a>
+                            </span>
+                            <span class="term-label">bisphosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2542247" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2542247
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Isolation, characterization, and structure of a mutant 89 Ar...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0004082" data-r="PMID:2542247" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable assertion of bisphosphoglycerate mutase activity from a study characterizing a catalytically impaired human BPGM variant (89 Arg-&gt;Cys) with markedly reduced synthase and mutase activities, directly linking the protein to this activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function, supported by biochemical characterization of the human enzyme and a disease-associated active-site variant. Duplicate of other GO:0004082 annotations, which is acceptable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2542247" target="_blank" class="term-link">
+                                        PMID:2542247
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">displays synthase, mutase, and phosphatase activities.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2542247" target="_blank" class="term-link">
+                                        PMID:2542247
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">normal and that of the mutase 4.1%.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007585" target="_blank" class="term-link">
+                                    GO:0007585
+                                </a>
+                            </span>
+                            <span class="term-label">respiratory gaseous exchange by respiratory system</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2542247" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2542247
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Isolation, characterization, and structure of a mutant 89 Ar...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07738" data-a="GO:0007585" data-r="PMID:2542247" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable annotation to respiratory gaseous exchange by the respiratory system. BPGM does modulate systemic oxygen delivery by setting 2,3-BPG levels and thereby hemoglobin oxygen affinity, but this GO term denotes gas exchange by the respiratory (breathing) system (lungs), not the erythrocyte hemoglobin-affinity mechanism through which BPGM acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> BPGM&#39;s contribution to oxygen transport is via 2,3-BPG allosteric regulation of hemoglobin, not via respiratory-system gas exchange. The term is a broad/mismatched process for this enzyme; the oxygen-delivery role is better captured through its molecular function and the 2,3-BPG glycolytic shunt. Retained but flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/BPGM/BPGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Plays a major role in regulating hemoglobin oxygen affinity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Bisphosphoglycerate mutase / 2,3-bisphosphoglycerate synthase activity: BPGM isomerises the glycolytic intermediate 1,3-bisphosphoglycerate to 2,3-bisphosphoglycerate (2,3-BPG) in the erythrocyte Rapoport-Luebering shunt (and, at lower pH, degrades 2,3-BPG via its phosphatase activity). By controlling 2,3-BPG levels it sets hemoglobin oxygen affinity, promoting oxygen delivery to tissues, and it bypasses the ATP-generating PGK1 step of glycolysis.</h3>
+                <span class="vote-buttons" data-g="P07738" data-a="FUNCTION: Bisphosphoglycerate mutase / 2,3-bisphosphoglycera..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004082" target="_blank" class="term-link">
+                            bisphosphoglycerate mutase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                glycolytic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/BPGM/BPGM-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Plays a major role in regulating hemoglobin oxygen affinity</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            Reactome:R-HSA-6798335
+
+                        </span>
+
+                        <div class="finding-text">One of its functions is the isomerisation of 1,3-bisphosphoglycerate (1,3BPG)  to 2,3-bisphosphoglycerate (2,3BPG)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                            PMID:23533145
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2542247" target="_blank" class="term-link">
+                            PMID:2542247
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Isolation, characterization, and structure of a mutant 89 Arg</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-6798335
+
+                    </span>
+                </div>
+
+                <div class="reference-title">BPGM dimer isomerises 1,3BPG to 2,3BPG</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/BPGM/BPGM-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt entry P07738 (PMGE_HUMAN), Bisphosphoglycerate mutase</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What determines the in vivo balance between the synthase, mutase, and phosphatase activities of BPGM, and how is 2,3-BPG homeostasis regulated in erythrocytes under different physiological conditions (e.g., hypoxia, altitude, anemia)?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P07738" data-a="Q: What determines the in vivo balance between the sy..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the reported BPGM-PGAM2 interaction have any functional significance, or is it an artifact of high-throughput interactome screens between two closely related mutases?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P07738" data-a="Q: Does the reported BPGM-PGAM2 interaction have any ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Knockdown/knockout of BPGM in erythroid cells with metabolomic measurement of 2,3-BPG and quantification of the resulting shift in hemoglobin oxygen-affinity (P50) to confirm the gene-to-phenotype link.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Loss of BPGM lowers erythrocyte 2,3-BPG and increases hemoglobin oxygen affinity.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P07738" data-a="EXPERIMENT: Knockdown/knockout of BPGM in erythroid cells with..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided mutagenesis of active-site residues (e.g., His-11, His-89, Arg-90) to dissect the contributions of synthase vs mutase vs phosphatase activities to 2,3-BPG levels.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Distinct active-site residues differentially control the synthase, mutase, and phosphatase activities that together set steady-state 2,3-BPG.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P07738" data-a="EXPERIMENT: Structure-guided mutagenesis of active-site residu..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(BPGM-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P07738" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="bpgm-bisphosphoglycerate-mutase-review-notes">BPGM (bisphosphoglycerate mutase) — review notes</h1>
+<p>UniProtKB: P07738 (PMGE_HUMAN). Human. HGNC:1093. Chromosome 7.</p>
+<h2 id="core-biology">Core biology</h2>
+<ul>
+<li>BPGM is the enzyme of the <strong>Rapoport-Luebering shunt</strong>, a branch of glycolysis that is highly<br />
+  expressed in erythrocytes.</li>
+<li><strong>Trifunctional enzyme</strong> of the cofactor-dependent phosphoglycerate mutase (dPGM) family, BPG-dependent<br />
+  PGAM subfamily; shares the phospho-histidine catalytic mechanism.</li>
+<li>PMID:2542247 abstract: "Bisphosphoglycerate mutase (EC 5.4.2.4.) is a trifunctional enzyme which<br />
+    displays synthase, mutase, and phosphatase activities."</li>
+<li>Principal activity: <strong>2,3-bisphosphoglycerate synthase / bisphosphoglycerate mutase</strong> (EC 5.4.2.4),<br />
+  converting 1,3-bisphosphoglycerate to 2,3-bisphosphoglycerate (2,3-BPG).</li>
+<li>RHEA:17765: (2R)-3-phospho-glyceroyl phosphate = (2R)-2,3-bisphosphoglycerate + H(+); EC 5.4.2.4.</li>
+<li>Also a weak <strong>phosphoglycerate mutase</strong> activity (EC 5.4.2.11; RHEA:15901, 2-PG &lt;=&gt; 3-PG) and a<br />
+<strong>2,3-BPG phosphatase</strong> activity degrading 2,3-BPG to 3-phosphoglycerate.</li>
+<li>UniProt FUNCTION (PMID:21045285): "Plays a major role in regulating hemoglobin oxygen affinity by<br />
+    controlling the levels of its allosteric effector 2,3-bisphosphoglycerate (2,3-BPG). Also exhibits<br />
+    mutase (EC 5.4.2.11) activity."</li>
+<li>UniProt ACTIVITY REGULATION (PMID:10477269, PMID:21045285): "At alkaline pH BPGM favors the synthase<br />
+    reaction; however, at lower pH the phosphatase reaction is dominant. Inhibited by citrate."</li>
+<li><strong>2,3-BPG</strong> is the major allosteric effector that binds deoxyhemoglobin and <strong>lowers hemoglobin oxygen<br />
+  affinity</strong>, promoting O2 delivery to tissues (Reactome R-HSA-6798335: "In red blood cells, 2,3BPG is<br />
+  the main allosteric effector of hemoglobin, binding preferentially to the deoxygenated hemoglobin<br />
+  tetramer, thus reducing oxygen affinity"). The shunt also bypasses the ATP-generating PGK1 step of<br />
+  glycolysis.</li>
+<li><strong>Homodimer</strong> (PMID:15258155, PMID:17052986). Cytosolic. Active-site His-11 forms the<br />
+  tele-phosphohistidine intermediate; His-89 proton donor/acceptor (UniProt ACT_SITE).</li>
+</ul>
+<h2 id="structure-localization">Structure / localization</h2>
+<ul>
+<li>259 aa, 30 kDa. Multiple crystal structures (1T8P, 2HHJ, 7THI, etc.).</li>
+<li>Cytosolic (soluble erythrocyte enzyme). Also detected in placental syncytiotrophoblast<br />
+  (PMID:16246416) and reported in urinary-prostatic exosome proteomes (PMID:23533145, mass-spec).</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>Deficiency causes <strong>bisphosphoglycerate mutase deficiency</strong> = Erythrocytosis, familial, 8 (ECYT8;<br />
+  MIM:222800): low 2,3-BPG, increased hemoglobin-oxygen affinity, secondary erythrocytosis<br />
+  (PMID:1421379, PMID:15054810, PMID:2542247).</li>
+<li>PMID:2542247: mutant "89 Arg-&gt;Cys" (mature-protein numbering; = residue 90 in UniProt) shows synthase<br />
+  0.57% and mutase 4.1% of normal, phosphatase unaffected — active-site Arg near substrate binding.</li>
+</ul>
+<h2 id="goa-annotations-17-lines-review-plan">GOA annotations (17 lines) — review plan</h2>
+<ul>
+<li>GO:0004082 bisphosphoglycerate mutase activity: appears 4x (IBA, IEA GO_REF:0000120, TAS Reactome,<br />
+  TAS PMID:2542247). ACCEPT the IBA as core MF; accept the others.</li>
+<li>GO:0005829 cytosol: IBA + TAS Reactome. ACCEPT (core localization).</li>
+<li>GO:0003824 catalytic activity (IEA InterPro): too general — MARK_AS_OVER_ANNOTATED (root-ish parent<br />
+  of the specific MF already present).</li>
+<li>GO:0004619 phosphoglycerate mutase activity (IEA UniProtKB-EC, EC 5.4.2.11): real secondary activity<br />
+  (UniProt lists EC 5.4.2.11). ACCEPT / KEEP_AS_NON_CORE.</li>
+<li>GO:0006096 glycolytic process (IEA): ACCEPT — Rapoport-Luebering shunt is a glycolytic branch.</li>
+<li>GO:0016868 intramolecular phosphotransferase activity (IEA InterPro): parent of the mutase MF; correct<br />
+  branch but less informative — KEEP_AS_NON_CORE / MARK_AS_OVER_ANNOTATED.</li>
+<li>GO:0005515 protein binding x3 (IPI, all WITH/FROM P15259 PGAM2; HuRI/BioPlex-type interactome papers):<br />
+  bare protein binding, uninformative -&gt; MARK_AS_OVER_ANNOTATED (per policy, not REMOVE).</li>
+<li>GO:1901136 carbohydrate derivative catabolic process (TAS Reactome): the phosphatase/consumption of<br />
+  1,3-BPG; broad but defensible. KEEP_AS_NON_CORE.</li>
+<li>GO:0070062 extracellular exosome (HDA PMID:23533145): mass-spec exosome proteome; not the site of<br />
+  function. MARK_AS_OVER_ANNOTATED.</li>
+<li>GO:0005975 carbohydrate metabolic process (NAS PMID:2542247): broad parent of glycolysis;<br />
+  KEEP_AS_NON_CORE / MARK_AS_OVER_ANNOTATED.</li>
+<li>GO:0007585 respiratory gaseous exchange by respiratory system (TAS PMID:2542247): this term is about<br />
+  the respiratory <em>system</em> (breathing/lung gas exchange), NOT the erythrocyte O2-affinity role. BPGM's<br />
+  effect on O2 delivery is via hemoglobin, not respiratory-system gas exchange. Over-annotation /<br />
+  arguably wrong branch. MARK_AS_OVER_ANNOTATED.</li>
+</ul>
+<h2 id="core-functions">Core functions</h2>
+<ul>
+<li>MF: GO:0004082 bisphosphoglycerate mutase activity.</li>
+<li>BP: GO:0006096 glycolytic process (the Rapoport-Luebering shunt branch that produces/degrades 2,3-BPG<br />
+  and regulates Hb O2 affinity). No dedicated "2,3-BPG metabolic process" term exists in GO.</li>
+<li>CC: GO:0005829 cytosol.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P07738
+gene_symbol: BPGM
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  Bisphosphoglycerate mutase (BPGM) is the enzyme of the Rapoport-Luebering shunt, a branch
+  of glycolysis that is prominently expressed in erythrocytes. It is a cytosolic homodimeric,
+  trifunctional member of the cofactor-dependent (histidine) phosphoglycerate mutase family
+  and uses a phospho-histidine catalytic intermediate. Its principal 2,3-bisphosphoglycerate
+  synthase / bisphosphoglycerate mutase activity (EC 5.4.2.4) converts 1,3-bisphosphoglycerate
+  to 2,3-bisphosphoglycerate (2,3-BPG); it additionally has a 2,3-BPG phosphatase activity that
+  degrades 2,3-BPG to 3-phosphoglycerate and a weak phosphoglycerate mutase activity (EC 5.4.2.11).
+  2,3-BPG is the major allosteric effector of hemoglobin: it binds preferentially to
+  deoxyhemoglobin and lowers hemoglobin oxygen affinity, promoting oxygen delivery to tissues.
+  By routing 1,3-bisphosphoglycerate through the shunt, BPGM also bypasses the ATP-generating
+  phosphoglycerate kinase (PGK1) step of glycolysis. Loss-of-function causes bisphosphoglycerate
+  mutase deficiency (familial erythrocytosis type 8), characterized by low 2,3-BPG, increased
+  hemoglobin-oxygen affinity, and secondary erythrocytosis.
+existing_annotations:
+- term:
+    id: GO:0004082
+    label: bisphosphoglycerate mutase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically inferred bisphosphoglycerate mutase activity. This is the principal,
+      experimentally established molecular function of BPGM (EC 5.4.2.4; synthesis of
+      2,3-bisphosphoglycerate from 1,3-bisphosphoglycerate) and the core function of the gene.
+    action: ACCEPT
+    reason: &gt;-
+      The IBA is correct and at the appropriate level of specificity. It matches the enzyme&#39;s
+      defining catalytic activity, established biochemically and structurally in human BPGM.
+    supported_by:
+    - reference_id: file:human/BPGM/BPGM-uniprot.txt
+      supporting_text: &#34;Plays a major role in regulating hemoglobin oxygen affinity&#34;
+    - reference_id: PMID:2542247
+      supporting_text: &#34;is a trifunctional enzyme which&#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred cytosolic localization. BPGM is a soluble cytosolic enzyme of the
+      erythrocyte, consistent with its role in glycolysis / the Rapoport-Luebering shunt.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization. Family members are cytosolic and BPGM is a soluble erythrocyte
+      enzyme with no membrane or organelle-targeting features.
+    supported_by:
+    - reference_id: file:human/BPGM/BPGM-uniprot.txt
+      supporting_text: &#34;Expressed in red blood cells.&#34;
+- term:
+    id: GO:0003824
+    label: catalytic activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro-based mapping to the root-level &#34;catalytic activity&#34; term. BPGM is an enzyme, so
+      this is not wrong, but it is far less informative than the specific bisphosphoglycerate
+      mutase activity already annotated.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This is an uninformative high-level parent of the specific molecular function GO:0004082,
+      which is independently annotated. It adds no functional information.
+- term:
+    id: GO:0004082
+    label: bisphosphoglycerate mutase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (UniProt/RHEA/EC 5.4.2.4) assertion of bisphosphoglycerate mutase activity,
+      duplicating the IBA and experimental annotations for the same term.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core molecular function, consistent with the RHEA:17765 / EC 5.4.2.4 reaction
+      recorded in UniProt. Duplicate of the IBA/TAS annotations, which is acceptable.
+    supported_by:
+    - reference_id: file:human/BPGM/BPGM-uniprot.txt
+      supporting_text: &#34;controlling the levels of its allosteric effector 2,3-&#34;
+- term:
+    id: GO:0004619
+    label: phosphoglycerate mutase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (EC 5.4.2.11 / RHEA:15901) assertion of phosphoglycerate mutase activity. BPGM
+      does exhibit a weak/secondary phosphoglycerate mutase activity in addition to its principal
+      bisphosphoglycerate mutase activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This is a genuine but secondary/minor activity of BPGM (UniProt records EC 5.4.2.11 in
+      addition to the principal EC 5.4.2.4), so it is correct but not the core function.
+    supported_by:
+    - reference_id: file:human/BPGM/BPGM-uniprot.txt
+      supporting_text: &#34;Also exhibits mutase (EC 5.4.2.11)&#34;
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic assertion that BPGM is involved in the glycolytic process. BPGM operates in the
+      Rapoport-Luebering shunt, a branch of glycolysis, acting on the glycolytic intermediate
+      1,3-bisphosphoglycerate.
+    action: ACCEPT
+    reason: &gt;-
+      Correct: the Rapoport-Luebering shunt is a glycolytic branch and BPGM acts on/around the
+      1,3-bisphosphoglycerate node of glycolysis (bypassing the PGK1 ATP-generating step). No
+      more specific &#34;2,3-BPG metabolic process&#34; term exists in GO, so this is the best-fitting BP.
+- term:
+    id: GO:0016868
+    label: intramolecular phosphotransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro-based mapping to intramolecular phosphotransferase activity, the parent class that
+      captures the mutase/isomerase mechanism (phospho-group transfer within a molecule via a
+      phospho-histidine intermediate).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct branch and mechanistically accurate, but it is a less-informative parent of the
+      specific bisphosphoglycerate mutase activity (GO:0004082) that is already annotated.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from a large-scale interactome/affinity-purification study (WITH/FROM
+      UniProtKB:P15259, PGAM2). This term conveys no specific molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;protein binding&#34; (GO:0005515) is uninformative per curation guidelines. The interaction
+      (with PGAM2, a paralogous phosphoglycerate mutase) is from a high-throughput interactome
+      screen and does not establish a specific functional role; retained but flagged rather than
+      used as a core function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from a high-throughput binary interactome map (HuRI; WITH/FROM
+      UniProtKB:P15259, PGAM2). Uninformative as a molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Same rationale as the other protein-binding IPI annotations: GO:0005515 is uninformative and
+      derives from a genome-scale interactome screen; kept but marked as over-annotation.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from a proteome-scale affinity-purification network (BioPlex;
+      WITH/FROM UniProtKB:P15259, PGAM2). Uninformative as a molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Same rationale as the other protein-binding IPI annotations: GO:0005515 is uninformative and
+      derives from a high-throughput interactome screen; kept but marked as over-annotation.
+- term:
+    id: GO:1901136
+    label: carbohydrate derivative catabolic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798335
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome-traceable involvement in a carbohydrate-derivative catabolic process, reflecting
+      BPGM consuming/isomerising the sugar-phosphate 1,3-bisphosphoglycerate (and the phosphatase
+      breakdown of 2,3-BPG) within the Rapoport-Luebering shunt.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A defensible but broad process description of BPGM&#39;s action on phosphorylated glycerate
+      intermediates; the more specific and central process is the glycolytic Rapoport-Luebering
+      shunt (glycolytic process). Kept as non-core.
+    supported_by:
+    - reference_id: Reactome:R-HSA-6798335
+      supporting_text: &#34;One of its functions is the isomerisation of 1,3-bisphosphoglycerate (1,3BPG)  to 2,3-bisphosphoglycerate (2,3BPG)&#34;
+- term:
+    id: GO:0004082
+    label: bisphosphoglycerate mutase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798335
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome-traceable assertion of bisphosphoglycerate mutase activity (isomerisation of
+      1,3-BPG to 2,3-BPG). This is the core molecular function of BPGM.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core molecular function with a traceable Reactome reaction (BPGM dimer isomerises
+      1,3BPG to 2,3BPG). Duplicate of the IBA/IEA annotations for GO:0004082, which is acceptable.
+    supported_by:
+    - reference_id: Reactome:R-HSA-6798335
+      supporting_text: &#34;Bisphosphoglycerate mutase (BPGM) is an erythrocyte-specific trifunctional enzyme.&#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798335
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome-traceable cytosolic localization, consistent with the soluble erythrocyte
+      Rapoport-Luebering shunt.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core localization, corroborating the IBA cytosol annotation.
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:23533145
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mass-spectrometry detection of BPGM in urinary/prostatic-secretion exosome
+      preparations. This is a proteome-inventory observation, not the functional site of BPGM,
+      which acts as a soluble cytosolic enzyme.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Exosome/secretome mass-spec inventories frequently capture abundant cytosolic enzymes as
+      passengers. There is no evidence that BPGM functions in the extracellular exosome; its
+      catalytic role is cytosolic. Retained but flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:23533145
+      supporting_text: &#34;exosome preparations were&#34;
+- term:
+    id: GO:0005975
+    label: carbohydrate metabolic process
+  evidence_type: NAS
+  original_reference_id: PMID:2542247
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Author-stated (NAS) involvement in carbohydrate metabolism, reflecting BPGM&#39;s action on
+      glycerate-phosphate intermediates of glycolysis / the Rapoport-Luebering shunt.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A broad parent process; correct but less informative than the glycolytic process
+      annotation. Kept as non-core.
+    supported_by:
+    - reference_id: PMID:2542247
+      supporting_text: &#34;is a trifunctional enzyme which&#34;
+- term:
+    id: GO:0004082
+    label: bisphosphoglycerate mutase activity
+  evidence_type: TAS
+  original_reference_id: PMID:2542247
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Traceable assertion of bisphosphoglycerate mutase activity from a study characterizing a
+      catalytically impaired human BPGM variant (89 Arg-&gt;Cys) with markedly reduced synthase and
+      mutase activities, directly linking the protein to this activity.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function, supported by biochemical characterization of the human enzyme and
+      a disease-associated active-site variant. Duplicate of other GO:0004082 annotations, which
+      is acceptable.
+    supported_by:
+    - reference_id: PMID:2542247
+      supporting_text: &#34;displays synthase, mutase, and phosphatase activities.&#34;
+    - reference_id: PMID:2542247
+      supporting_text: &#34;normal and that of the mutase 4.1%.&#34;
+- term:
+    id: GO:0007585
+    label: respiratory gaseous exchange by respiratory system
+  evidence_type: TAS
+  original_reference_id: PMID:2542247
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Traceable annotation to respiratory gaseous exchange by the respiratory system. BPGM does
+      modulate systemic oxygen delivery by setting 2,3-BPG levels and thereby hemoglobin oxygen
+      affinity, but this GO term denotes gas exchange by the respiratory (breathing) system
+      (lungs), not the erythrocyte hemoglobin-affinity mechanism through which BPGM acts.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      BPGM&#39;s contribution to oxygen transport is via 2,3-BPG allosteric regulation of hemoglobin,
+      not via respiratory-system gas exchange. The term is a broad/mismatched process for this
+      enzyme; the oxygen-delivery role is better captured through its molecular function and the
+      2,3-BPG glycolytic shunt. Retained but flagged as over-annotation.
+    supported_by:
+    - reference_id: file:human/BPGM/BPGM-uniprot.txt
+      supporting_text: &#34;Plays a major role in regulating hemoglobin oxygen affinity&#34;
+core_functions:
+- description: &gt;-
+    Bisphosphoglycerate mutase / 2,3-bisphosphoglycerate synthase activity: BPGM isomerises the
+    glycolytic intermediate 1,3-bisphosphoglycerate to 2,3-bisphosphoglycerate (2,3-BPG) in the
+    erythrocyte Rapoport-Luebering shunt (and, at lower pH, degrades 2,3-BPG via its phosphatase
+    activity). By controlling 2,3-BPG levels it sets hemoglobin oxygen affinity, promoting oxygen
+    delivery to tissues, and it bypasses the ATP-generating PGK1 step of glycolysis.
+  molecular_function:
+    id: GO:0004082
+    label: bisphosphoglycerate mutase activity
+  directly_involved_in:
+  - id: GO:0006096
+    label: glycolytic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: file:human/BPGM/BPGM-uniprot.txt
+    supporting_text: &#34;Plays a major role in regulating hemoglobin oxygen affinity&#34;
+  - reference_id: Reactome:R-HSA-6798335
+    supporting_text: &#34;One of its functions is the isomerisation of 1,3-bisphosphoglycerate (1,3BPG)  to 2,3-bisphosphoglycerate (2,3BPG)&#34;
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PAN-GO/GO_Central phylogenetic inference; supports the core bisphosphoglycerate mutase
+      activity and cytosol annotations at the correct level of specificity.
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:23533145
+  title: In-depth proteomic analyses of exosomes isolated from expressed prostatic
+    secretions in urine.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput exosome proteome inventory; BPGM detected as an abundant cytosolic passenger,
+      not evidence of extracellular-exosome function.
+- id: PMID:2542247
+  title: Isolation, characterization, and structure of a mutant 89 Arg
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Characterizes human BPGM as a trifunctional (synthase/mutase/phosphatase) enzyme and a
+      disease-associated active-site variant with reduced synthase and mutase activities.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale interactome (BioPlex-type) study; source of a bare protein-binding IPI (with
+      PGAM2), uninformative for specific molecular function.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      HuRI binary interactome map; source of a bare protein-binding IPI (with PGAM2), uninformative
+      for specific molecular function.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex proteome-scale network; source of a bare protein-binding IPI (with PGAM2),
+      uninformative for specific molecular function.
+- id: Reactome:R-HSA-6798335
+  title: BPGM dimer isomerises 1,3BPG to 2,3BPG
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reactome reaction describing BPGM isomerising 1,3-BPG to 2,3-BPG, the allosteric hemoglobin
+      effector; directly supports the core molecular function and biological process.
+- id: file:human/BPGM/BPGM-uniprot.txt
+  title: UniProt entry P07738 (PMGE_HUMAN), Bisphosphoglycerate mutase
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      UniProt curated record documenting the trifunctional activities (EC 5.4.2.4, EC 5.4.2.11),
+      hemoglobin oxygen-affinity regulation via 2,3-BPG, homodimer, cytosolic erythrocyte
+      expression, and ECYT8 disease association.
+suggested_questions:
+- question: &gt;-
+    What determines the in vivo balance between the synthase, mutase, and phosphatase activities
+    of BPGM, and how is 2,3-BPG homeostasis regulated in erythrocytes under different physiological
+    conditions (e.g., hypoxia, altitude, anemia)?
+- question: &gt;-
+    Does the reported BPGM-PGAM2 interaction have any functional significance, or is it an
+    artifact of high-throughput interactome screens between two closely related mutases?
+suggested_experiments:
+- description: &gt;-
+    Knockdown/knockout of BPGM in erythroid cells with metabolomic measurement of 2,3-BPG and
+    quantification of the resulting shift in hemoglobin oxygen-affinity (P50) to confirm the
+    gene-to-phenotype link.
+  hypothesis: &gt;-
+    Loss of BPGM lowers erythrocyte 2,3-BPG and increases hemoglobin oxygen affinity.
+- description: &gt;-
+    Structure-guided mutagenesis of active-site residues (e.g., His-11, His-89, Arg-90) to
+    dissect the contributions of synthase vs mutase vs phosphatase activities to 2,3-BPG levels.
+  hypothesis: &gt;-
+    Distinct active-site residues differentially control the synthase, mutase, and phosphatase
+    activities that together set steady-state 2,3-BPG.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/ENO3/ENO3-ai-review.html
+++ b/genes/human/ENO3/ENO3-ai-review.html
@@ -1,0 +1,4385 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ENO3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ENO3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P13929" target="_blank" class="term-link">
+                        P13929
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ENO3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P13929" data-a="DESCRIPTION: ENO3 encodes beta-enolase (muscle-specific enolase..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ENO3 encodes beta-enolase (muscle-specific enolase, MSE), the beta subunit of the glycolytic metalloenzyme enolase. It catalyses the penultimate step of glycolysis: the Mg2+-dependent, reversible dehydration of 2-phospho-D-glycerate (2-PG) to phosphoenolpyruvate (PEP) plus water (EC 4.2.1.11); the reverse hydration reaction operates in gluconeogenesis. Mammalian enolase functions as a dimer assembled from three tissue-specific subunits - alpha (ENO1, ubiquitous), beta (ENO3, muscle) and gamma (ENO2, neuronal) - which form homodimers and heterodimers; in striated muscle ENO3 forms alpha/beta heterodimers and beta/beta homodimers. The enzyme acts in the cytosol, with an additional sarcomeric pool localized to the Z line and, by similarity, the M band. Loss-of-function ENO3 variants cause glycogen storage disease type XIII (GSD13, beta-enolase deficiency), a metabolic myopathy of distal glycolysis characterized by exercise-induced myalgia, muscle weakness and fatigability, raised serum creatine kinase, and focal sarcoplasmic glycogen accumulation.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                                    GO:0004634
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0004634" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred (IBA) assignment of phosphopyruvate hydratase (enolase, EC 4.2.1.11) activity, the defining molecular function of the enolase family and the core catalytic function of ENO3. Beta-enolase converts 2-phosphoglycerate to phosphoenolpyruvate in glycolysis and the reverse in gluconeogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core molecular function of ENO3, at the correct level of specificity, supported by UniProt, EC/RHEA mapping, ISS from mouse ortholog, and multiple TAS Reactome annotations. The IBA is well supported across the enolase orthology group.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Enolase that catalyzes the conversion of 2-phosphoglycerate</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0006096" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred involvement in glycolysis. Enolase catalyses the ninth step of glycolysis (2-PG to PEP), a core biological process for ENO3.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core. ENO3 is a canonical glycolytic enzyme; the muscle beta-enolase supplies the high glycolytic flux of striated muscle. Supported by UniProt PATHWAY.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">glyceraldehyde 3-phosphate: step 4/5</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000015" target="_blank" class="term-link">
+                                    GO:0000015
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0000015" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred assignment to the phosphopyruvate hydratase (enolase) complex - the catalytically active enolase dimer. ENO3 acts as a beta/beta homodimer or an alpha/beta heterodimer with ENO1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Enolase is obligately dimeric and Mg2+ stabilizes the dimer; the complex term accurately captures ENO3&#39;s quaternary organization. This is where the informative content of the bare protein-binding IPIs (ENO1-ENO3) is properly represented.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBUNIT: Mammalian enolase is composed of 3 isozyme subunits, alpha,</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000015" target="_blank" class="term-link">
+                                    GO:0000015
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0000015" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO (IPR000941 Enolase) electronic assignment to the enolase dimer complex. Duplicates the IBA complex annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct InterPro-based mapping; consistent with the IBA part_of annotation and with the obligately dimeric nature of enolase.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBUNIT: Mammalian enolase is composed of 3 isozyme subunits, alpha,</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000287" target="_blank" class="term-link">
+                                    GO:0000287
+                                </a>
+                            </span>
+                            <span class="term-label">magnesium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0000287" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO (IPR000941 Enolase) electronic assignment of magnesium ion binding. Mg2+ is the essential catalytic cofactor of enolase; the structure of P13929 has annotated Mg2+-binding residues (Ser-245, Asp-293, Asp-318).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported. Mg2+ is required for catalysis and for stabilizing the enolase dimer, and UniProt lists explicit Mg2+ BINDING sites in ENO3. A genuine cofactor function; retained as core because catalysis is Mg2+-dependent.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Note=Mg(2+) is required for catalysis and for stabilizing the dimer</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                                    GO:0004634
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0004634" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of phosphopyruvate hydratase activity via combined IEA methods (EC 4.2.1.11, RHEA:10164, InterPro, mouse ortholog). Duplicates the core enolase molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct EC/RHEA/InterPro mapping to the core catalytic function of ENO3.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of cytoplasmic localization from the UniProt subcellular location vocabulary. Enolase is a soluble cytoplasmic/cytosolic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general; the more specific GO:0005829 cytosol (IDA, HPA) is the preferred core location. Kept as an accurate parent-level localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0006094" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic assignment of involvement in gluconeogenesis. Enolase catalyses the reversible 2-PG/PEP interconversion; running in the hydration (PEP to 2-PG) direction, it participates in the gluconeogenic pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biologically correct - the enolase reaction is reversible and operates in both glycolysis and gluconeogenesis, as stated explicitly in the UniProt FUNCTION line. Note that muscle is not a major gluconeogenic tissue, so this is a shared enzymatic capability rather than the dominant physiological role of ENO3, but the annotation is not wrong.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">to phosphoenolpyruvate in glycolysis and the reverse reaction in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0006096" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment (InterPro + UniPathway UPA00109) of involvement in glycolysis. Duplicates the IBA glycolytic process annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process; consistent with the IBA and Reactome annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">glyceraldehyde 3-phosphate: step 4/5</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated physical interaction (BioPlex AP-MS interactome) of ENO3 with ENO1 (UniProtKB:P06733), i.e. the alpha/beta enolase heterodimer. Annotated with the uninformative generic term protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; (GO:0005515) is uninformative and per curation guidelines should not be treated as a core function. The biologically meaningful content - the ENO1-ENO3 (alpha/beta) association - is properly represented by GO:0000015 phosphopyruvate hydratase complex. The interaction itself is a real, high-throughput AP-MS observation, so it is not removed, only flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">affinity purification of 10,128 human proteins-half the proteome-in 293T cells and includes 118,162 interactions among 14,586 proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35271311
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    OpenCell: Endogenous tagging for the cartography of human ce...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0005515" data-r="PMID:35271311" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated physical interaction (OpenCell endogenous-tagging IP-MS) of ENO3 with ENO1 (UniProtKB:P06733), again the alpha/beta enolase heterodimer, annotated with the generic term protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As for the BioPlex IPI, bare &#34;protein binding&#34; is uninformative; the ENO1-ENO3 interaction is captured more specifically by GO:0000015 phosphopyruvate hydratase complex. The interaction is a genuine large-scale IP-MS observation, so it is flagged as over-annotation rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
+                                        PMID:35271311
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">systematically map the localization and interactions of human proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0005829" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara electronic transfer (from mouse ortholog) of active localization in the cytosol - the compartment where glycolysis, and thus the enolase reaction, occurs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; the cytosol is where ENO3 performs its glycolytic function. The is_active_in qualifier is appropriate for a soluble metabolic enzyme. Corroborated by the HPA IDA cytosol annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061621" target="_blank" class="term-link">
+                                    GO:0061621
+                                </a>
+                            </span>
+                            <span class="term-label">canonical glycolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0061621" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment (ARBA + mouse ortholog) of involvement in canonical glycolysis, the ATP-generating glucose-to-pyruvate route. This is a more specific child of glycolytic process describing exactly the pathway ENO3 participates in.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and appropriately specific; ENO3 catalyses the penultimate step of canonical glycolysis. Consistent with the Reactome TAS canonical glycolysis annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">glyceraldehyde 3-phosphate: step 4/5</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70263
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0006094" data-r="Reactome:R-HSA-70263" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement placing ENO3 (as part of the enolase dimers) in the Gluconeogenesis pathway, catalysing the hydration of PEP to 2-PG.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biologically correct; the reversible enolase reaction operates in gluconeogenesis. Consistent with the ARBA IEA gluconeogenesis annotation and with UniProt FUNCTION. Shared enzymatic capability rather than the dominant muscle role, but not incorrect.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">to phosphoenolpyruvate in glycolysis and the reverse reaction in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061621" target="_blank" class="term-link">
+                                    GO:0061621
+                                </a>
+                            </span>
+                            <span class="term-label">canonical glycolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70171
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0061621" data-r="Reactome:R-HSA-70171" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement placing ENO3 in the Glycolysis pathway (canonical glycolysis).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; duplicates the IEA canonical glycolysis annotation with expert Reactome pathway curation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">glyceraldehyde 3-phosphate: step 4/5</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                                    GO:0004634
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70494
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0004634" data-r="Reactome:R-HSA-70494" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement for the enolase reaction (&#34;Enolase dimers (ENO1,2,3) convert PEP to 2PG&#34;), assigning phosphopyruvate hydratase activity to ENO3.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Expert-curated statement of the core catalytic function of ENO3; duplicates the IBA/IEA/ISS enolase MF annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                                    GO:0004634
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71660
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0004634" data-r="Reactome:R-HSA-71660" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement (&#34;Enolase dimers dehydrates 2PG&#34;) for the phosphopyruvate hydratase activity of ENO3.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Expert-curated statement of the core enolase catalytic function; duplicates the other enolase MF annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (Human Protein Atlas immunofluorescence) localizing ENO3 to the cytosol, the primary site of the glycolytic enolase reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental, specific, and core. This is the preferred cellular-component annotation for ENO3 and is consistent with UniProt (Cytoplasm) and the Ensembl is_active_in cytosol annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0005886" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay (Human Protein Atlas immunofluorescence) reporting a plasma-membrane signal for ENO3. Cell-surface enolase pools have been reported for enolases generally, but this is not the core cytosolic catalytic localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Enolase is a well-known moonlighting cell-surface protein in several isozymes, so a plasma-membrane pool is plausible and the experimental HPA signal is retained; however it does not represent the core glycolytic function of ENO3 and is marked non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                                    GO:0004634
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0004634" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity-based transfer (from the rat/mouse ortholog UniProtKB:P15429) of phosphopyruvate hydratase activity to ENO3. Duplicates the core enolase MF.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct ortholog-based transfer of the core catalytic function; the human ENO3 EC 4.2.1.11 assignment itself is ISS-inferred from P15429 in UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19433310" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19433310
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cathepsin X cleaves the C-terminal dipeptide of alpha- and g...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0016020" data-r="PMID:19433310" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CAFA-sourced direct-assay annotation to the generic term membrane, from a study of cathepsin X cleavage of enolase. The cited paper concerns alpha- and gamma-enolase neuronal biology, not muscle beta-enolase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;Membrane&#34; (GO:0016020) is a very general cellular-component term and does not represent the core cytosolic localization of ENO3. The supporting paper studies alpha/gamma-enolase (neurotrophic, cell-surface enolase), so its relevance to muscle beta-enolase is peripheral. Flagged as over-annotation rather than removed, since a moonlighting cell-surface/membrane enolase pool is documented for the family.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19433310" target="_blank" class="term-link">
+                                        PMID:19433310
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identify isozymes alpha- and gamma-enolases as targets for cathepsin X</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23533145
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In-depth proteomic analyses of exosomes isolated from expres...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0070062" data-r="PMID:23533145" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of ENO3 in exosomes isolated from expressed prostatic secretions in urine. A bulk secretome/exosome proteomics survey.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Glycolytic enzymes, including enolases, are ubiquitously detected in exosome/secretome proteomes, and such detections rarely reflect a dedicated biological function. This is not a core localization for muscle beta-enolase and is flagged as over-annotation. Kept (not removed) as it is a valid mass-spectrometry observation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                                        PMID:23533145
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">exosome preparations were characterized by a shotgun proteomics procedure</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22664934" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22664934
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Comparison of tear protein levels in breast cancer patients ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0005576" data-r="PMID:22664934" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of ENO3 in tear fluid (a comparative breast-cancer tear-proteome study). A bulk body-fluid proteomics survey.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Detection of an abundant cytosolic glycolytic enzyme in a body fluid does not establish a dedicated extracellular function; such findings are common contaminant/secretome observations. Not a core localization for ENO3, so flagged as over-annotation while retaining the experimental record.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22664934" target="_blank" class="term-link">
+                                        PMID:22664934
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">semi-quantitative comparison of tear protein levels in cancer (CA) and control</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70494
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0005829" data-r="Reactome:R-HSA-70494" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement localizing the ENO3-containing enolase reaction to the cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; the enolase reaction occurs in the cytosol. Duplicates the HPA IDA cytosol annotation with expert pathway curation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71660
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0005829" data-r="Reactome:R-HSA-71660" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement localizing the ENO3 enolase reaction to the cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; consistent with the other cytosol/cytoplasm annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ENO3/ENO3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                                    GO:0004634
+                                </a>
+                            </span>
+                            <span class="term-label">phosphopyruvate hydratase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8513787" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8513787
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural features of the human gene for muscle-specific en...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P13929" data-a="GO:0004634" data-r="PMID:8513787" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement (PINC) assigning phosphopyruvate hydratase activity to ENO3. The cited paper characterizes the human muscle-specific (beta) enolase gene and identifies it as the beta isoform of the glycolytic enzyme enolase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core catalytic function; the paper explicitly identifies ENO3 as the beta/muscle-specific isoform of the glycolytic enzyme enolase. Duplicates the other enolase MF annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8513787" target="_blank" class="term-link">
+                                        PMID:8513787
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the human gene for the beta or muscle-specific isoform of the glycolytic enzyme enolase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalyses the penultimate step of glycolysis, the Mg2+-dependent reversible dehydration of 2-phospho-D-glycerate to phosphoenolpyruvate plus water (EC 4.2.1.11), as the muscle-specific beta subunit of the enolase dimer; the reverse reaction contributes to gluconeogenesis.</h3>
+                <span class="vote-buttons" data-g="P13929" data-a="FUNCTION: Catalyses the penultimate step of glycolysis, the ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                            phosphopyruvate hydratase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                glycolytic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ENO3/ENO3-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Enolase that catalyzes the conversion of 2-phosphoglycerate</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ENO3/ENO3-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>The same enolase catalytic activity operating in the hydration (PEP to 2-PG) direction contributes to gluconeogenesis.</h3>
+                <span class="vote-buttons" data-g="P13929" data-a="FUNCTION: The same enolase catalytic activity operating in t..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004634" target="_blank" class="term-link">
+                            phosphopyruvate hydratase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                gluconeogenesis
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ENO3/ENO3-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">to phosphoenolpyruvate in glycolysis and the reverse reaction in</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Binds magnesium ion, the essential catalytic cofactor required for the enolase reaction and for stabilizing the enolase dimer.</h3>
+                <span class="vote-buttons" data-g="P13929" data-a="FUNCTION: Binds magnesium ion, the essential catalytic cofac..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000287" target="_blank" class="term-link">
+                            magnesium ion binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ENO3/ENO3-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Note=Mg(2+) is required for catalysis and for stabilizing the dimer</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ENO3/ENO3-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry P13929 (ENOB_HUMAN), Beta-enolase</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19433310" target="_blank" class="term-link">
+                            PMID:19433310
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cathepsin X cleaves the C-terminal dipeptide of alpha- and gamma-enolase and impairs survival and neuritogenesis of neuronal cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22664934" target="_blank" class="term-link">
+                            PMID:22664934
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Comparison of tear protein levels in breast cancer patients and healthy controls using a de novo proteomic approach.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                            PMID:23533145
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
+                            PMID:35271311
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8513787" target="_blank" class="term-link">
+                            PMID:8513787
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural features of the human gene for muscle-specific enolase. Differential splicing in the 5&#39;-untranslated sequence generates two forms of mRNA.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70171
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Glycolysis</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70263
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gluconeogenesis</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70494
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Enolase dimers (ENO1,2,3) convert PEP to 2PG</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71660
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Enolase dimers dehydrates 2PG</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ENO3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P13929" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="eno3-beta-enolase-muscle-specific-enolase-review-notes">ENO3 (Beta-enolase / muscle-specific enolase) review notes</h1>
+<p>UniProtKB: P13929 (ENOB_HUMAN), 434 aa, HGNC:3354, gene on chr17.</p>
+<h2 id="core-biology">Core biology</h2>
+<p>ENO3 is the beta (muscle-specific) isozyme of enolase, a cytosolic metalloenzyme<br />
+of the enolase superfamily. It catalyses the penultimate step of glycolysis:<br />
+the Mg2+-dependent, reversible dehydration of 2-phospho-D-glycerate (2-PG) to<br />
+phosphoenolpyruvate (PEP) + H2O; the reverse hydration reaction operates in<br />
+gluconeogenesis.</p>
+<ul>
+<li>EC 4.2.1.11; Rhea:RHEA:10164 (2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O<br />
+  [file:human/ENO3/ENO3-uniprot.txt "Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O"]</li>
+<li>FUNCTION: "Enolase that catalyzes the conversion of 2-phosphoglycerate to<br />
+  phosphoenolpyruvate in glycolysis and the reverse reaction in gluconeogenesis.<br />
+  Appears to have a function in striated muscle development and regeneration."<br />
+  [file:human/ENO3/ENO3-uniprot.txt]</li>
+<li>COFACTOR: "Mg(2+) is required for catalysis and for stabilizing the dimer."<br />
+  [file:human/ENO3/ENO3-uniprot.txt]</li>
+<li>PATHWAY: "Carbohydrate degradation; glycolysis; pyruvate from D-glyceraldehyde<br />
+  3-phosphate: step 4/5." [file:human/ENO3/ENO3-uniprot.txt]</li>
+</ul>
+<h2 id="isozymes-quaternary-structure">Isozymes / quaternary structure</h2>
+<p>Mammalian enolase is a dimer built from three tissue subunits: alpha (ENO1, ubiquitous),<br />
+beta (ENO3, muscle) and gamma (ENO2, neuronal). ENO3 forms alpha/beta heterodimers and<br />
+beta/beta homodimers in striated muscle.<br />
+[file:human/ENO3/ENO3-uniprot.txt "Mammalian enolase is composed of 3 isozyme subunits, alpha, beta and gamma"]<br />
+IntAct records the ENO1(P06733)-ENO3 interaction (the alpha/beta heterodimer).</p>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>SUBCELLULAR LOCATION: Cytoplasm; "Localized to the Z line. Some colocalization with<br />
+  CKM at M-band (By similarity)." [file:human/ENO3/ENO3-uniprot.txt] So a sarcomeric<br />
+  (Z-line / M-band) pool exists in addition to the bulk cytosol.</li>
+<li>HPA IDA: cytosol (GO:0005829) and plasma membrane (GO:0005886).</li>
+<li>Various HDA/IDA extracellular/membrane detections (exosome, tear fluid, membrane)<br />
+  are proteomic surveys, not indicators of the enzyme's core catalytic role — glycolytic<br />
+  enzymes are commonly detected in secretomes/exosomes. Treated as over-annotations.</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<p>Glycogen storage disease type XIII (GSD13, MIM:612932), beta-enolase deficiency: a<br />
+metabolic myopathy of distal glycolysis; exercise-induced myalgias, generalized muscle<br />
+weakness/fatigability, increased serum creatine kinase, decreased ENO3 activity, focal<br />
+sarcoplasmic glycogen-beta accumulation. Caused by ENO3 variants (Asp-156, Glu-374 in<br />
+the seminal report). [file:human/ENO3/ENO3-uniprot.txt; PMID:11506403 (abstract not cached)]</p>
+<h2 id="annotation-review-summary-actions">Annotation review summary (actions)</h2>
+<ul>
+<li>MF GO:0004634 phosphopyruvate hydratase activity — CORE. Multiple lines (IBA, IEA,<br />
+  ISS, TAS x3). ACCEPT the IBA (phylogenetic, right level) as core; ACCEPT the others.</li>
+<li>MF GO:0000287 magnesium ion binding (IEA, InterPro) — ACCEPT; Mg2+ cofactor is<br />
+  experimentally documented as required for catalysis/dimer stability.</li>
+<li>BP GO:0006096 glycolytic process / GO:0061621 canonical glycolysis — CORE. ACCEPT.</li>
+<li>BP GO:0006094 gluconeogenesis — ACCEPT (reverse reaction; UniProt FUNCTION supports).</li>
+<li>CC GO:0000015 phosphopyruvate hydratase complex (IBA, IEA) — ACCEPT; the enolase dimer.</li>
+<li>CC GO:0005829 cytosol / GO:0005737 cytoplasm — ACCEPT (bulk localization).</li>
+<li>CC GO:0005886 plasma membrane (HPA IDA) — KEEP_AS_NON_CORE; enolase surface pool is<br />
+  reported but is not the core catalytic role.</li>
+<li>CC GO:0016020 membrane (CAFA IDA, PMID:19433310) — MARK_AS_OVER_ANNOTATED; the paper<br />
+  concerns alpha/gamma-enolase neuronal biology, membrane localization is not ENO3-core.</li>
+<li>CC GO:0070062 extracellular exosome (HDA) / GO:0005576 extracellular region (HDA) —<br />
+  MARK_AS_OVER_ANNOTATED; proteomic secretome/exosome detections, not core function.</li>
+<li>MF GO:0005515 protein binding (IPI x2, both with ENO1/P06733) — MARK_AS_OVER_ANNOTATED;<br />
+  bare "protein binding" is uninformative. The real content (alpha/beta heterodimer) is<br />
+  captured by GO:0000015 phosphopyruvate hydratase complex.</li>
+</ul>
+<h2 id="references-cited">References cited</h2>
+<p>See ENO3-uniprot.txt DR/CC blocks and publications/PMID_*.md. PMID:11506403 (GSD13) and<br />
+PMID:15188056 (PNKD interaction) are cited in UniProt but not cached here; not used for<br />
+supporting_text quotes.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P13929
+gene_symbol: ENO3
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  ENO3 encodes beta-enolase (muscle-specific enolase, MSE), the beta subunit of the
+  glycolytic metalloenzyme enolase. It catalyses the penultimate step of glycolysis:
+  the Mg2+-dependent, reversible dehydration of 2-phospho-D-glycerate (2-PG) to
+  phosphoenolpyruvate (PEP) plus water (EC 4.2.1.11); the reverse hydration reaction
+  operates in gluconeogenesis. Mammalian enolase functions as a dimer assembled from
+  three tissue-specific subunits - alpha (ENO1, ubiquitous), beta (ENO3, muscle) and
+  gamma (ENO2, neuronal) - which form homodimers and heterodimers; in striated muscle
+  ENO3 forms alpha/beta heterodimers and beta/beta homodimers. The enzyme acts in the
+  cytosol, with an additional sarcomeric pool localized to the Z line and, by
+  similarity, the M band. Loss-of-function ENO3 variants cause glycogen storage disease
+  type XIII (GSD13, beta-enolase deficiency), a metabolic myopathy of distal glycolysis
+  characterized by exercise-induced myalgia, muscle weakness and fatigability, raised
+  serum creatine kinase, and focal sarcoplasmic glycogen accumulation.
+alternative_products:
+- name: &#39;1&#39;
+  id: P13929-1
+- name: &#39;2&#39;
+  id: P13929-2
+  sequence_note: VSP_037753
+- name: &#39;3&#39;
+  id: P13929-3
+  sequence_note: VSP_037752
+existing_annotations:
+- term:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically-inferred (IBA) assignment of phosphopyruvate hydratase (enolase,
+      EC 4.2.1.11) activity, the defining molecular function of the enolase family and
+      the core catalytic function of ENO3. Beta-enolase converts 2-phosphoglycerate to
+      phosphoenolpyruvate in glycolysis and the reverse in gluconeogenesis.
+    action: ACCEPT
+    reason: &gt;-
+      This is the core molecular function of ENO3, at the correct level of specificity,
+      supported by UniProt, EC/RHEA mapping, ISS from mouse ortholog, and multiple TAS
+      Reactome annotations. The IBA is well supported across the enolase orthology group.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: Enolase that catalyzes the conversion of 2-phosphoglycerate
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically-inferred involvement in glycolysis. Enolase catalyses the ninth
+      step of glycolysis (2-PG to PEP), a core biological process for ENO3.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and core. ENO3 is a canonical glycolytic enzyme; the muscle beta-enolase
+      supplies the high glycolytic flux of striated muscle. Supported by UniProt PATHWAY.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;glyceraldehyde 3-phosphate: step 4/5&#34;
+- term:
+    id: GO:0000015
+    label: phosphopyruvate hydratase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Phylogenetically-inferred assignment to the phosphopyruvate hydratase (enolase)
+      complex - the catalytically active enolase dimer. ENO3 acts as a beta/beta
+      homodimer or an alpha/beta heterodimer with ENO1.
+    action: ACCEPT
+    reason: &gt;-
+      Enolase is obligately dimeric and Mg2+ stabilizes the dimer; the complex term
+      accurately captures ENO3&#39;s quaternary organization. This is where the informative
+      content of the bare protein-binding IPIs (ENO1-ENO3) is properly represented.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;SUBUNIT: Mammalian enolase is composed of 3 isozyme subunits, alpha,&#34;
+- term:
+    id: GO:0000015
+    label: phosphopyruvate hydratase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      InterPro2GO (IPR000941 Enolase) electronic assignment to the enolase dimer complex.
+      Duplicates the IBA complex annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Correct InterPro-based mapping; consistent with the IBA part_of annotation and with
+      the obligately dimeric nature of enolase.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;SUBUNIT: Mammalian enolase is composed of 3 isozyme subunits, alpha,&#34;
+- term:
+    id: GO:0000287
+    label: magnesium ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO (IPR000941 Enolase) electronic assignment of magnesium ion binding.
+      Mg2+ is the essential catalytic cofactor of enolase; the structure of P13929 has
+      annotated Mg2+-binding residues (Ser-245, Asp-293, Asp-318).
+    action: ACCEPT
+    reason: &gt;-
+      Well supported. Mg2+ is required for catalysis and for stabilizing the enolase
+      dimer, and UniProt lists explicit Mg2+ BINDING sites in ENO3. A genuine cofactor
+      function; retained as core because catalysis is Mg2+-dependent.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: Note=Mg(2+) is required for catalysis and for stabilizing the dimer
+- term:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic assignment of phosphopyruvate hydratase activity via combined IEA
+      methods (EC 4.2.1.11, RHEA:10164, InterPro, mouse ortholog). Duplicates the core
+      enolase molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Correct EC/RHEA/InterPro mapping to the core catalytic function of ENO3.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic assignment of cytoplasmic localization from the UniProt subcellular
+      location vocabulary. Enolase is a soluble cytoplasmic/cytosolic enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Correct but general; the more specific GO:0005829 cytosol (IDA, HPA) is the
+      preferred core location. Kept as an accurate parent-level localization.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line&#34;
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ARBA electronic assignment of involvement in gluconeogenesis. Enolase catalyses the
+      reversible 2-PG/PEP interconversion; running in the hydration (PEP to 2-PG)
+      direction, it participates in the gluconeogenic pathway.
+    action: ACCEPT
+    reason: &gt;-
+      Biologically correct - the enolase reaction is reversible and operates in both
+      glycolysis and gluconeogenesis, as stated explicitly in the UniProt FUNCTION line.
+      Note that muscle is not a major gluconeogenic tissue, so this is a shared enzymatic
+      capability rather than the dominant physiological role of ENO3, but the annotation
+      is not wrong.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: to phosphoenolpyruvate in glycolysis and the reverse reaction in
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic assignment (InterPro + UniPathway UPA00109) of involvement in glycolysis.
+      Duplicates the IBA glycolytic process annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core biological process; consistent with the IBA and Reactome annotations.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;glyceraldehyde 3-phosphate: step 4/5&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated physical interaction (BioPlex AP-MS interactome) of ENO3 with ENO1
+      (UniProtKB:P06733), i.e. the alpha/beta enolase heterodimer. Annotated with the
+      uninformative generic term protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare &#34;protein binding&#34; (GO:0005515) is uninformative and per curation guidelines
+      should not be treated as a core function. The biologically meaningful content - the
+      ENO1-ENO3 (alpha/beta) association - is properly represented by GO:0000015
+      phosphopyruvate hydratase complex. The interaction itself is a real, high-throughput
+      AP-MS observation, so it is not removed, only flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: &gt;-
+        affinity purification of 10,128 human proteins-half the proteome-in 293T cells
+        and includes 118,162 interactions among 14,586 proteins
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35271311
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct-curated physical interaction (OpenCell endogenous-tagging IP-MS) of ENO3 with
+      ENO1 (UniProtKB:P06733), again the alpha/beta enolase heterodimer, annotated with the
+      generic term protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      As for the BioPlex IPI, bare &#34;protein binding&#34; is uninformative; the ENO1-ENO3
+      interaction is captured more specifically by GO:0000015 phosphopyruvate hydratase
+      complex. The interaction is a genuine large-scale IP-MS observation, so it is flagged
+      as over-annotation rather than removed.
+    supported_by:
+    - reference_id: PMID:35271311
+      supporting_text: &gt;-
+        systematically map the localization and interactions of human proteins
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara electronic transfer (from mouse ortholog) of active localization in
+      the cytosol - the compartment where glycolysis, and thus the enolase reaction, occurs.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and core; the cytosol is where ENO3 performs its glycolytic function. The
+      is_active_in qualifier is appropriate for a soluble metabolic enzyme. Corroborated by
+      the HPA IDA cytosol annotation.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line&#34;
+- term:
+    id: GO:0061621
+    label: canonical glycolysis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic assignment (ARBA + mouse ortholog) of involvement in canonical glycolysis,
+      the ATP-generating glucose-to-pyruvate route. This is a more specific child of
+      glycolytic process describing exactly the pathway ENO3 participates in.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and appropriately specific; ENO3 catalyses the penultimate step of canonical
+      glycolysis. Consistent with the Reactome TAS canonical glycolysis annotation.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;glyceraldehyde 3-phosphate: step 4/5&#34;
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70263
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement placing ENO3 (as part of the enolase dimers) in
+      the Gluconeogenesis pathway, catalysing the hydration of PEP to 2-PG.
+    action: ACCEPT
+    reason: &gt;-
+      Biologically correct; the reversible enolase reaction operates in gluconeogenesis.
+      Consistent with the ARBA IEA gluconeogenesis annotation and with UniProt FUNCTION.
+      Shared enzymatic capability rather than the dominant muscle role, but not incorrect.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: to phosphoenolpyruvate in glycolysis and the reverse reaction in
+- term:
+    id: GO:0061621
+    label: canonical glycolysis
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70171
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement placing ENO3 in the Glycolysis pathway
+      (canonical glycolysis).
+    action: ACCEPT
+    reason: &gt;-
+      Correct and core; duplicates the IEA canonical glycolysis annotation with expert
+      Reactome pathway curation.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;glyceraldehyde 3-phosphate: step 4/5&#34;
+- term:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70494
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement for the enolase reaction (&#34;Enolase dimers
+      (ENO1,2,3) convert PEP to 2PG&#34;), assigning phosphopyruvate hydratase activity to ENO3.
+    action: ACCEPT
+    reason: &gt;-
+      Expert-curated statement of the core catalytic function of ENO3; duplicates the
+      IBA/IEA/ISS enolase MF annotations.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O
+- term:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71660
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement (&#34;Enolase dimers dehydrates 2PG&#34;) for the
+      phosphopyruvate hydratase activity of ENO3.
+    action: ACCEPT
+    reason: &gt;-
+      Expert-curated statement of the core enolase catalytic function; duplicates the other
+      enolase MF annotations.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct assay (Human Protein Atlas immunofluorescence) localizing ENO3 to the cytosol,
+      the primary site of the glycolytic enolase reaction.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental, specific, and core. This is the preferred cellular-component annotation
+      for ENO3 and is consistent with UniProt (Cytoplasm) and the Ensembl is_active_in
+      cytosol annotation.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line&#34;
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct assay (Human Protein Atlas immunofluorescence) reporting a plasma-membrane
+      signal for ENO3. Cell-surface enolase pools have been reported for enolases generally,
+      but this is not the core cytosolic catalytic localization.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Enolase is a well-known moonlighting cell-surface protein in several isozymes, so a
+      plasma-membrane pool is plausible and the experimental HPA signal is retained; however
+      it does not represent the core glycolytic function of ENO3 and is marked non-core.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line&#34;
+- term:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-similarity-based transfer (from the rat/mouse ortholog UniProtKB:P15429) of
+      phosphopyruvate hydratase activity to ENO3. Duplicates the core enolase MF.
+    action: ACCEPT
+    reason: &gt;-
+      Correct ortholog-based transfer of the core catalytic function; the human ENO3 EC
+      4.2.1.11 assignment itself is ISS-inferred from P15429 in UniProt.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IDA
+  original_reference_id: PMID:19433310
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      CAFA-sourced direct-assay annotation to the generic term membrane, from a study of
+      cathepsin X cleavage of enolase. The cited paper concerns alpha- and gamma-enolase
+      neuronal biology, not muscle beta-enolase.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;Membrane&#34; (GO:0016020) is a very general cellular-component term and does not
+      represent the core cytosolic localization of ENO3. The supporting paper studies
+      alpha/gamma-enolase (neurotrophic, cell-surface enolase), so its relevance to muscle
+      beta-enolase is peripheral. Flagged as over-annotation rather than removed, since a
+      moonlighting cell-surface/membrane enolase pool is documented for the family.
+    supported_by:
+    - reference_id: PMID:19433310
+      supporting_text: &gt;-
+        we identify isozymes alpha- and gamma-enolases as targets for cathepsin X
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:23533145
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomic detection of ENO3 in exosomes isolated from expressed
+      prostatic secretions in urine. A bulk secretome/exosome proteomics survey.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Glycolytic enzymes, including enolases, are ubiquitously detected in exosome/secretome
+      proteomes, and such detections rarely reflect a dedicated biological function. This is
+      not a core localization for muscle beta-enolase and is flagged as over-annotation. Kept
+      (not removed) as it is a valid mass-spectrometry observation.
+    supported_by:
+    - reference_id: PMID:23533145
+      supporting_text: &gt;-
+        exosome preparations were characterized by a shotgun proteomics procedure
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: HDA
+  original_reference_id: PMID:22664934
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomic detection of ENO3 in tear fluid (a comparative breast-cancer
+      tear-proteome study). A bulk body-fluid proteomics survey.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Detection of an abundant cytosolic glycolytic enzyme in a body fluid does not establish
+      a dedicated extracellular function; such findings are common contaminant/secretome
+      observations. Not a core localization for ENO3, so flagged as over-annotation while
+      retaining the experimental record.
+    supported_by:
+    - reference_id: PMID:22664934
+      supporting_text: &gt;-
+        semi-quantitative comparison of tear protein levels in cancer (CA) and control
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70494
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement localizing the ENO3-containing enolase reaction to
+      the cytosol.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and core; the enolase reaction occurs in the cytosol. Duplicates the HPA IDA
+      cytosol annotation with expert pathway curation.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line&#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71660
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement localizing the ENO3 enolase reaction to the cytosol.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and core; consistent with the other cytosol/cytoplasm annotations.
+    supported_by:
+    - reference_id: file:human/ENO3/ENO3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Cytoplasm. Note=Localized to the Z line&#34;
+- term:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  evidence_type: TAS
+  original_reference_id: PMID:8513787
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Traceable-author-statement (PINC) assigning phosphopyruvate hydratase activity to ENO3.
+      The cited paper characterizes the human muscle-specific (beta) enolase gene and
+      identifies it as the beta isoform of the glycolytic enzyme enolase.
+    action: ACCEPT
+    reason: &gt;-
+      Core catalytic function; the paper explicitly identifies ENO3 as the beta/muscle-specific
+      isoform of the glycolytic enzyme enolase. Duplicates the other enolase MF annotations.
+    supported_by:
+    - reference_id: PMID:8513787
+      supporting_text: &gt;-
+        the human gene for the beta or muscle-specific isoform of the glycolytic enzyme enolase
+core_functions:
+- description: &gt;-
+    Catalyses the penultimate step of glycolysis, the Mg2+-dependent reversible dehydration
+    of 2-phospho-D-glycerate to phosphoenolpyruvate plus water (EC 4.2.1.11), as the
+    muscle-specific beta subunit of the enolase dimer; the reverse reaction contributes to
+    gluconeogenesis.
+  molecular_function:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  directly_involved_in:
+  - id: GO:0006096
+    label: glycolytic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: file:human/ENO3/ENO3-uniprot.txt
+    supporting_text: Enolase that catalyzes the conversion of 2-phosphoglycerate
+  - reference_id: file:human/ENO3/ENO3-uniprot.txt
+    supporting_text: Reaction=(2R)-2-phosphoglycerate = phosphoenolpyruvate + H2O
+- description: &gt;-
+    The same enolase catalytic activity operating in the hydration (PEP to 2-PG) direction
+    contributes to gluconeogenesis.
+  molecular_function:
+    id: GO:0004634
+    label: phosphopyruvate hydratase activity
+  directly_involved_in:
+  - id: GO:0006094
+    label: gluconeogenesis
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: file:human/ENO3/ENO3-uniprot.txt
+    supporting_text: to phosphoenolpyruvate in glycolysis and the reverse reaction in
+- description: &gt;-
+    Binds magnesium ion, the essential catalytic cofactor required for the enolase reaction
+    and for stabilizing the enolase dimer.
+  molecular_function:
+    id: GO:0000287
+    label: magnesium ion binding
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: file:human/ENO3/ENO3-uniprot.txt
+    supporting_text: Note=Mg(2+) is required for catalysis and for stabilizing the dimer
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: file:human/ENO3/ENO3-uniprot.txt
+  title: UniProtKB entry P13929 (ENOB_HUMAN), Beta-enolase
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Canonical UniProt record for human ENO3/beta-enolase; primary source for the catalytic
+      reaction, Mg2+ cofactor, glycolysis/gluconeogenesis pathway, cytoplasmic/Z-line
+      localization, isozyme/dimer composition, and GSD13 disease association.
+- id: PMID:19433310
+  title: Cathepsin X cleaves the C-terminal dipeptide of alpha- and gamma-enolase
+    and impairs survival and neuritogenesis of neuronal cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; study concerns alpha- and gamma-enolase (neuronal), not muscle
+      beta-enolase. Underpins the CAFA membrane IDA annotation, which is peripheral to ENO3.
+- id: PMID:22664934
+  title: Comparison of tear protein levels in breast cancer patients and healthy controls
+    using a de novo proteomic approach.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified body-fluid (tear) proteomics survey; ENO3 detection reflects abundance
+      in a body fluid rather than a dedicated extracellular function.
+- id: PMID:23533145
+  title: In-depth proteomic analyses of exosomes isolated from expressed prostatic
+    secretions in urine.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified exosome proteomics survey; supports the extracellular exosome HDA
+      annotation but does not indicate a core ENO3 function.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified BioPlex AP-MS interactome; documents the ENO1-ENO3 (alpha/beta)
+      interaction, captured more informatively by the phosphopyruvate hydratase complex term.
+- id: PMID:35271311
+  title: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization.&#39;
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified OpenCell IP-MS/imaging resource; documents the ENO1-ENO3 interaction,
+      better represented by the enolase complex term than by bare protein binding.
+- id: PMID:8513787
+  title: Structural features of the human gene for muscle-specific enolase. Differential
+    splicing in the 5&#39;-untranslated sequence generates two forms of mRNA.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; characterizes the human ENO3 (beta/muscle-specific) enolase gene and
+      identifies it as the beta isoform of the glycolytic enzyme enolase, supporting the
+      TAS phosphopyruvate hydratase activity annotation.
+- id: Reactome:R-HSA-70171
+  title: Glycolysis
+  findings: []
+- id: Reactome:R-HSA-70263
+  title: Gluconeogenesis
+  findings: []
+- id: Reactome:R-HSA-70494
+  title: Enolase dimers (ENO1,2,3) convert PEP to 2PG
+  findings: []
+- id: Reactome:R-HSA-71660
+  title: Enolase dimers dehydrates 2PG
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/LDHA/LDHA-ai-review.html
+++ b/genes/human/LDHA/LDHA-ai-review.html
@@ -1,0 +1,7043 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LDHA - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>LDHA</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P00338" target="_blank" class="term-link">
+                        P00338
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "LDHA";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P00338" data-a="DESCRIPTION: LDHA encodes the L-lactate dehydrogenase A chain (..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>LDHA encodes the L-lactate dehydrogenase A chain (LDH-A / LDH-M, the &#34;muscle&#34; subunit; EC 1.1.1.27), a cytosolic NAD+-dependent oxidoreductase that catalyses the reversible interconversion of pyruvate + NADH and L-lactate + NAD+. The A/M subunit kinetically favours the reduction of pyruvate to lactate, thereby regenerating cytosolic NAD+ so that glycolysis can continue under anaerobic or high-flux conditions; this is the terminal step of lactate fermentation and a hallmark of the Warburg effect in tumours. The catalytically active enzyme is a tetramer assembled from LDHA (A/M) and LDHB (B/H) subunits, giving five isoenzymes (A4 through B4); the LDHA homotetramer (M4, LDH-5) predominates in skeletal muscle and liver. Loss-of-function of LDHA causes glycogen storage disease type XI (LDH-M deficiency), characterized by exertional myopathy, myoglobinuria and cramps.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019244" target="_blank" class="term-link">
+                                    GO:0019244
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate fermentation to lactate</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0019244" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to the specific process that LDHA terminates - reduction of pyruvate to lactate as the final step of lactate fermentation, regenerating NAD+ for glycolysis. This is a core biological process for the A/M subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LDHA catalyses exactly this reaction, and the A/M subunit kinetically favours the pyruvate-to-lactate direction, which is the defining role of this isoform. UniProt assigns the pathway &#34;pyruvate fermentation to lactate&#34; to LDHA. Well-supported core BP.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24816116" target="_blank" class="term-link">
+                                        PMID:24816116
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">predominantly found in skeletal muscle and catalyses the reversible conversion</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">pyruvate fermentation to lactate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0004459" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to the precise EC 1.1.1.27 molecular function of LDHA. This is the core molecular function of the gene product.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by structural/enzymatic work on human LDH-A and by the UniProt catalytic-activity statement (RHEA:23444, EC 1.1.1.27). The IBA is at exactly the right level of specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                                        PMID:11276087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">interconverts pyruvate and lactate with concomitant</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interconverts simultaneously and stereospecifically pyruvate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation placing LDHA activity in the mitochondrion. LDHA is canonically a cytosolic enzyme; a mitochondrial LDH pool (&#34;mLDH&#34;) has been proposed but remains contested and is not the core localization of the human A/M subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records LDHA subcellular location as Cytoplasm, and the experimental/HPA/Reactome annotations consistently place it in the cytosol. Although some literature invokes a mitochondrial lactate-oxidation pool, this is disputed and not established for human LDHA; the IBA projection should not be treated as a core location. Retained as a possible non-core pool rather than removed, since it is a reviewed phylogenetic call.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33406399" target="_blank" class="term-link">
+                                        PMID:33406399
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">competing with mitochondrial lactate dehydrogenase (mLDH) for nicotinamide</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003824" target="_blank" class="term-link">
+                                    GO:0003824
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0003824" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation to the root catalytic-activity term. Correct but far too general given that LDHA has a precisely defined EC-level function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LDHA is a well-characterized oxidoreductase with a specific NAD+-dependent lactate dehydrogenase activity; the generic &#34;catalytic activity&#34; term is uninformative and should be replaced by the specific function.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    L-lactate dehydrogenase (NAD+) activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interconverts simultaneously and stereospecifically pyruvate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0004459" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt IEA, GO_REF:0000120) annotation to the precise EC 1.1.1.27 function, mapped via RHEA:23444/EC:1.1.1.27. Core molecular function; consistent with the experimental annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct, specific MF supported by UniProt catalytic-activity data and experimental enzymology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=1.1.1.27</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt IEA) annotation to cytoplasm, matching the UniProt subcellular-location statement. Correct but less precise than the cytosol annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LDHA is a soluble cytosolic enzyme; the more specific term GO:0005829 cytosol (supported experimentally by HPA and Reactome) is preferable to the broad &#34;cytoplasm&#34;.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    cytosol
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016491" target="_blank" class="term-link">
+                                    GO:0016491
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0016491" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO annotation to the broad oxidoreductase parent. Correct in class but too general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LDHA&#39;s oxidoreductase activity is specifically NAD+-dependent L-lactate dehydrogenase; replace the generic parent with the specific function.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    L-lactate dehydrogenase (NAD+) activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=1.1.1.27</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016616" target="_blank" class="term-link">
+                                    GO:0016616
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP as acceptor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0016616" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO annotation to the CH-OH/NAD(P) oxidoreductase parent. This is the correct branch (LDHA acts on the CH-OH group of lactate using NAD+), but a level too general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The specific child term GO:0004459 L-lactate dehydrogenase (NAD+) activity is the appropriate function and is already supported experimentally.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    L-lactate dehydrogenase (NAD+) activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=1.1.1.27</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21988832
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Toward an understanding of the protein interaction network o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:21988832" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated binary interaction (LDHA-LDHB, P07195) from a large-scale liver interactome study, annotated to the uninformative &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, bare &#34;protein binding&#34; is uninformative and is not retained as a core function. The interaction itself (LDHA-LDHB) is real and biologically meaningful (A/B heterotetramer isoenzymes), but the generic MF term adds nothing beyond what identical/heterosubunit association already captures. Retained (not removed) as an experimental IPI.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link">
+                                        PMID:21988832
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Toward an understanding of the protein interaction network of the human liver</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23523103" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23523103
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Lysine-5 acetylation negatively regulates lactate dehydrogen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:23523103" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction with HSPA8/HSC70 (P11142). HSC70 recognizes K5-acetylated LDHA and delivers it to lysosomes for chaperone-mediated degradation, a regulatory (turnover) interaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative and non-core; retained as an experimental IPI. The underlying biology (acetylation-triggered HSC70-mediated degradation) is a regulatory mechanism, not the enzyme&#39;s molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23523103" target="_blank" class="term-link">
+                                        PMID:23523103
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LDH-A is recognized by the HSC70 chaperone and delivered to lysosomes for</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction (LDHA-LDHB, P07195) from a large-scale human interactome mapping study, annotated to the generic &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare &#34;protein binding&#34;; non-core. Retained as an experimental IPI (LDHA-LDHB subunit association).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                                        PMID:28514442
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Architecture of the human interactome defines protein communities and disease</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction with LDHC (P07864) from the same human interactome study, annotated to the generic &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare &#34;protein binding&#34;; non-core. Retained as an experimental IPI (LDHA-LDHC subunit association).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                                        PMID:28514442
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Architecture of the human interactome defines protein communities and disease</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31515488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive disruption of protein interactions by genetic vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:31515488" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction (LDHA-LDHB, P07195) from a variant-effect interactome study, annotated to the generic &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare &#34;protein binding&#34;; non-core. Retained as an experimental IPI.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                                        PMID:31515488
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Extensive disruption of protein interactions by genetic variants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction (LDHA-LDHB, P07195) from a proteome-scale interactome network study, annotated to the generic &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare &#34;protein binding&#34;; non-core. Retained as an experimental IPI.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dual proteome-scale networks reveal cell-specific remodeling of the human</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction with LDHC (P07864) from the same proteome-scale study, annotated to the generic &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare &#34;protein binding&#34;; non-core. Retained as an experimental IPI.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dual proteome-scale networks reveal cell-specific remodeling of the human</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35271311
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    OpenCell: Endogenous tagging for the cartography of human ce...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:35271311" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction (LDHA-LDHB, P07195) from the OpenCell endogenous tagging study, annotated to the generic &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare &#34;protein binding&#34;; non-core. Retained as an experimental IPI.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
+                                        PMID:35271311
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">OpenCell: Endogenous tagging for the cartography of human cellular organization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35271311
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    OpenCell: Endogenous tagging for the cartography of human ce...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:35271311" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction with LDHC (P07864) from the OpenCell study, annotated to the generic &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare &#34;protein binding&#34;; non-core. Retained as an experimental IPI.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
+                                        PMID:35271311
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">OpenCell: Endogenous tagging for the cartography of human cellular organization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction with LDHC (P07864) from a multimodal cell-map study, annotated to the generic &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare &#34;protein binding&#34;; non-core. Retained as an experimental IPI.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                                        PMID:40205054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Multimodal cell maps as a foundation for structural and functional genomics</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21988832
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Toward an understanding of the protein interaction network o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0042802" data-r="PMID:21988832" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct self-interaction (LDHA-LDHA, P00338). Reflects the homotypic subunit association that builds the active LDHA homotetramer (M4/LDH-5).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Informative and biologically core - LDHA self-associates into a homotetramer, which is required for catalytic activity. Directly corroborated by crystallography showing homotetramerization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                                        PMID:11276087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the M form, predominantly found in</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Homotetramer</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25502805" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25502805
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A massively parallel pipeline to clone DNA variants and exam...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0042802" data-r="PMID:25502805" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct self-interaction (LDHA-LDHA) from a massively parallel variant-phenotyping pipeline, supporting homotetramer self-association.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Informative, core - consistent with the LDHA homotetramer required for function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25502805" target="_blank" class="term-link">
+                                        PMID:25502805
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A massively parallel pipeline to clone DNA variants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31515488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive disruption of protein interactions by genetic vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0042802" data-r="PMID:31515488" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct self-interaction (LDHA-LDHA), supporting homotetramer self-association.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Informative, core - consistent with the LDHA homotetramer required for catalytic activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                                        PMID:31515488
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Extensive disruption of protein interactions by genetic variants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004457" target="_blank" class="term-link">
+                                    GO:0004457
+                                </a>
+                            </span>
+                            <span class="term-label">lactate dehydrogenase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0004457" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara orthology (IEA) transfer of lactate dehydrogenase activity from the mouse ortholog. Correct; a slightly broader parent of the NAD+-specific term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurately captures LDHA&#39;s function; retained even though it is one level broader than GO:0004459, as it is not incorrect and is well-supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=1.1.1.27</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005829" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara orthology (IEA) transfer of cytosolic localization. Matches the experimental cytosol annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LDHA is a soluble cytosolic glycolytic enzyme; localization is correct and core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035686" target="_blank" class="term-link">
+                                    GO:0035686
+                                </a>
+                            </span>
+                            <span class="term-label">sperm fibrous sheath</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0035686" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara orthology (IEA) transfer of a sperm fibrous sheath localization from the mouse ortholog. This is a specialized germ-cell localization more characteristic of the testis-specific paralog LDHC, not a core localization of somatic LDHA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LDHA is predominantly a cytosolic enzyme of muscle and liver; a sperm fibrous sheath localization is peripheral/germ-cell-specific and is not part of the core function. Retained as a possible non-core localization from orthology transfer rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042867" target="_blank" class="term-link">
+                                    GO:0042867
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0042867" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara orthology (IEA) transfer of pyruvate catabolic process. LDHA consumes pyruvate (reducing it to lactate), so this is a correct process annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LDHA catalyses pyruvate reduction to lactate, a catabolic fate of pyruvate that regenerates NAD+. Correct, though the more specific fermentation term is the primary process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24816116" target="_blank" class="term-link">
+                                        PMID:24816116
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">predominantly found in skeletal muscle and catalyses the reversible conversion</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HPA immunofluorescence (IDA) localization of LDHA to the cytosol. Direct experimental support for the core cytosolic localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for cytosolic localization, consistent with LDHA being a soluble glycolytic enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11276087
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for altered activity of M- and H-isozyme fo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0004459" data-r="PMID:11276087" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (crystallography + enzymology) demonstration of the NAD+-dependent lactate dehydrogenase activity of human LDH-M (LDHA). Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Definitive experimental support - the study determined the crystal structure of the human M (LDHA) isoform as a ternary complex with NADH and the substrate analog oxamate and characterized its catalytic activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                                        PMID:11276087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">interconverts pyruvate and lactate with concomitant</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006089" target="_blank" class="term-link">
+                                    GO:0006089
+                                </a>
+                            </span>
+                            <span class="term-label">lactate metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24816116" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24816116
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural characterization of the apo form and NADH binary ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0006089" data-r="PMID:24816116" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IDA linking the LDH complex to lactate metabolism, based on the structural/enzymatic characterization of human LDH-A. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LDHA directly interconverts pyruvate and lactate; participation in lactate metabolic process is well-supported experimentally.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24816116" target="_blank" class="term-link">
+                                        PMID:24816116
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">predominantly found in skeletal muscle and catalyses the reversible conversion</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990204" target="_blank" class="term-link">
+                                    GO:1990204
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24816116" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24816116
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural characterization of the apo form and NADH binary ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:1990204" data-r="PMID:24816116" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal annotation that LDHA is part of an oxidoreductase complex (the LDH tetramer). The active enzyme is an oligomeric oxidoreductase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The functional LDH enzyme is a homo/heterotetramer that is a bona fide oxidoreductase complex; this correctly captures LDHA&#39;s participation in an oligomeric enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24816116" target="_blank" class="term-link">
+                                        PMID:24816116
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">assemble to form hLDH-1 (B4), hLDH-2 (AB3), hLDH-3 (A2B2), hLDH-4 (A3B) and hLDH-5 (A4)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006089" target="_blank" class="term-link">
+                                    GO:0006089
+                                </a>
+                            </span>
+                            <span class="term-label">lactate metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34381247" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34381247
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The tumor suppressor folliculin inhibits lactate dehydrogena...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0006089" data-r="PMID:34381247" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt IDA linking LDHA to lactate metabolic process, based on the FLCN study demonstrating that LDHA activity (lactate production) is directly regulated. Core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This study experimentally established LDHA as the enzyme driving lactate production (Warburg effect), directly supporting its role in lactate metabolism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34381247" target="_blank" class="term-link">
+                                        PMID:34381247
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identify the human tumor suppressor folliculin (FLCN) as a binding partner and uncompetitive inhibitor of LDHA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9861563
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005829" data-r="Reactome:R-HSA-9861563" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS cytosolic localization (from the CTLH-ligase ubiquitination reaction). Consistent with the core cytosolic location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytosolic localization is well-established for LDHA and supported by multiple independent sources.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34381247" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34381247
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The tumor suppressor folliculin inhibits lactate dehydrogena...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0004459" data-r="PMID:34381247" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP annotation of the L-lactate dehydrogenase activity, from the FLCN study using the LDHA R106 mutant to probe activity regulation. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The study functionally assayed LDHA enzymatic activity (including a mutagenesis of Arg-106 affecting FLCN binding), directly supporting the MF annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34381247" target="_blank" class="term-link">
+                                        PMID:34381247
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identify the human tumor suppressor folliculin (FLCN) as a binding partner and uncompetitive inhibitor of LDHA</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34381247" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34381247
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The tumor suppressor folliculin inhibits lactate dehydrogena...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:34381247" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt IPI for the direct LDHA-FLCN (folliculin, Q8NFG4) interaction. FLCN is a direct, uncompetitive inhibitor of LDHA - a physiologically important regulatory interaction, but annotated to the uninformative &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative per curation policy and is not retained as a core MF. The interaction itself is real, direct and functionally important (activity regulation), and is retained as an experimental IPI rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34381247" target="_blank" class="term-link">
+                                        PMID:34381247
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identify the human tumor suppressor folliculin (FLCN) as a binding partner and uncompetitive inhibitor of LDHA</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the interaction is direct and inhibits enzymatic activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34381247" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34381247
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The tumor suppressor folliculin inhibits lactate dehydrogena...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0042802" data-r="PMID:34381247" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt IPI self-interaction (LDHA-LDHA) reported in the FLCN study, consistent with the LDHA homotetramer / dimer-tetramer equilibrium described there.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Informative and core - LDHA self-association underlies the active tetramer; the FLCN study explicitly discusses the LDHA dimer/tetramer states.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34381247" target="_blank" class="term-link">
+                                        PMID:34381247
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">FLCN prefers binding to the less active LDHA dimer, compared to the hyperactive LDHA tetramer</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33406399" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33406399
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An Upstream Open Reading Frame in Phosphatase and Tensin Hom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005515" data-r="PMID:33406399" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt IPI for the LDHA-MP31 (C0HLV8) interaction. MP31, a micropeptide from the PTEN uORF, competes with LDH for NAD+ and limits lactate-pyruvate conversion; annotated to the uninformative &#34;protein binding&#34; term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative and non-core. The MP31 interaction is real (mutagenesis of Asp-56 and Arg-99 abolishes it) and regulatory, retained as an experimental IPI rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33406399" target="_blank" class="term-link">
+                                        PMID:33406399
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">competing with mitochondrial lactate dehydrogenase (mLDH) for nicotinamide</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045296" target="_blank" class="term-link">
+                                    GO:0045296
+                                </a>
+                            </span>
+                            <span class="term-label">cadherin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25468996
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    E-cadherin interactome complexity and robustness resolved by...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0045296" data-r="PMID:25468996" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput BioID proximity-biotinylation proteomics detected LDHA in the vicinity of the E-cadherin cytoplasmic tail. This is a proximity hit, not a demonstrated direct/functional cadherin interaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> BioID labels proteins within ~20-30 nm of the bait and captures many abundant cytosolic proteins; the authors note most identified proteins are not junctional. LDHA is an abundant glycolytic enzyme with no established cadherin adhesion role, so this is an over-annotation. Retained (not removed) as an experimental high-throughput observation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link">
+                                        PMID:25468996
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we employed proximity biotinylation and quantitative proteomics to isolate and identify 612 proteins in the vicinity of E-cadherin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11487543" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11487543
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Intestinal epithelial cells secrete exosome-like vesicles.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0070062" data-r="PMID:11487543" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of LDHA in secreted exosome-like vesicles. LDHA is an abundant cytosolic protein commonly detected in exosome preparations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Detection of a highly abundant cytosolic glycolytic enzyme in exosome proteomes does not establish exosome localization as a core function; likely reflects passive incorporation/contamination. Retained as a high-throughput observation, not core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11487543" target="_blank" class="term-link">
+                                        PMID:11487543
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">exosome-like vesicles</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23533145
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In-depth proteomic analyses of exosomes isolated from expres...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0070062" data-r="PMID:23533145" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of LDHA in prostatic-secretion exosomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As with other exosome-proteomics hits, this reflects the abundance of the cytosolic enzyme rather than a dedicated exosomal function; non-core, retained as an observation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                                        PMID:23533145
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">exosomes isolated from expressed prostatic secretions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput membrane-proteome (NK cell) detection of LDHA. LDHA is a soluble cytosolic enzyme; membrane co-fractionation is likely peripheral association or contamination of the membrane fraction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No evidence that LDHA is an integral or functionally membrane-associated protein; this large-scale fractionation hit is non-core. Retained as an observation rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">membrane proteome of NK cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21630459
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteomic characterization of the human sperm nucleus.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005634" data-r="PMID:21630459" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of LDHA in the human sperm nucleus fraction. A nuclear pool of LDHA has been reported in some contexts, but this HDA hit does not establish a core nuclear function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LDHA is predominantly cytosolic; nuclear detection in a sperm-nucleus proteome is peripheral/context-specific and non-core. Retained as a high-throughput observation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
+                                        PMID:21630459
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">sperm nucleus</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19056867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Large-scale proteomics and phosphoproteomics of urinary exos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0070062" data-r="PMID:19056867" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of LDHA in urinary exosomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Abundant cytosolic enzyme detected in exosome proteomics; non-core. Retained as a high-throughput observation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                                        PMID:19056867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">proteomics and phosphoproteomics of urinary exosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20458337
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MHC class II-associated proteins in B-cell exosomes and pote...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0070062" data-r="PMID:20458337" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of LDHA in B-cell exosomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As with other exosome-proteomics hits, non-core; reflects abundance rather than dedicated exosomal function. Retained as an observation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link">
+                                        PMID:20458337
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">exosomes and potential functional</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70510
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005829" data-r="Reactome:R-HSA-70510" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS cytosolic localization (LDH tetramer oxidises lactate to pyruvate reaction). Consistent with core cytosolic location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-established cytosolic localization for the glycolytic LDH enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71849
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005829" data-r="Reactome:R-HSA-71849" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS cytosolic localization (LDH tetramer reduces pyruvate to lactate reaction). Consistent with core cytosolic location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-established cytosolic localization for the glycolytic LDH enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2334430" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2334430
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular characterization of genetic mutation in human lact...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0004459" data-r="PMID:2334430" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement MF annotation from the molecular characterization of human LDH-A(M) deficiency. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This genetics paper characterizes the LDH-A (Muscle) subunit and its deficiency, treating the L-lactate dehydrogenase activity of LDHA as established. Core MF, consistent with all other evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2334430" target="_blank" class="term-link">
+                                        PMID:2334430
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">deficient in LDH-A (Muscle) subunit</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2434947" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2434947
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Centrosomal proteins and lactate dehydrogenase possess a com...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0005829" data-r="PMID:2434947" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement cytosolic localization from an older study. Consistent with the core cytosolic location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytosolic localization is robustly established for LDHA across many sources.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHA/LDHA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1953713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1953713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of genetic mutations in human lactate dehydrogenase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0004459" data-r="PMID:1953713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable-author-statement MF annotation from a study of LDH-A(M) deficiency mutations. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The paper analyzes disease-causing mutations in the human LDH-A gene, treating the lactate dehydrogenase activity of LDHA as established. Core MF, concordant with the experimental annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1953713" target="_blank" class="term-link">
+                                        PMID:1953713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human lactate dehydrogenase (LDH)-A mutant gene was analyzed</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1953713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1953713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of genetic mutations in human lactate dehydrogenase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00338" data-a="GO:0006096" data-r="PMID:1953713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated involvement of LDHA in the glycolytic process. LDHA regenerates cytosolic NAD+ (by reducing pyruvate to lactate) required to sustain glycolytic flux; a core process for the A/M subunit under anaerobic / high-flux conditions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LDHA is a canonical glycolysis-associated enzyme - its lactate-forming reaction recycles NAD+ that keeps glycolysis (specifically GAPDH) running. Correct core process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1953713" target="_blank" class="term-link">
+                                        PMID:1953713
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human lactate dehydrogenase (LDH)-A mutant gene was analyzed</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>NAD+-dependent L-lactate dehydrogenase - reversibly interconverts pyruvate + NADH and L-lactate + NAD+, with the A/M subunit favouring reduction of pyruvate to lactate to regenerate cytosolic NAD+</h3>
+                <span class="vote-buttons" data-g="P00338" data-a="FUNCTION: NAD+-dependent L-lactate dehydrogenase - reversibl..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                            L-lactate dehydrogenase (NAD+) activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019244" target="_blank" class="term-link">
+                                pyruvate fermentation to lactate
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                                PMID:11276087
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">interconverts pyruvate and lactate with concomitant</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/LDHA/LDHA-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Interconverts simultaneously and stereospecifically pyruvate</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Lactate/NAD+ recycling supporting glycolytic flux - reducing pyruvate to lactate regenerates NAD+ so that glycolysis can continue under anaerobic or high-flux (e.g. Warburg-effect) conditions</h3>
+                <span class="vote-buttons" data-g="P00338" data-a="FUNCTION: Lactate/NAD+ recycling supporting glycolytic flux ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                            L-lactate dehydrogenase (NAD+) activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006089" target="_blank" class="term-link">
+                                lactate metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24816116" target="_blank" class="term-link">
+                                PMID:24816116
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">predominantly found in skeletal muscle and catalyses the reversible conversion</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34381247" target="_blank" class="term-link">
+                                PMID:34381247
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">we identify the human tumor suppressor folliculin (FLCN) as a binding partner and uncompetitive inhibitor of LDHA</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Homotetramer assembly - LDHA self-associates (and heteroassociates with LDHB/LDHC) into the catalytically active tetrameric oxidoreductase complex (M4/LDH-5 and A/B isoenzymes)</h3>
+                <span class="vote-buttons" data-g="P00338" data-a="FUNCTION: Homotetramer assembly - LDHA self-associates (and ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                            identical protein binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019244" target="_blank" class="term-link">
+                                pyruvate fermentation to lactate
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990204" target="_blank" class="term-link">
+                            oxidoreductase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                                PMID:11276087
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the M form, predominantly found in</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24816116" target="_blank" class="term-link">
+                                PMID:24816116
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">assemble to form hLDH-1 (B4), hLDH-2 (AB3), hLDH-3 (A2B2), hLDH-4 (A3B) and hLDH-5 (A4)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                            PMID:11276087
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for altered activity of M- and H-isozyme forms of human lactate dehydrogenase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11487543" target="_blank" class="term-link">
+                            PMID:11487543
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Intestinal epithelial cells secrete exosome-like vesicles.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                            PMID:19056867
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1953713" target="_blank" class="term-link">
+                            PMID:1953713
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of genetic mutations in human lactate dehydrogenase-A(M) deficiency using DNA conformation polymorphism in combination with polyacrylamide gradient gel and silver staining.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link">
+                            PMID:20458337
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MHC class II-associated proteins in B-cell exosomes and potential functional implications for exosome biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
+                            PMID:21630459
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteomic characterization of the human sperm nucleus.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link">
+                            PMID:21988832
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Toward an understanding of the protein interaction network of the human liver.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2334430" target="_blank" class="term-link">
+                            PMID:2334430
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular characterization of genetic mutation in human lactate dehydrogenase-A (M) deficiency.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23523103" target="_blank" class="term-link">
+                            PMID:23523103
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Lysine-5 acetylation negatively regulates lactate dehydrogenase A and is decreased in pancreatic cancer.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                            PMID:23533145
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2434947" target="_blank" class="term-link">
+                            PMID:2434947
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Centrosomal proteins and lactate dehydrogenase possess a common epitope in human cell lines.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24816116" target="_blank" class="term-link">
+                            PMID:24816116
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural characterization of the apo form and NADH binary complex of human lactate dehydrogenase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25468996" target="_blank" class="term-link">
+                            PMID:25468996
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">E-cadherin interactome complexity and robustness resolved by quantitative proteomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25502805" target="_blank" class="term-link">
+                            PMID:25502805
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A massively parallel pipeline to clone DNA variants and examine molecular phenotypes of human disease mutations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                            PMID:31515488
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33406399" target="_blank" class="term-link">
+                            PMID:33406399
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An Upstream Open Reading Frame in Phosphatase and Tensin Homolog Encodes a Circuit Breaker of Lactate Metabolism.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34381247" target="_blank" class="term-link">
+                            PMID:34381247
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The tumor suppressor folliculin inhibits lactate dehydrogenase A and regulates the Warburg effect.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
+                            PMID:35271311
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70510
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LDH tetramer oxidises LACT to PYR</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71849
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LDH tetramer reduces PYR to LACT</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9861563
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CTLH E3 ligase ubiquitinates LDHA</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/LDHA/LDHA-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry P00338 (LDHA_HUMAN)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is there a genuine, functionally significant mitochondrial pool of human LDHA (&#34;mLDH&#34;), or is the mitochondrial IBA annotation an over-projection?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P00338" data-a="Q: Is there a genuine, functionally significant mitoc..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> To what extent do the reported nuclear and cadherin-proximal localizations of LDHA reflect moonlighting functions versus abundance-driven proteomics artifacts?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P00338" data-a="Q: To what extent do the reported nuclear and cadheri..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantitative subcellular fractionation with activity assays to test whether a catalytically active mitochondrial LDHA pool exists in human cells.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P00338" data-a="EXPERIMENT: Quantitative subcellular fractionation with activi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided mutagenesis of the FLCN- and MP31-interaction interfaces to define how these regulators modulate LDHA activity and oligomeric state in vivo.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P00338" data-a="EXPERIMENT: Structure-guided mutagenesis of the FLCN- and MP31..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(LDHA-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P00338" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ldha-p00338-review-notes">LDHA (P00338) review notes</h1>
+<h2 id="identity-and-core-biology">Identity and core biology</h2>
+<ul>
+<li>LDHA = L-lactate dehydrogenase A chain, a.k.a. LDH-A / LDH-M (muscle) subunit; EC 1.1.1.27.</li>
+<li>Catalyses reversible, NAD+-dependent interconversion of pyruvate + NADH ↔ L-lactate + NAD+.<br />
+  UniProt FUNCTION: "Interconverts simultaneously and stereospecifically pyruvate and lactate with<br />
+  concomitant interconversion of NADH and NAD(+)" [file:human/LDHA/LDHA-uniprot.txt].</li>
+<li>Catalytic activity (RHEA:23444, EC 1.1.1.27): (S)-lactate + NAD(+) = pyruvate + NADH + H(+).</li>
+<li>A/M subunit kinetically favours pyruvate→lactate (regenerates cytosolic NAD+ for glycolysis /<br />
+  lactate fermentation), whereas B/H favours the reverse <a href="https://pubmed.ncbi.nlm.nih.gov/24816116" title="the A (or M) subunit   preferentially converts pyruvate to lactate, while for the B (or H) form the converse is true">PMID:24816116</a>.</li>
+<li>Active enzyme is a tetramer; LDHA (A/M) and LDHB (B/H) subunits assemble into five isoenzymes<br />
+  hLDH-1 (B4) … hLDH-5 (A4) <a href="https://pubmed.ncbi.nlm.nih.gov/24816116">PMID:24816116</a>. LDHA homotetramer = M4 = LDH-5 [PMID:11276087<br />
+  "HOMOTETRAMERIZATION"; UniProt SUBUNIT "Homotetramer"].</li>
+<li>Cytosolic/cytoplasmic (UniProt SUBCELLULAR LOCATION: Cytoplasm; HPA IDA cytosol; Reactome TAS).</li>
+<li>Predominantly expressed in anaerobic tissues (skeletal muscle, liver).</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>Deficiency causes Glycogen storage disease 11 (GSD11 / LDH-M deficiency, MIM:612933):<br />
+  exertional myoglobinuria, myopathy, cramps, easy fatigue [UniProt DISEASE; PMID:2334430,<br />
+  PMID:1953713 genetic characterization of LDH-A(M) deficiency mutations].</li>
+</ul>
+<h2 id="regulation-interactions-mostly-non-core-regulatory">Regulation / interactions (mostly non-core, regulatory)</h2>
+<ul>
+<li>FLCN (folliculin) binds LDHA directly and is an uncompetitive inhibitor; regulates Warburg<br />
+  effect <a href="https://pubmed.ncbi.nlm.nih.gov/34381247">PMID:34381247</a>. This paper's IMP for GO:0004459 (via R106 mutant) and IPI to FLCN<br />
+  (Q8NFG4) and self (identical protein binding) are supported.</li>
+<li>MP31 micropeptide (from PTEN uORF; C0HLV8) competes with LDH for NAD+ <a href="https://pubmed.ncbi.nlm.nih.gov/33406399">PMID:33406399</a>; IPI supported.</li>
+<li>K5 acetylation inhibits LDHA and targets it for chaperone-mediated (HSC70) lysosomal degradation<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23523103">PMID:23523103</a>; explains IntAct IPI with HSPA8/HSC70 (P11142).</li>
+<li>CTLH E3 ligase ubiquitinates LDHA, inhibiting activity (Reactome R-HSA-9861563).</li>
+</ul>
+<h2 id="goa-review-approach">GOA review approach</h2>
+<ul>
+<li>Core MF: GO:0004459 L-lactate dehydrogenase (NAD+) activity (many redundant evidence lines: IBA,<br />
+  IEA, EXP PMID:11276087, IMP PMID:34381247, TAS, NAS) — ACCEPT the well-supported ones, the<br />
+  vaguer parents get MODIFY/MARK.</li>
+<li>GO:0004457 lactate dehydrogenase activity (parent of 0004459) — ACCEPT (correct, slightly broader).</li>
+<li>Core BP: pyruvate→lactate fermentation / lactate metabolic process / glycolytic process / pyruvate<br />
+  metabolism — all sound; keep the specific ones as core, broader/looser as non-core.</li>
+<li>Core CC: cytosol/cytoplasm — ACCEPT.</li>
+<li>GO:0005739 mitochondrion (IBA): LDHA is canonically cytosolic. A mitochondrial pool has been<br />
+  proposed (mLDH, e.g. PMID:33406399 "mitochondrial lactate dehydrogenase (mLDH)") but it is<br />
+  contested and not the core localization; the IBA is a projected/uncertain call. Mark as<br />
+  MARK_AS_OVER_ANNOTATED (non-core, contested) rather than accepting as a core location.</li>
+<li>GO:0005515 protein binding (bare) IPIs: uninformative per curation policy → MARK_AS_OVER_ANNOTATED<br />
+  (NOT remove; these are experimental IntAct/UniProt IPIs).</li>
+<li>GO:0042802 identical protein binding: informative (homotetramer self-association) → ACCEPT.</li>
+<li>GO:0045296 cadherin binding (HDA, BioID proximity proteomics, PMID:25468996): proximity-labeling<br />
+  hit, not a demonstrated functional cadherin interaction → MARK_AS_OVER_ANNOTATED.</li>
+<li>Exosome/membrane/nucleus/sperm-fibrous-sheath localizations: high-throughput proteomics<br />
+  (HDA/IEA-from-mouse ortholog) detecting abundant glycolytic enzyme in many fractions; not core<br />
+  → MARK_AS_OVER_ANNOTATED (keep as detected, not core; don't remove experimental HDA).</li>
+<li>GO:1990204 oxidoreductase complex (ComplexPortal IPI, PMID:24816116): LDH tetramer is a bona fide<br />
+  oxidoreductase complex → ACCEPT.</li>
+<li>IEA catalytic-activity/oxidoreductase parents (GO:0003824, GO:0016491, GO:0016616): correct but<br />
+  too general given the specific EC-level annotation exists → MODIFY to GO:0004459.<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P00338
+gene_symbol: LDHA
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: LDHA encodes the L-lactate dehydrogenase A chain (LDH-A / LDH-M, the
+  &#34;muscle&#34; subunit; EC 1.1.1.27), a cytosolic NAD+-dependent oxidoreductase that
+  catalyses the reversible interconversion of pyruvate + NADH and L-lactate + NAD+.
+  The A/M subunit kinetically favours the reduction of pyruvate to lactate, thereby
+  regenerating cytosolic NAD+ so that glycolysis can continue under anaerobic or
+  high-flux conditions; this is the terminal step of lactate fermentation and a
+  hallmark of the Warburg effect in tumours. The catalytically active enzyme is a
+  tetramer assembled from LDHA (A/M) and LDHB (B/H) subunits, giving five isoenzymes
+  (A4 through B4); the LDHA homotetramer (M4, LDH-5) predominates in skeletal muscle
+  and liver. Loss-of-function of LDHA causes glycogen storage disease type XI (LDH-M
+  deficiency), characterized by exertional myopathy, myoglobinuria and cramps.
+alternative_products:
+- name: &#39;1&#39;
+  id: P00338-1
+- name: &#39;2&#39;
+  id: P00338-2
+  sequence_note: VSP_014261, VSP_042787
+- name: &#39;3&#39;
+  id: P00338-3
+  sequence_note: VSP_042206
+- name: &#39;4&#39;
+  id: P00338-4
+  sequence_note: VSP_042786
+- name: &#39;5&#39;
+  id: P00338-5
+  sequence_note: VSP_042788, VSP_042789
+existing_annotations:
+- term:
+    id: GO:0019244
+    label: pyruvate fermentation to lactate
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic (IBA) annotation to the specific process that LDHA
+      terminates - reduction of pyruvate to lactate as the final step of lactate
+      fermentation, regenerating NAD+ for glycolysis. This is a core biological
+      process for the A/M subunit.
+    action: ACCEPT
+    reason: LDHA catalyses exactly this reaction, and the A/M subunit kinetically
+      favours the pyruvate-to-lactate direction, which is the defining role of this
+      isoform. UniProt assigns the pathway &#34;pyruvate fermentation to lactate&#34; to
+      LDHA. Well-supported core BP.
+    supported_by:
+    - reference_id: PMID:24816116
+      supporting_text: predominantly found in skeletal muscle and catalyses the reversible conversion
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: pyruvate fermentation to lactate
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) annotation to the precise EC 1.1.1.27 molecular
+      function of LDHA. This is the core molecular function of the gene product.
+    action: ACCEPT
+    reason: Directly supported by structural/enzymatic work on human LDH-A and by
+      the UniProt catalytic-activity statement (RHEA:23444, EC 1.1.1.27). The IBA
+      is at exactly the right level of specificity.
+    supported_by:
+    - reference_id: PMID:11276087
+      supporting_text: interconverts pyruvate and lactate with concomitant
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: Interconverts simultaneously and stereospecifically pyruvate
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) annotation placing LDHA activity in the
+      mitochondrion. LDHA is canonically a cytosolic enzyme; a mitochondrial LDH
+      pool (&#34;mLDH&#34;) has been proposed but remains contested and is not the core
+      localization of the human A/M subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: UniProt records LDHA subcellular location as Cytoplasm, and the
+      experimental/HPA/Reactome annotations consistently place it in the cytosol.
+      Although some literature invokes a mitochondrial lactate-oxidation pool, this
+      is disputed and not established for human LDHA; the IBA projection should not
+      be treated as a core location. Retained as a possible non-core pool rather
+      than removed, since it is a reviewed phylogenetic call.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+        - COMPARTMENT_OR_COMPLEX_MISMATCH
+    supported_by:
+    - reference_id: PMID:33406399
+      supporting_text: competing with mitochondrial lactate dehydrogenase (mLDH) for nicotinamide
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
+- term:
+    id: GO:0003824
+    label: catalytic activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic annotation to the root catalytic-activity term.
+      Correct but far too general given that LDHA has a precisely defined EC-level
+      function.
+    action: MODIFY
+    reason: LDHA is a well-characterized oxidoreductase with a specific NAD+-dependent
+      lactate dehydrogenase activity; the generic &#34;catalytic activity&#34; term is
+      uninformative and should be replaced by the specific function.
+    proposed_replacement_terms:
+    - id: GO:0004459
+      label: L-lactate dehydrogenase (NAD+) activity
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: Interconverts simultaneously and stereospecifically pyruvate
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic (UniProt IEA, GO_REF:0000120) annotation to the precise
+      EC 1.1.1.27 function, mapped via RHEA:23444/EC:1.1.1.27. Core molecular
+      function; consistent with the experimental annotations.
+    action: ACCEPT
+    reason: Correct, specific MF supported by UniProt catalytic-activity data and
+      experimental enzymology.
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: EC=1.1.1.27
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Electronic (UniProt IEA) annotation to cytoplasm, matching the UniProt
+      subcellular-location statement. Correct but less precise than the cytosol
+      annotations.
+    action: MODIFY
+    reason: LDHA is a soluble cytosolic enzyme; the more specific term GO:0005829
+      cytosol (supported experimentally by HPA and Reactome) is preferable to the
+      broad &#34;cytoplasm&#34;.
+    proposed_replacement_terms:
+    - id: GO:0005829
+      label: cytosol
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
+- term:
+    id: GO:0016491
+    label: oxidoreductase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO annotation to the broad oxidoreductase parent. Correct in
+      class but too general.
+    action: MODIFY
+    reason: LDHA&#39;s oxidoreductase activity is specifically NAD+-dependent L-lactate
+      dehydrogenase; replace the generic parent with the specific function.
+    proposed_replacement_terms:
+    - id: GO:0004459
+      label: L-lactate dehydrogenase (NAD+) activity
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: EC=1.1.1.27
+- term:
+    id: GO:0016616
+    label: oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP
+      as acceptor
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO annotation to the CH-OH/NAD(P) oxidoreductase parent. This
+      is the correct branch (LDHA acts on the CH-OH group of lactate using NAD+),
+      but a level too general.
+    action: MODIFY
+    reason: The specific child term GO:0004459 L-lactate dehydrogenase (NAD+)
+      activity is the appropriate function and is already supported experimentally.
+    proposed_replacement_terms:
+    - id: GO:0004459
+      label: L-lactate dehydrogenase (NAD+) activity
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: EC=1.1.1.27
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21988832
+  qualifier: enables
+  review:
+    summary: IntAct-curated binary interaction (LDHA-LDHB, P07195) from a large-scale
+      liver interactome study, annotated to the uninformative &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per curation guidelines, bare &#34;protein binding&#34; is uninformative and is
+      not retained as a core function. The interaction itself (LDHA-LDHB) is real
+      and biologically meaningful (A/B heterotetramer isoenzymes), but the generic
+      MF term adds nothing beyond what identical/heterosubunit association already
+      captures. Retained (not removed) as an experimental IPI.
+    supported_by:
+    - reference_id: PMID:21988832
+      supporting_text: Toward an understanding of the protein interaction network of the human liver
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23523103
+  qualifier: enables
+  review:
+    summary: IntAct interaction with HSPA8/HSC70 (P11142). HSC70 recognizes
+      K5-acetylated LDHA and delivers it to lysosomes for chaperone-mediated
+      degradation, a regulatory (turnover) interaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative and non-core; retained as an
+      experimental IPI. The underlying biology (acetylation-triggered HSC70-mediated
+      degradation) is a regulatory mechanism, not the enzyme&#39;s molecular function.
+    supported_by:
+    - reference_id: PMID:23523103
+      supporting_text: LDH-A is recognized by the HSC70 chaperone and delivered to lysosomes for
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: IntAct interaction (LDHA-LDHB, P07195) from a large-scale human
+      interactome mapping study, annotated to the generic &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare &#34;protein binding&#34;; non-core. Retained as an
+      experimental IPI (LDHA-LDHB subunit association).
+    supported_by:
+    - reference_id: PMID:28514442
+      supporting_text: Architecture of the human interactome defines protein communities and disease
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: IntAct interaction with LDHC (P07864) from the same human interactome
+      study, annotated to the generic &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare &#34;protein binding&#34;; non-core. Retained as an
+      experimental IPI (LDHA-LDHC subunit association).
+    supported_by:
+    - reference_id: PMID:28514442
+      supporting_text: Architecture of the human interactome defines protein communities and disease
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  qualifier: enables
+  review:
+    summary: IntAct interaction (LDHA-LDHB, P07195) from a variant-effect
+      interactome study, annotated to the generic &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare &#34;protein binding&#34;; non-core. Retained as an
+      experimental IPI.
+    supported_by:
+    - reference_id: PMID:31515488
+      supporting_text: Extensive disruption of protein interactions by genetic variants
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: IntAct interaction (LDHA-LDHB, P07195) from a proteome-scale
+      interactome network study, annotated to the generic &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare &#34;protein binding&#34;; non-core. Retained as an
+      experimental IPI.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: Dual proteome-scale networks reveal cell-specific remodeling of the human
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: IntAct interaction with LDHC (P07864) from the same proteome-scale
+      study, annotated to the generic &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare &#34;protein binding&#34;; non-core. Retained as an
+      experimental IPI.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: Dual proteome-scale networks reveal cell-specific remodeling of the human
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35271311
+  qualifier: enables
+  review:
+    summary: IntAct interaction (LDHA-LDHB, P07195) from the OpenCell endogenous
+      tagging study, annotated to the generic &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare &#34;protein binding&#34;; non-core. Retained as an
+      experimental IPI.
+    supported_by:
+    - reference_id: PMID:35271311
+      supporting_text: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35271311
+  qualifier: enables
+  review:
+    summary: IntAct interaction with LDHC (P07864) from the OpenCell study,
+      annotated to the generic &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare &#34;protein binding&#34;; non-core. Retained as an
+      experimental IPI.
+    supported_by:
+    - reference_id: PMID:35271311
+      supporting_text: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: IntAct interaction with LDHC (P07864) from a multimodal cell-map study,
+      annotated to the generic &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare &#34;protein binding&#34;; non-core. Retained as an
+      experimental IPI.
+    supported_by:
+    - reference_id: PMID:40205054
+      supporting_text: Multimodal cell maps as a foundation for structural and functional genomics
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21988832
+  qualifier: enables
+  review:
+    summary: IntAct self-interaction (LDHA-LDHA, P00338). Reflects the homotypic
+      subunit association that builds the active LDHA homotetramer (M4/LDH-5).
+    action: ACCEPT
+    reason: Informative and biologically core - LDHA self-associates into a
+      homotetramer, which is required for catalytic activity. Directly corroborated
+      by crystallography showing homotetramerization.
+    supported_by:
+    - reference_id: PMID:11276087
+      supporting_text: the M form, predominantly found in
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: Homotetramer
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25502805
+  qualifier: enables
+  review:
+    summary: IntAct self-interaction (LDHA-LDHA) from a massively parallel
+      variant-phenotyping pipeline, supporting homotetramer self-association.
+    action: ACCEPT
+    reason: Informative, core - consistent with the LDHA homotetramer required for
+      function.
+    supported_by:
+    - reference_id: PMID:25502805
+      supporting_text: A massively parallel pipeline to clone DNA variants
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  qualifier: enables
+  review:
+    summary: IntAct self-interaction (LDHA-LDHA), supporting homotetramer
+      self-association.
+    action: ACCEPT
+    reason: Informative, core - consistent with the LDHA homotetramer required for
+      catalytic activity.
+    supported_by:
+    - reference_id: PMID:31515488
+      supporting_text: Extensive disruption of protein interactions by genetic variants
+- term:
+    id: GO:0004457
+    label: lactate dehydrogenase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: Ensembl-Compara orthology (IEA) transfer of lactate dehydrogenase
+      activity from the mouse ortholog. Correct; a slightly broader parent of the
+      NAD+-specific term.
+    action: ACCEPT
+    reason: Accurately captures LDHA&#39;s function; retained even though it is one level
+      broader than GO:0004459, as it is not incorrect and is well-supported.
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: EC=1.1.1.27
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: Ensembl-Compara orthology (IEA) transfer of cytosolic localization.
+      Matches the experimental cytosol annotations.
+    action: ACCEPT
+    reason: LDHA is a soluble cytosolic glycolytic enzyme; localization is correct
+      and core.
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
+- term:
+    id: GO:0035686
+    label: sperm fibrous sheath
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: Ensembl-Compara orthology (IEA) transfer of a sperm fibrous sheath
+      localization from the mouse ortholog. This is a specialized germ-cell
+      localization more characteristic of the testis-specific paralog LDHC, not a
+      core localization of somatic LDHA.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: LDHA is predominantly a cytosolic enzyme of muscle and liver; a sperm
+      fibrous sheath localization is peripheral/germ-cell-specific and is not part
+      of the core function. Retained as a possible non-core localization from
+      orthology transfer rather than removed.
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
+- term:
+    id: GO:0042867
+    label: pyruvate catabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Ensembl-Compara orthology (IEA) transfer of pyruvate catabolic process.
+      LDHA consumes pyruvate (reducing it to lactate), so this is a correct process
+      annotation.
+    action: ACCEPT
+    reason: LDHA catalyses pyruvate reduction to lactate, a catabolic fate of
+      pyruvate that regenerates NAD+. Correct, though the more specific fermentation
+      term is the primary process.
+    supported_by:
+    - reference_id: PMID:24816116
+      supporting_text: predominantly found in skeletal muscle and catalyses the reversible conversion
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: HPA immunofluorescence (IDA) localization of LDHA to the cytosol.
+      Direct experimental support for the core cytosolic localization.
+    action: ACCEPT
+    reason: Direct experimental evidence for cytosolic localization, consistent with
+      LDHA being a soluble glycolytic enzyme.
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: EXP
+  original_reference_id: PMID:11276087
+  qualifier: enables
+  review:
+    summary: Experimental (crystallography + enzymology) demonstration of the
+      NAD+-dependent lactate dehydrogenase activity of human LDH-M (LDHA). Core
+      molecular function.
+    action: ACCEPT
+    reason: Definitive experimental support - the study determined the crystal
+      structure of the human M (LDHA) isoform as a ternary complex with NADH and
+      the substrate analog oxamate and characterized its catalytic activity.
+    supported_by:
+    - reference_id: PMID:11276087
+      supporting_text: interconverts pyruvate and lactate with concomitant
+- term:
+    id: GO:0006089
+    label: lactate metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:24816116
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal IDA linking the LDH complex to lactate metabolism, based
+      on the structural/enzymatic characterization of human LDH-A. Core biological
+      process.
+    action: ACCEPT
+    reason: LDHA directly interconverts pyruvate and lactate; participation in
+      lactate metabolic process is well-supported experimentally.
+    supported_by:
+    - reference_id: PMID:24816116
+      supporting_text: predominantly found in skeletal muscle and catalyses the reversible conversion
+- term:
+    id: GO:1990204
+    label: oxidoreductase complex
+  evidence_type: IPI
+  original_reference_id: PMID:24816116
+  qualifier: part_of
+  review:
+    summary: ComplexPortal annotation that LDHA is part of an oxidoreductase complex
+      (the LDH tetramer). The active enzyme is an oligomeric oxidoreductase.
+    action: ACCEPT
+    reason: The functional LDH enzyme is a homo/heterotetramer that is a bona fide
+      oxidoreductase complex; this correctly captures LDHA&#39;s participation in an
+      oligomeric enzyme.
+    supported_by:
+    - reference_id: PMID:24816116
+      supporting_text: assemble to form hLDH-1 (B4), hLDH-2 (AB3), hLDH-3 (A2B2), hLDH-4 (A3B) and hLDH-5 (A4)
+- term:
+    id: GO:0006089
+    label: lactate metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:34381247
+  qualifier: involved_in
+  review:
+    summary: UniProt IDA linking LDHA to lactate metabolic process, based on the
+      FLCN study demonstrating that LDHA activity (lactate production) is directly
+      regulated. Core process.
+    action: ACCEPT
+    reason: This study experimentally established LDHA as the enzyme driving lactate
+      production (Warburg effect), directly supporting its role in lactate
+      metabolism.
+    supported_by:
+    - reference_id: PMID:34381247
+      supporting_text: we identify the human tumor suppressor folliculin (FLCN) as a binding partner and uncompetitive inhibitor of LDHA
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9861563
+  qualifier: located_in
+  review:
+    summary: Reactome TAS cytosolic localization (from the CTLH-ligase ubiquitination
+      reaction). Consistent with the core cytosolic location.
+    action: ACCEPT
+    reason: Cytosolic localization is well-established for LDHA and supported by
+      multiple independent sources.
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: IMP
+  original_reference_id: PMID:34381247
+  qualifier: enables
+  review:
+    summary: IMP annotation of the L-lactate dehydrogenase activity, from the FLCN
+      study using the LDHA R106 mutant to probe activity regulation. Core molecular
+      function.
+    action: ACCEPT
+    reason: The study functionally assayed LDHA enzymatic activity (including a
+      mutagenesis of Arg-106 affecting FLCN binding), directly supporting the MF
+      annotation.
+    supported_by:
+    - reference_id: PMID:34381247
+      supporting_text: we identify the human tumor suppressor folliculin (FLCN) as a binding partner and uncompetitive inhibitor of LDHA
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34381247
+  qualifier: enables
+  review:
+    summary: UniProt IPI for the direct LDHA-FLCN (folliculin, Q8NFG4) interaction.
+      FLCN is a direct, uncompetitive inhibitor of LDHA - a physiologically
+      important regulatory interaction, but annotated to the uninformative &#34;protein
+      binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative per curation policy and is not
+      retained as a core MF. The interaction itself is real, direct and functionally
+      important (activity regulation), and is retained as an experimental IPI rather
+      than removed.
+    supported_by:
+    - reference_id: PMID:34381247
+      supporting_text: we identify the human tumor suppressor folliculin (FLCN) as a binding partner and uncompetitive inhibitor of LDHA
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: the interaction is direct and inhibits enzymatic activity
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34381247
+  qualifier: enables
+  review:
+    summary: UniProt IPI self-interaction (LDHA-LDHA) reported in the FLCN study,
+      consistent with the LDHA homotetramer / dimer-tetramer equilibrium described
+      there.
+    action: ACCEPT
+    reason: Informative and core - LDHA self-association underlies the active
+      tetramer; the FLCN study explicitly discusses the LDHA dimer/tetramer states.
+    supported_by:
+    - reference_id: PMID:34381247
+      supporting_text: FLCN prefers binding to the less active LDHA dimer, compared to the hyperactive LDHA tetramer
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33406399
+  qualifier: enables
+  review:
+    summary: UniProt IPI for the LDHA-MP31 (C0HLV8) interaction. MP31, a micropeptide
+      from the PTEN uORF, competes with LDH for NAD+ and limits lactate-pyruvate
+      conversion; annotated to the uninformative &#34;protein binding&#34; term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative and non-core. The MP31
+      interaction is real (mutagenesis of Asp-56 and Arg-99 abolishes it) and
+      regulatory, retained as an experimental IPI rather than removed.
+    supported_by:
+    - reference_id: PMID:33406399
+      supporting_text: competing with mitochondrial lactate dehydrogenase (mLDH) for nicotinamide
+- term:
+    id: GO:0045296
+    label: cadherin binding
+  evidence_type: HDA
+  original_reference_id: PMID:25468996
+  qualifier: enables
+  review:
+    summary: High-throughput BioID proximity-biotinylation proteomics detected LDHA
+      in the vicinity of the E-cadherin cytoplasmic tail. This is a proximity hit,
+      not a demonstrated direct/functional cadherin interaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: BioID labels proteins within ~20-30 nm of the bait and captures many
+      abundant cytosolic proteins; the authors note most identified proteins are not
+      junctional. LDHA is an abundant glycolytic enzyme with no established cadherin
+      adhesion role, so this is an over-annotation. Retained (not removed) as an
+      experimental high-throughput observation.
+    supported_by:
+    - reference_id: PMID:25468996
+      supporting_text: we employed proximity biotinylation and quantitative proteomics to isolate and identify 612 proteins in the vicinity of E-cadherin
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:11487543
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of LDHA in secreted exosome-like
+      vesicles. LDHA is an abundant cytosolic protein commonly detected in exosome
+      preparations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Detection of a highly abundant cytosolic glycolytic enzyme in exosome
+      proteomes does not establish exosome localization as a core function; likely
+      reflects passive incorporation/contamination. Retained as a high-throughput
+      observation, not core.
+    supported_by:
+    - reference_id: PMID:11487543
+      supporting_text: exosome-like vesicles
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:23533145
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of LDHA in prostatic-secretion
+      exosomes.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: As with other exosome-proteomics hits, this reflects the abundance of
+      the cytosolic enzyme rather than a dedicated exosomal function; non-core,
+      retained as an observation.
+    supported_by:
+    - reference_id: PMID:23533145
+      supporting_text: exosomes isolated from expressed prostatic secretions
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: High-throughput membrane-proteome (NK cell) detection of LDHA. LDHA is
+      a soluble cytosolic enzyme; membrane co-fractionation is likely peripheral
+      association or contamination of the membrane fraction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: No evidence that LDHA is an integral or functionally membrane-associated
+      protein; this large-scale fractionation hit is non-core. Retained as an
+      observation rather than removed.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: membrane proteome of NK cells
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: HDA
+  original_reference_id: PMID:21630459
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of LDHA in the human sperm nucleus
+      fraction. A nuclear pool of LDHA has been reported in some contexts, but this
+      HDA hit does not establish a core nuclear function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: LDHA is predominantly cytosolic; nuclear detection in a sperm-nucleus
+      proteome is peripheral/context-specific and non-core. Retained as a
+      high-throughput observation.
+    supported_by:
+    - reference_id: PMID:21630459
+      supporting_text: sperm nucleus
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of LDHA in urinary exosomes.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Abundant cytosolic enzyme detected in exosome proteomics; non-core.
+      Retained as a high-throughput observation.
+    supported_by:
+    - reference_id: PMID:19056867
+      supporting_text: proteomics and phosphoproteomics of urinary exosomes
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:20458337
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of LDHA in B-cell exosomes.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: As with other exosome-proteomics hits, non-core; reflects abundance
+      rather than dedicated exosomal function. Retained as an observation.
+    supported_by:
+    - reference_id: PMID:20458337
+      supporting_text: exosomes and potential functional
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70510
+  qualifier: located_in
+  review:
+    summary: Reactome TAS cytosolic localization (LDH tetramer oxidises lactate to
+      pyruvate reaction). Consistent with core cytosolic location.
+    action: ACCEPT
+    reason: Well-established cytosolic localization for the glycolytic LDH enzyme.
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71849
+  qualifier: located_in
+  review:
+    summary: Reactome TAS cytosolic localization (LDH tetramer reduces pyruvate to
+      lactate reaction). Consistent with core cytosolic location.
+    action: ACCEPT
+    reason: Well-established cytosolic localization for the glycolytic LDH enzyme.
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: TAS
+  original_reference_id: PMID:2334430
+  qualifier: enables
+  review:
+    summary: Traceable-author-statement MF annotation from the molecular
+      characterization of human LDH-A(M) deficiency. Core molecular function.
+    action: ACCEPT
+    reason: This genetics paper characterizes the LDH-A (Muscle) subunit and its
+      deficiency, treating the L-lactate dehydrogenase activity of LDHA as
+      established. Core MF, consistent with all other evidence.
+    supported_by:
+    - reference_id: PMID:2334430
+      supporting_text: deficient in LDH-A (Muscle) subunit
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: PMID:2434947
+  qualifier: located_in
+  review:
+    summary: Traceable-author-statement cytosolic localization from an older study.
+      Consistent with the core cytosolic location.
+    action: ACCEPT
+    reason: Cytosolic localization is robustly established for LDHA across many
+      sources.
+    supported_by:
+    - reference_id: file:human/LDHA/LDHA-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm&#39;
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: NAS
+  original_reference_id: PMID:1953713
+  qualifier: enables
+  review:
+    summary: Non-traceable-author-statement MF annotation from a study of LDH-A(M)
+      deficiency mutations. Core molecular function.
+    action: ACCEPT
+    reason: The paper analyzes disease-causing mutations in the human LDH-A gene,
+      treating the lactate dehydrogenase activity of LDHA as established. Core MF,
+      concordant with the experimental annotations.
+    supported_by:
+    - reference_id: PMID:1953713
+      supporting_text: Human lactate dehydrogenase (LDH)-A mutant gene was analyzed
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: NAS
+  original_reference_id: PMID:1953713
+  qualifier: involved_in
+  review:
+    summary: Author-stated involvement of LDHA in the glycolytic process. LDHA
+      regenerates cytosolic NAD+ (by reducing pyruvate to lactate) required to
+      sustain glycolytic flux; a core process for the A/M subunit under anaerobic /
+      high-flux conditions.
+    action: ACCEPT
+    reason: LDHA is a canonical glycolysis-associated enzyme - its lactate-forming
+      reaction recycles NAD+ that keeps glycolysis (specifically GAPDH) running.
+      Correct core process annotation.
+    supported_by:
+    - reference_id: PMID:1953713
+      supporting_text: Human lactate dehydrogenase (LDH)-A mutant gene was analyzed
+core_functions:
+- description: NAD+-dependent L-lactate dehydrogenase - reversibly interconverts
+    pyruvate + NADH and L-lactate + NAD+, with the A/M subunit favouring reduction
+    of pyruvate to lactate to regenerate cytosolic NAD+
+  molecular_function:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  directly_involved_in:
+  - id: GO:0019244
+    label: pyruvate fermentation to lactate
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:11276087
+    supporting_text: interconverts pyruvate and lactate with concomitant
+  - reference_id: file:human/LDHA/LDHA-uniprot.txt
+    supporting_text: Interconverts simultaneously and stereospecifically pyruvate
+- description: Lactate/NAD+ recycling supporting glycolytic flux - reducing pyruvate
+    to lactate regenerates NAD+ so that glycolysis can continue under anaerobic or
+    high-flux (e.g. Warburg-effect) conditions
+  molecular_function:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  directly_involved_in:
+  - id: GO:0006089
+    label: lactate metabolic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:24816116
+    supporting_text: predominantly found in skeletal muscle and catalyses the reversible conversion
+  - reference_id: PMID:34381247
+    supporting_text: we identify the human tumor suppressor folliculin (FLCN) as a binding partner and uncompetitive inhibitor of LDHA
+- description: Homotetramer assembly - LDHA self-associates (and heteroassociates
+    with LDHB/LDHC) into the catalytically active tetrameric oxidoreductase complex
+    (M4/LDH-5 and A/B isoenzymes)
+  molecular_function:
+    id: GO:0042802
+    label: identical protein binding
+  directly_involved_in:
+  - id: GO:0019244
+    label: pyruvate fermentation to lactate
+  in_complex:
+    id: GO:1990204
+    label: oxidoreductase complex
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:11276087
+    supporting_text: the M form, predominantly found in
+  - reference_id: PMID:24816116
+    supporting_text: assemble to form hLDH-1 (B4), hLDH-2 (AB3), hLDH-3 (A2B2), hLDH-4 (A3B) and hLDH-5 (A4)
+proposed_new_terms: []
+suggested_questions:
+- question: Is there a genuine, functionally significant mitochondrial pool of human
+    LDHA (&#34;mLDH&#34;), or is the mitochondrial IBA annotation an over-projection?
+- question: To what extent do the reported nuclear and cadherin-proximal localizations
+    of LDHA reflect moonlighting functions versus abundance-driven proteomics artifacts?
+suggested_experiments:
+- description: Quantitative subcellular fractionation with activity assays to test
+    whether a catalytically active mitochondrial LDHA pool exists in human cells.
+- description: Structure-guided mutagenesis of the FLCN- and MP31-interaction
+    interfaces to define how these regulators modulate LDHA activity and oligomeric
+    state in vivo.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:11276087
+  title: Structural basis for altered activity of M- and H-isozyme forms of human
+    lactate dehydrogenase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; crystal structures of human M (LDHA) and H (LDHB)
+      isoforms as NADH/oxamate ternary complexes; establishes catalytic activity and
+      homotetramerization. Abstract-only in cache but directly on-target.
+- id: PMID:11487543
+  title: Intestinal epithelial cells secrete exosome-like vesicles.
+  findings: []
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings: []
+- id: PMID:1953713
+  title: Analysis of genetic mutations in human lactate dehydrogenase-A(M) deficiency
+    using DNA conformation polymorphism in combination with polyacrylamide gradient
+    gel and silver staining.
+  findings: []
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+- id: PMID:20458337
+  title: MHC class II-associated proteins in B-cell exosomes and potential functional
+    implications for exosome biogenesis.
+  findings: []
+- id: PMID:21630459
+  title: Proteomic characterization of the human sperm nucleus.
+  findings: []
+- id: PMID:21988832
+  title: Toward an understanding of the protein interaction network of the human liver.
+  findings: []
+- id: PMID:2334430
+  title: Molecular characterization of genetic mutation in human lactate dehydrogenase-A
+    (M) deficiency.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; characterizes a frameshift mutation causing human
+      LDH-A(M) deficiency (GSD11). Directly relevant to LDHA function and disease.
+- id: PMID:23523103
+  title: Lysine-5 acetylation negatively regulates lactate dehydrogenase A and is
+    decreased in pancreatic cancer.
+  findings: []
+- id: PMID:23533145
+  title: In-depth proteomic analyses of exosomes isolated from expressed prostatic
+    secretions in urine.
+  findings: []
+- id: PMID:2434947
+  title: Centrosomal proteins and lactate dehydrogenase possess a common epitope in
+    human cell lines.
+  findings: []
+- id: PMID:24816116
+  title: Structural characterization of the apo form and NADH binary complex of human
+    lactate dehydrogenase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; apo and NADH-bound crystal structures of human
+      LDH-A; describes A vs B subunit kinetics and the five A/B tetramer isoenzymes.
+- id: PMID:25468996
+  title: E-cadherin interactome complexity and robustness resolved by quantitative
+    proteomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: BioID proximity-proteomics study; LDHA is a proximity hit near the
+      E-cadherin tail, not a demonstrated functional cadherin interactor.
+- id: PMID:25502805
+  title: A massively parallel pipeline to clone DNA variants and examine molecular
+    phenotypes of human disease mutations.
+  findings: []
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+- id: PMID:31515488
+  title: Extensive disruption of protein interactions by genetic variants across the
+    allele frequency spectrum in human populations.
+  findings: []
+- id: PMID:33406399
+  title: An Upstream Open Reading Frame in Phosphatase and Tensin Homolog Encodes
+    a Circuit Breaker of Lactate Metabolism.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: PubMed-verified; identifies MP31 micropeptide that competes with
+      LDH for NAD+; supports the LDHA-MP31 IPI. Regulatory context, not core enzyme
+      function.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+- id: PMID:34381247
+  title: The tumor suppressor folliculin inhibits lactate dehydrogenase A and regulates
+    the Warburg effect.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; FLCN is a direct uncompetitive inhibitor of LDHA;
+      functional activity assays and dimer/tetramer state analysis support the MF
+      (IMP) and interaction (IPI) annotations.
+- id: PMID:35271311
+  title: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization.&#39;
+  findings: []
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+- id: Reactome:R-HSA-70510
+  title: LDH tetramer oxidises LACT to PYR
+  findings: []
+- id: Reactome:R-HSA-71849
+  title: LDH tetramer reduces PYR to LACT
+  findings: []
+- id: Reactome:R-HSA-9861563
+  title: CTLH E3 ligase ubiquitinates LDHA
+  findings: []
+- id: file:human/LDHA/LDHA-uniprot.txt
+  title: UniProtKB entry P00338 (LDHA_HUMAN)
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/LDHB/LDHB-ai-review.html
+++ b/genes/human/LDHB/LDHB-ai-review.html
@@ -1,0 +1,6491 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LDHB - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>LDHB</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P07195" target="_blank" class="term-link">
+                        P07195
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "LDHB";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P07195" data-a="DESCRIPTION: LDHB encodes the B (also called H, &#34;heart&#34;) subuni..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>LDHB encodes the B (also called H, &#34;heart&#34;) subunit of L-lactate dehydrogenase (LDH; EC 1.1.1.27), a cytosolic NAD-dependent oxidoreductase. It catalyses the reversible, stereospecific interconversion of pyruvate + NADH + H+ and L-lactate + NAD+. Catalytically active LDH is a tetramer assembled in variable ratios from LDHA (M) and LDHB (H) subunits, producing the five classic isoenzymes (M4 through H4). LDHB-rich isoenzymes (H4) are kinetically tuned to favour the oxidation of L-lactate back to pyruvate and predominate in oxidative tissues such as heart and kidney that consume lactate as a metabolic fuel, whereas LDHA-rich isoenzymes favour the reduction of pyruvate to lactate during fermentative glycolysis. LDHB also participates in cytosolic NAD+/NADH redox balance. Loss-of-function LDHB variants cause lactate dehydrogenase B (H-subunit) deficiency, a generally benign condition of interest chiefly to laboratory medicine.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019244" target="_blank" class="term-link">
+                                    GO:0019244
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate fermentation to lactate</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0019244" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to the pyruvate-to-lactate fermentation process for the LDH family node. LDHB is a bona fide L-lactate dehydrogenase and catalyses this reversible reaction, so the annotation is biologically correct at the family level, but its named direction (pyruvate -&gt; lactate, fermentation) is the direction favoured by the LDHA (M) subunit; the LDHB-rich H4 isoenzyme is kinetically tuned to the reverse (lactate -&gt; pyruvate) direction in oxidative tissues.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The reaction is correctly assigned to the family, but for LDHB specifically the fermentation (lactate-producing) direction is not the physiologically dominant role; the lactate-oxidising direction is more characteristic. Keep as non-core; the core metabolic role is better captured by lactate/pyruvate metabolic process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27618187" target="_blank" class="term-link">
+                                        PMID:27618187
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">it has been suggested that LDHA preferentially reduces pyruvate to lactate, while LDHB supports conversion of lactate to pyruvate in cells that utilize lactate as a nutrient source for oxidative metabolism or gluconeogenesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0004459" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of the core catalytic molecular function, L-lactate dehydrogenase (NAD+) activity (EC 1.1.1.27). This is the defining activity of LDHB and is corroborated by direct enzymatic, structural, and orthology evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core molecular function of LDHB, strongly supported across experimental (PMID:11276087, PMID:27618187), phylogenetic, and electronic evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Reaction=(S)-lactate + NAD(+) = pyruvate + NADH + H(+);</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                                        PMID:11276087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Lactate dehydrogenase (LDH) interconverts pyruvate and lactate with concomitant</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation placing LDHB activity in the mitochondrion. A minority of experimental work (PMID:27618187) reports LDHB association with the inner mitochondrial membrane and mitochondrial LDH activity, but the canonical, dominant localization of LDH is cytosolic.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> There is experimental support for a mitochondrial pool of LDHB, but this is a non-canonical, still-debated localization for a classically cytosolic glycolytic enzyme. Retain as non-core rather than a core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27618187" target="_blank" class="term-link">
+                                        PMID:27618187
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">gold-labeled LDHB localizes to the inner mitochondrial membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003824" target="_blank" class="term-link">
+                                    GO:0003824
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0003824" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic mapping to the root catalytic activity term. Correct but far too general given the well-defined L-lactate dehydrogenase (NAD+) activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative parent of the specific enzymatic function; the precise MF term GO:0004459 is annotated with strong experimental evidence and should be preferred.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0004459" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (multi-method IEA) assignment of the core L-lactate dehydrogenase (NAD+) activity, consistent with the EC 1.1.1.27 / RHEA:23444 mapping and with experimental evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function, redundant with but consistent with the experimental and phylogenetic annotations of the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Reaction=(S)-lactate + NAD(+) = pyruvate + NADH + H(+);</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment of the cytoplasm, consistent with UniProt subcellular location and with LDH being a soluble cytosolic glycolytic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct, though the more specific cytosol (GO:0005829) is the preferred core location. Cytoplasm is a valid broader statement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm. Mitochondrion inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation derived from the UniProt Subcellular Location keyword mapping (Mitochondrion inner membrane), which in turn rests on the experimental report PMID:27618187. This is a non-canonical localization for LDHB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported experimentally (PMID:27618187) via the UniProt subcellular location, but a minority/debated localization; the core location is cytosolic. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm. Mitochondrion inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016491" target="_blank" class="term-link">
+                                    GO:0016491
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0016491" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic mapping to the general oxidoreductase activity term. Correct but too general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Parent of the specific L-lactate dehydrogenase (NAD+) activity; uninformative given the well-supported specific MF term.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016616" target="_blank" class="term-link">
+                                    GO:0016616
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP as acceptor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0016616" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic mapping to an intermediate oxidoreductase term describing the CH-OH-group / NAD(P)-acceptor chemistry. Accurate for LDH chemistry but less specific than L-lactate dehydrogenase (NAD+) activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct grandparent-level chemistry but redundant with the specific MF term GO:0004459, which should be preferred.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21044950" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21044950
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genome-wide YFP fluorescence complementation screen identifi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:21044950" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct two-hybrid/interaction datum with TERF1 (P54274). Bare protein binding conveys no specific function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding annotation from a high-throughput interaction screen; not a core function and no specific molecular function can be inferred. Retained per policy rather than removed.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21988832
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Toward an understanding of the protein interaction network o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:21988832" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction datum with LDHA (P00338), consistent with formation of mixed M/H LDH tetramers, but captured only as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The underlying LDHA interaction is biologically real (heterotetramer assembly), but the bare protein binding term is uninformative; the tetramer relationship is better captured by identical protein binding / oxidoreductase complex.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24725412" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24725412
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ribosomal protein s15 phosphorylation mediates LRRK2 neurode...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:24725412" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction datum with LRRK2 (Q5S007) from a Parkinson-disease study. Bare protein binding, no specific function implied for LDHB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding annotation; not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction datum with LDHA isoform (P00338-3) from a proteome-scale interactome map. Bare protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding annotation from a high-throughput interactome study; not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25910212
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Widespread macromolecular interaction perturbations in human...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:25910212" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction datum with LDHA isoform (P00338-3) from a study of interaction perturbations in genetic disorders. Bare protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding annotation; not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction data (LDHA P00338, LDHC P07864) from an interactome community study. Consistent with LDH-family tetramer assembly but recorded as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding term; the biologically relevant LDH-family subunit interactions are better captured elsewhere.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31515488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive disruption of protein interactions by genetic vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:31515488" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction datum with LDHA (P00338) from a study of variant-driven interaction disruption. Bare protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding annotation; not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction data (SDCBP O00560, LDHA isoform P00338-3) from a reference binary interactome map. Bare protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding annotation from a high-throughput screen; not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32814053
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactome Mapping Provides a Network of Neurodegenerative ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction datum with HTT (P42858) from a neurodegenerative-disease interactome study. Bare protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding annotation; not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction data (LDHA P00338, LDHC P07864) from a cell-specific interactome remodeling study. LDH-family subunit interactions recorded as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding term; the relevant subunit interactions are better represented by the tetramer/complex annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35271311
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    OpenCell: Endogenous tagging for the cartography of human ce...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:35271311" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction data (LDHA P00338, LDHC P07864) from the OpenCell endogenous-tagging interactome. Bare protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding annotation; not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct interaction datum with LDHC (P07864) from a multimodal cell-map study. Bare protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding annotation; not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0042802" data-r="PMID:25416956" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct self-interaction (P07195 with P07195), reflecting the homotetrameric assembly of the LDHB (H4) isoenzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biologically meaningful (LDHB homotetramerization) and more informative than bare protein binding, but the self-association is a structural feature supporting the complex rather than the core catalytic function. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Homotetramer (PubMed:11276087)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25502805" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25502805
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A massively parallel pipeline to clone DNA variants and exam...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0042802" data-r="PMID:25502805" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct self-interaction (P07195 with P07195) from a variant-cloning / molecular-phenotype pipeline, again reflecting LDHB homotetramerization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with homotetramer assembly; informative structural annotation but not the core catalytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Homotetramer (PubMed:11276087)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31515488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive disruption of protein interactions by genetic vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0042802" data-r="PMID:31515488" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct self-interaction (P07195 with P07195), reflecting LDHB homotetramerization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with homotetramer assembly; informative structural annotation but not the core catalytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Homotetramer (PubMed:11276087)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0042802" data-r="PMID:32296183" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct self-interaction (P07195 with P07195) from the reference binary interactome, reflecting LDHB homotetramerization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with homotetramer assembly; informative structural annotation but not the core catalytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Homotetramer (PubMed:11276087)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004457" target="_blank" class="term-link">
+                                    GO:0004457
+                                </a>
+                            </span>
+                            <span class="term-label">lactate dehydrogenase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0004457" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl orthology (IEA) assignment of lactate dehydrogenase activity, the immediate parent of the NAD+-specific L-lactate dehydrogenase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and consistent with the core function; a slightly broader phrasing of the same catalytic activity. Acceptable as-is.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                                        PMID:11276087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Lactate dehydrogenase (LDH) interconverts pyruvate and lactate with concomitant</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005829" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl orthology (IEA) placement of LDHB activity in the cytosol, the canonical location of this glycolytic enzyme, concordant with the HPA IDA and Reactome TAS annotations to cytosol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core subcellular location; strongly corroborated by IDA (HPA) and TAS (Reactome) evidence.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006089" target="_blank" class="term-link">
+                                    GO:0006089
+                                </a>
+                            </span>
+                            <span class="term-label">lactate metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0006089" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl orthology (IEA) assignment to lactate metabolic process, capturing LDHB&#39;s role in the interconversion of lactate and pyruvate. Also independently supported by ComplexPortal IDA (PMID:15117937).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurately reflects the core biological process in which LDHB participates (lactate/pyruvate interconversion), and is the process best matching the LDHB-favoured lactate-oxidising direction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27618187" target="_blank" class="term-link">
+                                        PMID:27618187
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LDHB supports conversion of lactate to pyruvate in cells that utilize lactate as a nutrient source for oxidative metabolism or gluconeogenesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019674" target="_blank" class="term-link">
+                                    GO:0019674
+                                </a>
+                            </span>
+                            <span class="term-label">NAD+ metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0019674" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl orthology (IEA) assignment to NAD+ metabolic process, reflecting that LDHB regenerates/consumes NAD+/NADH during the lactate-pyruvate reaction and thereby contributes to cytosolic redox balance.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biologically correct (the reaction interconverts NAD+ and NADH), but NAD+ metabolism is a downstream consequence of the catalytic activity rather than the core annotated function. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15117937" target="_blank" class="term-link">
+                                        PMID:15117937
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">central to NAD(+) regeneration</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019900" target="_blank" class="term-link">
+                                    GO:0019900
+                                </a>
+                            </span>
+                            <span class="term-label">kinase binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0019900" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl orthology (IEA) transfer of a kinase-binding annotation from a rat ortholog. There is no specific experimental evidence that human LDHB binds a kinase as a defined molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Orthology-transferred generic binding annotation with no clear functional relevance to LDHB&#39;s role; likely an over-annotation and not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0042802" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl orthology (IEA) transfer of identical protein binding, consistent with the homotetrameric assembly of LDHB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects LDHB homotetramerization; informative structural feature but not the core catalytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Homotetramer (PubMed:11276087)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051287" target="_blank" class="term-link">
+                                    GO:0051287
+                                </a>
+                            </span>
+                            <span class="term-label">NAD binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0051287" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl orthology (IEA) assignment of NAD binding. LDHB is an NAD-dependent dehydrogenase with a Rossmann-fold NAD-binding domain and defined NAD(+)-binding residues, so this is a correct and informative molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct; NAD binding is a genuine, structurally documented molecular function of LDHB (NAD-binding Rossmann domain; NAD(+) binding site residues in UniProt).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Reaction=(S)-lactate + NAD(+) = pyruvate + NADH + H(+);</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct immunofluorescence (HPA) localization of LDHB to the cytosol, the canonical location of this glycolytic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core subcellular location, concordant with electronic and TAS cytosol annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11276087
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for altered activity of M- and H-isozyme fo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0004459" data-r="PMID:11276087" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (structural/biophysical) demonstration of L-lactate dehydrogenase (NAD+) activity for human LDH-H, via crystallographic ternary complexes with NADH and substrate analog and kinetic characterization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the defining, experimentally established core molecular function of LDHB, characterized structurally and kinetically for the H isoform.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                                        PMID:11276087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Lactate dehydrogenase (LDH) interconverts pyruvate and lactate with concomitant</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                                        PMID:11276087
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the H form, found mainly in cardiac muscle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006089" target="_blank" class="term-link">
+                                    GO:0006089
+                                </a>
+                            </span>
+                            <span class="term-label">lactate metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15117937" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15117937
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and activity of a series of azole-based compo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0006089" data-r="PMID:15117937" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IDA annotation of the LDH complex to lactate metabolic process. LDH is central to lactate/pyruvate interconversion and NAD+ regeneration.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly captures the core biological process; LDHB participates in lactate metabolism as the H subunit of the LDH complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15117937" target="_blank" class="term-link">
+                                        PMID:15117937
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">central to NAD(+) regeneration</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990204" target="_blank" class="term-link">
+                                    GO:1990204
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15117937" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15117937
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and activity of a series of azole-based compo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:1990204" data-r="PMID:15117937" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal assertion that LDHB is part of the L-lactate dehydrogenase (oxidoreductase) complex, i.e. the LDH tetramer. UniProt/ComplexPortal record the A/B (M/H) tetramer variants (CPX-6592/6594/6598/6599).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct; catalytically active LDH is a tetramer, and LDHB is a constituent subunit. This appropriately captures the complex-level context of the enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27618187" target="_blank" class="term-link">
+                                        PMID:27618187
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Functional LDH is a homo or hetero tetramer composed of LDHA and LDHB subunits</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Homotetramer (PubMed:11276087)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27618187" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27618187
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Lactate metabolism is associated with mammalian mitochondria...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0004459" data-r="PMID:27618187" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay of LDHB (L-lactate dehydrogenase) activity in whole-cell and isolated mitochondrial lysates, confirming the core catalytic function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core molecular function of LDHB.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27618187" target="_blank" class="term-link">
+                                        PMID:27618187
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the mitochondria had higher LDHB activity, further suggesting that LDHB activity is concentrated in mitochondria</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33406399" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33406399
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An Upstream Open Reading Frame in Phosphatase and Tensin Hom...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005515" data-r="PMID:33406399" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt-curated IPI interaction with the PTEN-uORF micropeptide MP31 (C0HLV8). MP31 binds LDHB and inhibits mitochondrial LDH activity by competing for NAD+, acting as a regulatory circuit breaker of lactate-pyruvate conversion; the interaction is abolished by LDHB mutations D53A and R100A.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the most biologically meaningful of the protein-binding annotations (a specific, functionally characterized regulatory interaction), but the term itself is the uninformative generic protein binding. Retained (not removed) per policy; a more specific enzyme-inhibitor / MP31-binding characterization would be preferable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33406399" target="_blank" class="term-link">
+                                        PMID:33406399
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">limits lactate-pyruvate conversion in mitochondria by</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33406399" target="_blank" class="term-link">
+                                        PMID:33406399
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">competing with mitochondrial lactate dehydrogenase (mLDH) for</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27618187" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27618187
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Lactate metabolism is associated with mammalian mitochondria...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005743" data-r="PMID:27618187" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TEM immunogold localization of LDHB to the inner mitochondrial membrane in HeLa cells, with concordant mitochondrial LDH activity in isolated mitochondria. A specific but non-canonical localization for this classically cytosolic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported (PMID:27618187), but a minority/debated localization; the dominant location of LDHB is cytosolic. Retain as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27618187" target="_blank" class="term-link">
+                                        PMID:27618187
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">gold-labeled LDHB localizes to the inner mitochondrial membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045121" target="_blank" class="term-link">
+                                    GO:0045121
+                                </a>
+                            </span>
+                            <span class="term-label">membrane raft</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25204797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25204797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Flotillin-1 facilitates toll-like receptor 3 signaling in hu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0045121" data-r="PMID:25204797" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Localization to membrane raft reported in a flotillin-1/TLR3 endothelial signaling study that used SILAC proteomics of raft/caveolae fractions. LDHB is a soluble cytosolic enzyme and its recovery in raft proteomic fractions most likely reflects abundant-protein co-purification rather than a functional raft localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A soluble glycolytic enzyme is not expected to be a genuine membrane raft resident; this is likely a proteomic co-isolation artifact and an over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25204797" target="_blank" class="term-link">
+                                        PMID:25204797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Flotillin-1 and -2 are markers of membrane rafts</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23533145
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In-depth proteomic analyses of exosomes isolated from expres...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0070062" data-r="PMID:23533145" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of LDHB in urinary/prostatic-secretion exosome preparations. Abundant cytosolic enzymes are commonly detected in exosome proteomes without evidence of a functional role there.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytosolic-enzyme detection in exosome proteomics; not a functional localization and not a core annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of LDHB in an NK-cell membrane proteome preparation. Non-specific membrane assignment for a soluble enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic membrane assignment for a cytosolic protein from a proteomic membrane-fraction study; likely co-isolation and an over-annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19056867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Large-scale proteomics and phosphoproteomics of urinary exos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0070062" data-r="PMID:19056867" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of LDHB in urinary exosomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytosolic-enzyme detection in exosome proteomics; not a functional localization and not a core annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20458337
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MHC class II-associated proteins in B-cell exosomes and pote...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0070062" data-r="PMID:20458337" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of LDHB in B-cell exosomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytosolic-enzyme detection in exosome proteomics; not a functional localization and not a core annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70510
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005829" data-r="Reactome:R-HSA-70510" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement placing LDHB in the cytosol in the context of LDH tetramer oxidises LACT to PYR, the lactate-oxidising direction favoured by the LDHB-rich isoenzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core cytosolic location, consistent with IDA and IEA cytosol annotations and with the canonical glycolytic-enzyme localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71849
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005829" data-r="Reactome:R-HSA-71849" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement placing LDHB in the cytosol in the context of LDH tetramer reduces PYR to LACT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core cytosolic location, redundant with but consistent with the other cytosol annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16130169
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteomics of human umbilical vein endothelial cells applied...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0005737" data-r="PMID:16130169" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement (UniProt) cytoplasm localization derived from a HUVEC proteomics study. Consistent with the soluble cytoplasmic nature of LDHB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct broader localization; the more specific cytosol is preferred as the core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LDHB/LDHB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm. Mitochondrion inner membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                                    GO:0004459
+                                </a>
+                            </span>
+                            <span class="term-label">L-lactate dehydrogenase (NAD+) activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8314553" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8314553
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of a genetic mutation in an electrophoretic variant...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P07195" data-a="GO:0004459" data-r="PMID:8314553" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement of L-lactate dehydrogenase (NAD+) activity, from a study characterizing an electrophoretic LDH-B(H) subunit variant (K7E) with decreased heat stability and slightly reduced activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function; the paper explicitly concerns the human LDH-B (H) subunit and its enzymatic activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8314553" target="_blank" class="term-link">
+                                        PMID:8314553
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">An electrophoretic variant of the lactate dehydrogenase (LDH)-B(H) subunit was</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cytosolic NAD-dependent L-lactate dehydrogenase (H/B subunit) catalysing the reversible interconversion of pyruvate + NADH and L-lactate + NAD+; in LDHB-rich (H4) isoenzymes this favours oxidation of lactate to pyruvate in oxidative tissues.</h3>
+                <span class="vote-buttons" data-g="P07195" data-a="FUNCTION: Cytosolic NAD-dependent L-lactate dehydrogenase (H..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                            L-lactate dehydrogenase (NAD+) activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006089" target="_blank" class="term-link">
+                                lactate metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                                PMID:11276087
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Lactate dehydrogenase (LDH) interconverts pyruvate and lactate with concomitant</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/LDHB/LDHB-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Reaction=(S)-lactate + NAD(+) = pyruvate + NADH + H(+);</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As a subunit of the tetrameric L-lactate dehydrogenase complex, LDHB assembles into homotetramers (H4) and heterotetramers with LDHA (M), forming the catalytically active oxidoreductase complex.</h3>
+                <span class="vote-buttons" data-g="P07195" data-a="FUNCTION: As a subunit of the tetrameric L-lactate dehydroge..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004459" target="_blank" class="term-link">
+                            L-lactate dehydrogenase (NAD+) activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006089" target="_blank" class="term-link">
+                                lactate metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990204" target="_blank" class="term-link">
+                            oxidoreductase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27618187" target="_blank" class="term-link">
+                                PMID:27618187
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Functional LDH is a homo or hetero tetramer composed of LDHA and LDHB subunits</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/LDHB/LDHB-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Homotetramer (PubMed:11276087)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/LDHB/LDHB-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry P07195 (LDHB_HUMAN)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11276087" target="_blank" class="term-link">
+                            PMID:11276087
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for altered activity of M- and H-isozyme forms of human lactate dehydrogenase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human LDH-H and LDH-M interconvert pyruvate and lactate with concomitant NADH/NAD+ interconversion; the H form is found mainly in cardiac muscle and is structurally indistinguishable at the active site from the M form.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15117937" target="_blank" class="term-link">
+                            PMID:15117937
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification and activity of a series of azole-based compounds with lactate dehydrogenase-directed anti-malarial activity.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">LDH is central to NAD+ regeneration during glycolysis coupled with homolactic fermentation.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link">
+                            PMID:16130169
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteomics of human umbilical vein endothelial cells applied to etoposide-induced apoptosis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                            PMID:19056867
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link">
+                            PMID:20458337
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MHC class II-associated proteins in B-cell exosomes and potential functional implications for exosome biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21044950" target="_blank" class="term-link">
+                            PMID:21044950
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genome-wide YFP fluorescence complementation screen identifies new regulators for telomere signaling in human cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link">
+                            PMID:21988832
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Toward an understanding of the protein interaction network of the human liver.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                            PMID:23533145
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24725412" target="_blank" class="term-link">
+                            PMID:24725412
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Ribosomal protein s15 phosphorylation mediates LRRK2 neurodegeneration in Parkinson&#39;s disease.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25204797" target="_blank" class="term-link">
+                            PMID:25204797
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Flotillin-1 facilitates toll-like receptor 3 signaling in human endothelial cells.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Flotillins are membrane raft markers; LDHB was recovered in the raft/caveolae proteomic analysis of this study.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25502805" target="_blank" class="term-link">
+                            PMID:25502805
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A massively parallel pipeline to clone DNA variants and examine molecular phenotypes of human disease mutations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
+                            PMID:25910212
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27618187" target="_blank" class="term-link">
+                            PMID:27618187
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Lactate metabolism is associated with mammalian mitochondria.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Functional LDH is a tetramer of LDHA and LDHB subunits; LDHB is the predominant heart (H) subunit and supports conversion of lactate to pyruvate in lactate-consuming oxidative cells. LDHB was localized by TEM immunogold to the inner mitochondrial membrane and mitochondrial lysates showed LDHB activity.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                            PMID:31515488
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                            PMID:32814053
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33406399" target="_blank" class="term-link">
+                            PMID:33406399
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An Upstream Open Reading Frame in Phosphatase and Tensin Homolog Encodes a Circuit Breaker of Lactate Metabolism.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MP31, a micropeptide from the PTEN uORF, binds LDHB and limits lactate-pyruvate conversion in mitochondria by competing with mitochondrial LDH for NAD+.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
+                            PMID:35271311
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8314553" target="_blank" class="term-link">
+                            PMID:8314553
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of a genetic mutation in an electrophoretic variant of the human lactate dehydrogenase-B(H) subunit.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">An electrophoretic LDH-B(H) subunit variant (K7E) with decreased heat stability and slightly lower LDH activity was characterized, confirming LDHB as the H subunit of human LDH.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70510
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LDH tetramer oxidises LACT to PYR</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71849
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LDH tetramer reduces PYR to LACT</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the mitochondrial (inner-membrane) pool of LDHB a genuine, functionally significant localization in vivo, or is it largely restricted to specific cell types (e.g. fermenting cancer cells) and experimental conditions?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P07195" data-a="Q: Is the mitochondrial (inner-membrane) pool of LDHB..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> To what extent does the MP31 (PTEN-uORF) circuit-breaker regulation of LDHB operate in normal physiology versus tumour metabolism?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P07195" data-a="Q: To what extent does the MP31 (PTEN-uORF) circuit-b..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compartment-resolved activity assays (cytosol vs mitochondrial sub-fractions) across oxidative and glycolytic human tissues to quantify the physiological contribution of any mitochondrial LDHB pool.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P07195" data-a="EXPERIMENT: Compartment-resolved activity assays (cytosol vs m..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-guided kinetic comparison of purified LDHB homotetramer versus defined M/H heterotetramers to quantify the directional (lactate to pyruvate) preference under physiological substrate/redox conditions.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P07195" data-a="EXPERIMENT: Structure-guided kinetic comparison of purified LD..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(LDHB-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P07195" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="ldhb-l-lactate-dehydrogenase-b-chain-p07195-review-notes">LDHB (L-lactate dehydrogenase B chain, P07195) — review notes</h1>
+<h2 id="core-biology">Core biology</h2>
+<p>LDHB encodes the B / H ("heart") subunit of L-lactate dehydrogenase (LDH; EC 1.1.1.27).<br />
+Active LDH is a tetramer assembled from LDHA (M) and LDHB (H) subunits, giving rise to<br />
+the classic five isoenzymes (M4, M3H1, M2H2, M1H3, H4). LDHB-rich isoenzymes (H4)<br />
+kinetically favour oxidation of L-lactate back to pyruvate, suiting oxidative tissues<br />
+(heart, kidney) that consume lactate as fuel.</p>
+<ul>
+<li>Catalytic reaction (UniProt CATALYTIC ACTIVITY, RHEA:23444, EC 1.1.1.27):<br />
+<code>(S)-lactate + NAD(+) = pyruvate + NADH + H(+)</code>. Reversible; UniProt notes both<br />
+  left-to-right (RHEA:23445) and right-to-left (RHEA:23446) physiological directions.</li>
+<li>UniProt FUNCTION [ECO:0000269|PubMed:27618187]: "Interconverts simultaneously and<br />
+  stereospecifically pyruvate and lactate with concomitant interconversion of NADH and<br />
+  NAD(+)."</li>
+<li>SUBUNIT: Homotetramer (PubMed:11276087). Interacts with the PTEN-uORF micropeptide<br />
+  MP31, which inhibits mitochondrial LDH activity (PubMed:33406399).</li>
+<li>Tissue specificity: "Predominantly expressed in aerobic tissues such as cardiac<br />
+  muscle" [ECO:0000305|PubMed:11276087]. HPA: tissue-enhanced heart muscle, kidney.</li>
+</ul>
+<h2 id="kinetic-structural-basis-pmid11276087">Kinetic / structural basis (PMID:11276087)</h2>
+<p>Read et al. crystallised human LDH-M and LDH-H ternary complexes with NADH + oxamate.<br />
+"Lactate dehydrogenase (LDH) interconverts pyruvate and lactate with concomitant<br />
+interconversion of NADH and NAD(+)." The two isoforms are structurally<br />
+indistinguishable at the active site; kinetic differences arise from peripheral charged<br />
+surface residues. Confirms homotetramer, NAD+ binding, and MF = L-lactate dehydrogenase<br />
+(NAD+) activity. [full_text_available: false — abstract only]</p>
+<h2 id="mitochondrial-association-pmid27618187-chen-et-al-nat-chem-biol-2016">Mitochondrial association (PMID:27618187, Chen et al. Nat Chem Biol 2016)</h2>
+<p>Full text available. Key verbatim findings:<br />
+- "Functional LDH is a homo or hetero tetramer composed of LDHA and LDHB subunits"<br />
+- "LDHB is the predominant isoform found in heart muscle and is often referred to as the<br />
+  H subunit"<br />
+- "it has been suggested that LDHA preferentially reduces pyruvate to lactate, while<br />
+  LDHB supports conversion of lactate to pyruvate in cells that utilize lactate as a<br />
+  nutrient source for oxidative metabolism or gluconeogenesis"<br />
+- TEM immunogold: "gold-labeled LDHB localizes to the inner mitochondrial membrane"<br />
+- LDHB activity detected in whole-cell and isolated mitochondrial lysates.<br />
+This is the experimental basis for the IDA GO:0004459 and IDA GO:0005743 (mito inner<br />
+membrane) annotations. Note this is a specific, somewhat contested localization; the<br />
+dominant/canonical localization remains cytosolic (glycolytic enzyme).</p>
+<h2 id="mp31-interaction-pmid33406399">MP31 interaction (PMID:33406399)</h2>
+<p>MP31 is a micropeptide from the PTEN uORF that "limits lactate-pyruvate conversion in<br />
+mitochondria by competing with mitochondrial lactate dehydrogenase (mLDH) for<br />
+nicotinamide adenine dinucleotide (NAD+)." UniProt: interaction abolished by LDHB<br />
+mutants D53A and R100A. Supports a real, functionally meaningful protein-protein<br />
+interaction (regulatory), curated by UniProt as GO:0005515 IPI with C0HLV8 (MP31).</p>
+<h2 id="disease">Disease</h2>
+<p>LDHB deficiency (LDHBD, MIM:614128): "A condition with no deleterious effects on<br />
+health." Clinically mild/asymptomatic; laboratory-medicine interest (LDH isoenzyme<br />
+misdiagnosis). Many missense variants documented in UniProt (K7E, R107W inactive, etc.).</p>
+<h2 id="annotation-assessment-summary">Annotation assessment summary</h2>
+<ul>
+<li>MF core: GO:0004459 L-lactate dehydrogenase (NAD+) activity — strongly supported<br />
+  (EXP PMID:11276087, IDA PMID:27618187, IBA, IEA, TAS). ACCEPT.</li>
+<li>GO:0004457 lactate dehydrogenase activity — parent term, ACCEPT (broader is fine).</li>
+<li>BP: GO:0006089 lactate metabolic process, GO:0042867 pyruvate catabolic /<br />
+  GO:0019244 pyruvate fermentation to lactate, GO:0019674 NAD+ metabolic process —<br />
+  all consistent. IBA pyruvate fermentation to lactate reflects the PANTHER family node;<br />
+  for LDHB (H4) the physiologically favoured direction is lactate-&gt;pyruvate, so<br />
+  "fermentation to lactate" is somewhat directionally biased toward LDHA, but the<br />
+  reaction is the same and reversible — keep, mark non-core where over-specific.</li>
+<li>CC: cytosol GO:0005829 (IDA HPA, IEA, TAS Reactome) — core canonical location.<br />
+  cytoplasm GO:0005737 — ACCEPT (broader). mitochondrion / mito inner membrane<br />
+  (IBA + IDA PMID:27618187) — real but non-canonical; keep as non-core. exosome /<br />
+  membrane / membrane raft — mass-spec / proteomics HDA/IDA; over-annotations for a<br />
+  soluble glycolytic enzyme, mark over-annotated.</li>
+<li>protein binding (GO:0005515) IPIs — bare, uninformative; MARK_AS_OVER_ANNOTATED<br />
+  (do NOT REMOVE per policy). The MP31 one (PMID:33406399) is the most biologically<br />
+  meaningful.</li>
+<li>identical protein binding GO:0042802 — reflects homotetramerization; keep as<br />
+  non-core (informative-ish, supports tetramer).</li>
+<li>kinase binding / NAD binding (Ensembl IEA GO_REF:0000107) — NAD binding is correct<br />
+  (NAD-dependent enzyme); kinase binding is an orthology-transferred over-annotation,<br />
+  mark over-annotated.<br />
+</content></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P07195
+gene_symbol: LDHB
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: LDHB encodes the B (also called H, &#34;heart&#34;) subunit of L-lactate dehydrogenase
+  (LDH; EC 1.1.1.27), a cytosolic NAD-dependent oxidoreductase. It catalyses the reversible,
+  stereospecific interconversion of pyruvate + NADH + H+ and L-lactate + NAD+. Catalytically
+  active LDH is a tetramer assembled in variable ratios from LDHA (M) and LDHB (H) subunits,
+  producing the five classic isoenzymes (M4 through H4). LDHB-rich isoenzymes (H4) are
+  kinetically tuned to favour the oxidation of L-lactate back to pyruvate and predominate
+  in oxidative tissues such as heart and kidney that consume lactate as a metabolic fuel,
+  whereas LDHA-rich isoenzymes favour the reduction of pyruvate to lactate during
+  fermentative glycolysis. LDHB also participates in cytosolic NAD+/NADH redox balance.
+  Loss-of-function LDHB variants cause lactate dehydrogenase B (H-subunit) deficiency, a
+  generally benign condition of interest chiefly to laboratory medicine.
+existing_annotations:
+- term:
+    id: GO:0019244
+    label: pyruvate fermentation to lactate
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic (IBA) annotation to the pyruvate-to-lactate fermentation process
+      for the LDH family node. LDHB is a bona fide L-lactate dehydrogenase and catalyses
+      this reversible reaction, so the annotation is biologically correct at the family
+      level, but its named direction (pyruvate -&gt; lactate, fermentation) is the direction
+      favoured by the LDHA (M) subunit; the LDHB-rich H4 isoenzyme is kinetically tuned to
+      the reverse (lactate -&gt; pyruvate) direction in oxidative tissues.
+    action: KEEP_AS_NON_CORE
+    reason: The reaction is correctly assigned to the family, but for LDHB specifically the
+      fermentation (lactate-producing) direction is not the physiologically dominant role;
+      the lactate-oxidising direction is more characteristic. Keep as non-core; the core
+      metabolic role is better captured by lactate/pyruvate metabolic process.
+    supported_by:
+    - reference_id: PMID:27618187
+      supporting_text: it has been suggested that LDHA preferentially reduces pyruvate to
+        lactate, while LDHB supports conversion of lactate to pyruvate in cells that utilize
+        lactate as a nutrient source for oxidative metabolism or gluconeogenesis
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) assignment of the core catalytic molecular function,
+      L-lactate dehydrogenase (NAD+) activity (EC 1.1.1.27). This is the defining activity
+      of LDHB and is corroborated by direct enzymatic, structural, and orthology evidence.
+    action: ACCEPT
+    reason: This is the core molecular function of LDHB, strongly supported across
+      experimental (PMID:11276087, PMID:27618187), phylogenetic, and electronic evidence.
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: Reaction=(S)-lactate + NAD(+) = pyruvate + NADH + H(+);
+    - reference_id: PMID:11276087
+      supporting_text: Lactate dehydrogenase (LDH) interconverts pyruvate and lactate with
+        concomitant
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) annotation placing LDHB activity in the mitochondrion. A
+      minority of experimental work (PMID:27618187) reports LDHB association with the inner
+      mitochondrial membrane and mitochondrial LDH activity, but the canonical, dominant
+      localization of LDH is cytosolic.
+    action: KEEP_AS_NON_CORE
+    reason: There is experimental support for a mitochondrial pool of LDHB, but this is a
+      non-canonical, still-debated localization for a classically cytosolic glycolytic
+      enzyme. Retain as non-core rather than a core location.
+    supported_by:
+    - reference_id: PMID:27618187
+      supporting_text: gold-labeled LDHB localizes to the inner mitochondrial membrane
+- term:
+    id: GO:0003824
+    label: catalytic activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic mapping to the root catalytic activity term. Correct
+      but far too general given the well-defined L-lactate dehydrogenase (NAD+) activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative parent of the specific enzymatic function; the precise MF term
+      GO:0004459 is annotated with strong experimental evidence and should be preferred.
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic (multi-method IEA) assignment of the core L-lactate dehydrogenase
+      (NAD+) activity, consistent with the EC 1.1.1.27 / RHEA:23444 mapping and with
+      experimental evidence.
+    action: ACCEPT
+    reason: Correct core molecular function, redundant with but consistent with the
+      experimental and phylogenetic annotations of the same term.
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: Reaction=(S)-lactate + NAD(+) = pyruvate + NADH + H(+);
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Electronic assignment of the cytoplasm, consistent with UniProt subcellular
+      location and with LDH being a soluble cytosolic glycolytic enzyme.
+    action: ACCEPT
+    reason: Correct, though the more specific cytosol (GO:0005829) is the preferred core
+      location. Cytoplasm is a valid broader statement.
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm. Mitochondrion inner membrane&#39;
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic annotation derived from the UniProt Subcellular Location keyword
+      mapping (Mitochondrion inner membrane), which in turn rests on the experimental
+      report PMID:27618187. This is a non-canonical localization for LDHB.
+    action: KEEP_AS_NON_CORE
+    reason: Supported experimentally (PMID:27618187) via the UniProt subcellular location,
+      but a minority/debated localization; the core location is cytosolic. Keep as
+      non-core.
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm. Mitochondrion inner membrane&#39;
+- term:
+    id: GO:0016491
+    label: oxidoreductase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic mapping to the general oxidoreductase activity term.
+      Correct but too general.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Parent of the specific L-lactate dehydrogenase (NAD+) activity; uninformative
+      given the well-supported specific MF term.
+- term:
+    id: GO:0016616
+    label: oxidoreductase activity, acting on the CH-OH group of donors, NAD or NADP
+      as acceptor
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO electronic mapping to an intermediate oxidoreductase term
+      describing the CH-OH-group / NAD(P)-acceptor chemistry. Accurate for LDH chemistry
+      but less specific than L-lactate dehydrogenase (NAD+) activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Correct grandparent-level chemistry but redundant with the specific MF term
+      GO:0004459, which should be preferred.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21044950
+  qualifier: enables
+  review:
+    summary: IntAct two-hybrid/interaction datum with TERF1 (P54274). Bare protein binding
+      conveys no specific function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding annotation from a high-throughput
+      interaction screen; not a core function and no specific molecular function can be
+      inferred. Retained per policy rather than removed.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21988832
+  qualifier: enables
+  review:
+    summary: IntAct interaction datum with LDHA (P00338), consistent with formation of
+      mixed M/H LDH tetramers, but captured only as generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The underlying LDHA interaction is biologically real (heterotetramer assembly),
+      but the bare protein binding term is uninformative; the tetramer relationship is
+      better captured by identical protein binding / oxidoreductase complex.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:24725412
+  qualifier: enables
+  review:
+    summary: IntAct interaction datum with LRRK2 (Q5S007) from a Parkinson-disease study.
+      Bare protein binding, no specific function implied for LDHB.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding annotation; not a core function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  qualifier: enables
+  review:
+    summary: IntAct interaction datum with LDHA isoform (P00338-3) from a proteome-scale
+      interactome map. Bare protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding annotation from a high-throughput
+      interactome study; not a core function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25910212
+  qualifier: enables
+  review:
+    summary: IntAct interaction datum with LDHA isoform (P00338-3) from a study of
+      interaction perturbations in genetic disorders. Bare protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding annotation; not a core function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: IntAct interaction data (LDHA P00338, LDHC P07864) from an interactome
+      community study. Consistent with LDH-family tetramer assembly but recorded as
+      generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding term; the biologically relevant LDH-family
+      subunit interactions are better captured elsewhere.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  qualifier: enables
+  review:
+    summary: IntAct interaction datum with LDHA (P00338) from a study of variant-driven
+      interaction disruption. Bare protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding annotation; not a core function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: IntAct interaction data (SDCBP O00560, LDHA isoform P00338-3) from a reference
+      binary interactome map. Bare protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding annotation from a high-throughput screen;
+      not a core function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  qualifier: enables
+  review:
+    summary: IntAct interaction datum with HTT (P42858) from a neurodegenerative-disease
+      interactome study. Bare protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding annotation; not a core function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: IntAct interaction data (LDHA P00338, LDHC P07864) from a cell-specific
+      interactome remodeling study. LDH-family subunit interactions recorded as generic
+      protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding term; the relevant subunit interactions
+      are better represented by the tetramer/complex annotations.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35271311
+  qualifier: enables
+  review:
+    summary: IntAct interaction data (LDHA P00338, LDHC P07864) from the OpenCell
+      endogenous-tagging interactome. Bare protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding annotation; not a core function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: IntAct interaction datum with LDHC (P07864) from a multimodal cell-map study.
+      Bare protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding annotation; not a core function.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  qualifier: enables
+  review:
+    summary: IntAct self-interaction (P07195 with P07195), reflecting the homotetrameric
+      assembly of the LDHB (H4) isoenzyme.
+    action: KEEP_AS_NON_CORE
+    reason: Biologically meaningful (LDHB homotetramerization) and more informative than
+      bare protein binding, but the self-association is a structural feature supporting the
+      complex rather than the core catalytic function. Keep as non-core.
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: Homotetramer (PubMed:11276087)
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25502805
+  qualifier: enables
+  review:
+    summary: IntAct self-interaction (P07195 with P07195) from a variant-cloning /
+      molecular-phenotype pipeline, again reflecting LDHB homotetramerization.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with homotetramer assembly; informative structural annotation but
+      not the core catalytic function.
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: Homotetramer (PubMed:11276087)
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  qualifier: enables
+  review:
+    summary: IntAct self-interaction (P07195 with P07195), reflecting LDHB
+      homotetramerization.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with homotetramer assembly; informative structural annotation but
+      not the core catalytic function.
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: Homotetramer (PubMed:11276087)
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: IntAct self-interaction (P07195 with P07195) from the reference binary
+      interactome, reflecting LDHB homotetramerization.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with homotetramer assembly; informative structural annotation but
+      not the core catalytic function.
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: Homotetramer (PubMed:11276087)
+- term:
+    id: GO:0004457
+    label: lactate dehydrogenase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: Ensembl orthology (IEA) assignment of lactate dehydrogenase activity, the
+      immediate parent of the NAD+-specific L-lactate dehydrogenase activity.
+    action: ACCEPT
+    reason: Correct and consistent with the core function; a slightly broader phrasing of
+      the same catalytic activity. Acceptable as-is.
+    supported_by:
+    - reference_id: PMID:11276087
+      supporting_text: Lactate dehydrogenase (LDH) interconverts pyruvate and lactate with
+        concomitant
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: is_active_in
+  review:
+    summary: Ensembl orthology (IEA) placement of LDHB activity in the cytosol, the
+      canonical location of this glycolytic enzyme, concordant with the HPA IDA and
+      Reactome TAS annotations to cytosol.
+    action: ACCEPT
+    reason: Correct core subcellular location; strongly corroborated by IDA (HPA) and TAS
+      (Reactome) evidence.
+- term:
+    id: GO:0006089
+    label: lactate metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Ensembl orthology (IEA) assignment to lactate metabolic process, capturing
+      LDHB&#39;s role in the interconversion of lactate and pyruvate. Also independently
+      supported by ComplexPortal IDA (PMID:15117937).
+    action: ACCEPT
+    reason: Accurately reflects the core biological process in which LDHB participates
+      (lactate/pyruvate interconversion), and is the process best matching the LDHB-favoured
+      lactate-oxidising direction.
+    supported_by:
+    - reference_id: PMID:27618187
+      supporting_text: LDHB supports conversion of lactate to pyruvate in cells that utilize
+        lactate as a nutrient source for oxidative metabolism or gluconeogenesis
+- term:
+    id: GO:0019674
+    label: NAD+ metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Ensembl orthology (IEA) assignment to NAD+ metabolic process, reflecting that
+      LDHB regenerates/consumes NAD+/NADH during the lactate-pyruvate reaction and thereby
+      contributes to cytosolic redox balance.
+    action: KEEP_AS_NON_CORE
+    reason: Biologically correct (the reaction interconverts NAD+ and NADH), but NAD+
+      metabolism is a downstream consequence of the catalytic activity rather than the core
+      annotated function. Keep as non-core.
+    supported_by:
+    - reference_id: PMID:15117937
+      supporting_text: central to NAD(+) regeneration
+- term:
+    id: GO:0019900
+    label: kinase binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: Ensembl orthology (IEA) transfer of a kinase-binding annotation from a rat
+      ortholog. There is no specific experimental evidence that human LDHB binds a kinase
+      as a defined molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Orthology-transferred generic binding annotation with no clear functional
+      relevance to LDHB&#39;s role; likely an over-annotation and not a core function.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: Ensembl orthology (IEA) transfer of identical protein binding, consistent with
+      the homotetrameric assembly of LDHB.
+    action: KEEP_AS_NON_CORE
+    reason: Reflects LDHB homotetramerization; informative structural feature but not the
+      core catalytic function.
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: Homotetramer (PubMed:11276087)
+- term:
+    id: GO:0051287
+    label: NAD binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: Ensembl orthology (IEA) assignment of NAD binding. LDHB is an NAD-dependent
+      dehydrogenase with a Rossmann-fold NAD-binding domain and defined NAD(+)-binding
+      residues, so this is a correct and informative molecular function.
+    action: ACCEPT
+    reason: Correct; NAD binding is a genuine, structurally documented molecular function
+      of LDHB (NAD-binding Rossmann domain; NAD(+) binding site residues in UniProt).
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: Reaction=(S)-lactate + NAD(+) = pyruvate + NADH + H(+);
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: Direct immunofluorescence (HPA) localization of LDHB to the cytosol, the
+      canonical location of this glycolytic enzyme.
+    action: ACCEPT
+    reason: Experimentally supported core subcellular location, concordant with electronic
+      and TAS cytosol annotations.
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: EXP
+  original_reference_id: PMID:11276087
+  qualifier: enables
+  review:
+    summary: Experimental (structural/biophysical) demonstration of L-lactate dehydrogenase
+      (NAD+) activity for human LDH-H, via crystallographic ternary complexes with NADH and
+      substrate analog and kinetic characterization.
+    action: ACCEPT
+    reason: This is the defining, experimentally established core molecular function of
+      LDHB, characterized structurally and kinetically for the H isoform.
+    supported_by:
+    - reference_id: PMID:11276087
+      supporting_text: Lactate dehydrogenase (LDH) interconverts pyruvate and lactate with
+        concomitant
+    - reference_id: PMID:11276087
+      supporting_text: the H form, found mainly in cardiac muscle
+- term:
+    id: GO:0006089
+    label: lactate metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:15117937
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal IDA annotation of the LDH complex to lactate metabolic process.
+      LDH is central to lactate/pyruvate interconversion and NAD+ regeneration.
+    action: ACCEPT
+    reason: Correctly captures the core biological process; LDHB participates in lactate
+      metabolism as the H subunit of the LDH complex.
+    supported_by:
+    - reference_id: PMID:15117937
+      supporting_text: central to NAD(+) regeneration
+- term:
+    id: GO:1990204
+    label: oxidoreductase complex
+  evidence_type: IPI
+  original_reference_id: PMID:15117937
+  qualifier: part_of
+  review:
+    summary: ComplexPortal assertion that LDHB is part of the L-lactate dehydrogenase
+      (oxidoreductase) complex, i.e. the LDH tetramer. UniProt/ComplexPortal record the
+      A/B (M/H) tetramer variants (CPX-6592/6594/6598/6599).
+    action: ACCEPT
+    reason: Correct; catalytically active LDH is a tetramer, and LDHB is a constituent
+      subunit. This appropriately captures the complex-level context of the enzyme.
+    supported_by:
+    - reference_id: PMID:27618187
+      supporting_text: Functional LDH is a homo or hetero tetramer composed of LDHA and
+        LDHB subunits
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: Homotetramer (PubMed:11276087)
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: IDA
+  original_reference_id: PMID:27618187
+  qualifier: enables
+  review:
+    summary: Direct assay of LDHB (L-lactate dehydrogenase) activity in whole-cell and
+      isolated mitochondrial lysates, confirming the core catalytic function.
+    action: ACCEPT
+    reason: Experimentally supported core molecular function of LDHB.
+    supported_by:
+    - reference_id: PMID:27618187
+      supporting_text: the mitochondria had higher LDHB activity, further suggesting that
+        LDHB activity is concentrated in mitochondria
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33406399
+  qualifier: enables
+  review:
+    summary: UniProt-curated IPI interaction with the PTEN-uORF micropeptide MP31 (C0HLV8).
+      MP31 binds LDHB and inhibits mitochondrial LDH activity by competing for NAD+, acting
+      as a regulatory circuit breaker of lactate-pyruvate conversion; the interaction is
+      abolished by LDHB mutations D53A and R100A.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: This is the most biologically meaningful of the protein-binding annotations
+      (a specific, functionally characterized regulatory interaction), but the term itself
+      is the uninformative generic protein binding. Retained (not removed) per policy; a
+      more specific enzyme-inhibitor / MP31-binding characterization would be preferable.
+    supported_by:
+    - reference_id: PMID:33406399
+      supporting_text: limits lactate-pyruvate conversion in mitochondria by
+    - reference_id: PMID:33406399
+      supporting_text: competing with mitochondrial lactate dehydrogenase (mLDH) for
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:27618187
+  qualifier: located_in
+  review:
+    summary: TEM immunogold localization of LDHB to the inner mitochondrial membrane in
+      HeLa cells, with concordant mitochondrial LDH activity in isolated mitochondria. A
+      specific but non-canonical localization for this classically cytosolic enzyme.
+    action: KEEP_AS_NON_CORE
+    reason: Experimentally supported (PMID:27618187), but a minority/debated localization;
+      the dominant location of LDHB is cytosolic. Retain as non-core.
+    supported_by:
+    - reference_id: PMID:27618187
+      supporting_text: gold-labeled LDHB localizes to the inner mitochondrial membrane
+- term:
+    id: GO:0045121
+    label: membrane raft
+  evidence_type: IDA
+  original_reference_id: PMID:25204797
+  qualifier: located_in
+  review:
+    summary: Localization to membrane raft reported in a flotillin-1/TLR3 endothelial
+      signaling study that used SILAC proteomics of raft/caveolae fractions. LDHB is a
+      soluble cytosolic enzyme and its recovery in raft proteomic fractions most likely
+      reflects abundant-protein co-purification rather than a functional raft localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: A soluble glycolytic enzyme is not expected to be a genuine membrane raft
+      resident; this is likely a proteomic co-isolation artifact and an over-annotation.
+    supported_by:
+    - reference_id: PMID:25204797
+      supporting_text: Flotillin-1 and -2 are markers of membrane rafts
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:23533145
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of LDHB in urinary/prostatic-secretion
+      exosome preparations. Abundant cytosolic enzymes are commonly detected in exosome
+      proteomes without evidence of a functional role there.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Cytosolic-enzyme detection in exosome proteomics; not a functional localization
+      and not a core annotation.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of LDHB in an NK-cell membrane proteome
+      preparation. Non-specific membrane assignment for a soluble enzyme.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic membrane assignment for a cytosolic protein from a proteomic
+      membrane-fraction study; likely co-isolation and an over-annotation.
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of LDHB in urinary exosomes.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Cytosolic-enzyme detection in exosome proteomics; not a functional localization
+      and not a core annotation.
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:20458337
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of LDHB in B-cell exosomes.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Cytosolic-enzyme detection in exosome proteomics; not a functional localization
+      and not a core annotation.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70510
+  qualifier: located_in
+  review:
+    summary: Reactome traceable-author-statement placing LDHB in the cytosol in the context
+      of LDH tetramer oxidises LACT to PYR, the lactate-oxidising direction favoured by the
+      LDHB-rich isoenzyme.
+    action: ACCEPT
+    reason: Correct core cytosolic location, consistent with IDA and IEA cytosol
+      annotations and with the canonical glycolytic-enzyme localization.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71849
+  qualifier: located_in
+  review:
+    summary: Reactome traceable-author-statement placing LDHB in the cytosol in the context
+      of LDH tetramer reduces PYR to LACT.
+    action: ACCEPT
+    reason: Correct core cytosolic location, redundant with but consistent with the other
+      cytosol annotations.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: TAS
+  original_reference_id: PMID:16130169
+  qualifier: located_in
+  review:
+    summary: Traceable-author-statement (UniProt) cytoplasm localization derived from a
+      HUVEC proteomics study. Consistent with the soluble cytoplasmic nature of LDHB.
+    action: ACCEPT
+    reason: Correct broader localization; the more specific cytosol is preferred as the
+      core location.
+    supported_by:
+    - reference_id: file:human/LDHB/LDHB-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm. Mitochondrion inner membrane&#39;
+- term:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  evidence_type: TAS
+  original_reference_id: PMID:8314553
+  qualifier: enables
+  review:
+    summary: Traceable-author-statement of L-lactate dehydrogenase (NAD+) activity, from a
+      study characterizing an electrophoretic LDH-B(H) subunit variant (K7E) with decreased
+      heat stability and slightly reduced activity.
+    action: ACCEPT
+    reason: Correct core molecular function; the paper explicitly concerns the human LDH-B
+      (H) subunit and its enzymatic activity.
+    supported_by:
+    - reference_id: PMID:8314553
+      supporting_text: An electrophoretic variant of the lactate dehydrogenase (LDH)-B(H)
+        subunit was
+core_functions:
+- description: Cytosolic NAD-dependent L-lactate dehydrogenase (H/B subunit) catalysing the
+    reversible interconversion of pyruvate + NADH and L-lactate + NAD+; in LDHB-rich (H4)
+    isoenzymes this favours oxidation of lactate to pyruvate in oxidative tissues.
+  molecular_function:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  directly_involved_in:
+  - id: GO:0006089
+    label: lactate metabolic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:11276087
+    supporting_text: Lactate dehydrogenase (LDH) interconverts pyruvate and lactate with
+      concomitant
+  - reference_id: file:human/LDHB/LDHB-uniprot.txt
+    supporting_text: Reaction=(S)-lactate + NAD(+) = pyruvate + NADH + H(+);
+- description: As a subunit of the tetrameric L-lactate dehydrogenase complex, LDHB
+    assembles into homotetramers (H4) and heterotetramers with LDHA (M), forming the
+    catalytically active oxidoreductase complex.
+  molecular_function:
+    id: GO:0004459
+    label: L-lactate dehydrogenase (NAD+) activity
+  directly_involved_in:
+  - id: GO:0006089
+    label: lactate metabolic process
+  in_complex:
+    id: GO:1990204
+    label: oxidoreductase complex
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:27618187
+    supporting_text: Functional LDH is a homo or hetero tetramer composed of LDHA and LDHB
+      subunits
+  - reference_id: file:human/LDHB/LDHB-uniprot.txt
+    supporting_text: Homotetramer (PubMed:11276087)
+suggested_questions:
+- question: Is the mitochondrial (inner-membrane) pool of LDHB a genuine, functionally
+    significant localization in vivo, or is it largely restricted to specific cell types
+    (e.g. fermenting cancer cells) and experimental conditions?
+- question: To what extent does the MP31 (PTEN-uORF) circuit-breaker regulation of LDHB
+    operate in normal physiology versus tumour metabolism?
+suggested_experiments:
+- description: Compartment-resolved activity assays (cytosol vs mitochondrial
+    sub-fractions) across oxidative and glycolytic human tissues to quantify the
+    physiological contribution of any mitochondrial LDHB pool.
+- description: Structure-guided kinetic comparison of purified LDHB homotetramer versus
+    defined M/H heterotetramers to quantify the directional (lactate to pyruvate)
+    preference under physiological substrate/redox conditions.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: file:human/LDHB/LDHB-uniprot.txt
+  title: UniProtKB entry P07195 (LDHB_HUMAN)
+  findings: []
+- id: PMID:11276087
+  title: Structural basis for altered activity of M- and H-isozyme forms of human
+    lactate dehydrogenase.
+  findings:
+  - statement: Human LDH-H and LDH-M interconvert pyruvate and lactate with concomitant
+      NADH/NAD+ interconversion; the H form is found mainly in cardiac muscle and is
+      structurally indistinguishable at the active site from the M form.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract-only cache; establishes the core L-lactate dehydrogenase (NAD+)
+      activity and the H (heart) subunit identity of LDHB.
+- id: PMID:15117937
+  title: Identification and activity of a series of azole-based compounds with lactate
+    dehydrogenase-directed anti-malarial activity.
+  findings:
+  - statement: LDH is central to NAD+ regeneration during glycolysis coupled with
+      homolactic fermentation.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Primarily about Plasmodium LDH inhibitors; used by ComplexPortal as the
+      reference for the human LDH complex annotations. Supports LDH&#39;s central role in NAD+
+      regeneration.
+- id: PMID:16130169
+  title: Proteomics of human umbilical vein endothelial cells applied to etoposide-induced
+    apoptosis.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: HUVEC proteomics; source of a TAS cytoplasm localization. Contextual only.
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Exosome proteomics; abundant-cytosolic-protein detection, not a functional
+      localization.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Membrane-fraction proteomics; generic membrane detection for a soluble
+      enzyme.
+- id: PMID:20458337
+  title: MHC class II-associated proteins in B-cell exosomes and potential functional
+    implications for exosome biogenesis.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Exosome proteomics; abundant-cytosolic-protein detection.
+- id: PMID:21044950
+  title: Genome-wide YFP fluorescence complementation screen identifies new regulators
+    for telomere signaling in human cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput interaction screen (TERF1); source of a generic protein
+      binding datum.
+- id: PMID:21988832
+  title: Toward an understanding of the protein interaction network of the human liver.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Interactome study (LDHA); generic protein binding datum consistent with
+      LDH tetramer assembly.
+- id: PMID:23533145
+  title: In-depth proteomic analyses of exosomes isolated from expressed prostatic
+    secretions in urine.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Exosome proteomics; abundant-cytosolic-protein detection.
+- id: PMID:24725412
+  title: Ribosomal protein s15 phosphorylation mediates LRRK2 neurodegeneration in
+    Parkinson&#39;s disease.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: LRRK2 interactome context; generic protein binding datum.
+- id: PMID:25204797
+  title: Flotillin-1 facilitates toll-like receptor 3 signaling in human endothelial cells.
+  findings:
+  - statement: Flotillins are membrane raft markers; LDHB was recovered in the raft/caveolae
+      proteomic analysis of this study.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Membrane-raft proteomics; the raft localization of a soluble glycolytic
+      enzyme is most likely a co-isolation artifact.
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Interactome map; source of protein binding (LDHA) and identical protein
+      binding (self) data.
+- id: PMID:25502805
+  title: A massively parallel pipeline to clone DNA variants and examine molecular
+    phenotypes of human disease mutations.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Variant-cloning interaction pipeline; source of an identical protein
+      binding (self) datum consistent with homotetramerization.
+- id: PMID:25910212
+  title: Widespread macromolecular interaction perturbations in human genetic disorders.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Interaction-perturbation study (LDHA); generic protein binding datum.
+- id: PMID:27618187
+  title: Lactate metabolism is associated with mammalian mitochondria.
+  findings:
+  - statement: Functional LDH is a tetramer of LDHA and LDHB subunits; LDHB is the
+      predominant heart (H) subunit and supports conversion of lactate to pyruvate in
+      lactate-consuming oxidative cells. LDHB was localized by TEM immunogold to the inner
+      mitochondrial membrane and mitochondrial lysates showed LDHB activity.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Full text available; direct experimental support for LDHB catalytic
+      activity, tetramer composition, H-subunit identity, and a non-canonical
+      mitochondrial localization.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Interactome community study (LDHA/LDHC); generic protein binding data.
+- id: PMID:31515488
+  title: Extensive disruption of protein interactions by genetic variants across the
+    allele frequency spectrum in human populations.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Variant interaction study (LDHA); source of protein binding and identical
+      protein binding data.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Binary interactome map; source of protein binding (SDCBP/LDHA) and
+      identical protein binding (self) data.
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
+    and Uncovers Widespread Protein Aggregation in Affected Brains.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Neurodegeneration interactome (HTT); generic protein binding datum.
+- id: PMID:33406399
+  title: An Upstream Open Reading Frame in Phosphatase and Tensin Homolog Encodes
+    a Circuit Breaker of Lactate Metabolism.
+  findings:
+  - statement: MP31, a micropeptide from the PTEN uORF, binds LDHB and limits
+      lactate-pyruvate conversion in mitochondria by competing with mitochondrial LDH for
+      NAD+.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Abstract-only cache; UniProt curates this as the LDHB-MP31 (C0HLV8)
+      interaction abolished by LDHB D53A/R100A. Functionally meaningful regulatory
+      interaction, though annotated only as generic protein binding.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Cell-specific interactome remodeling (LDHA/LDHC); generic protein binding
+      data.
+- id: PMID:35271311
+  title: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization.&#39;
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: OpenCell interactome (LDHA/LDHC); generic protein binding data.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Multimodal cell-map interactome (LDHC); generic protein binding datum.
+- id: PMID:8314553
+  title: Analysis of a genetic mutation in an electrophoretic variant of the human
+    lactate dehydrogenase-B(H) subunit.
+  findings:
+  - statement: An electrophoretic LDH-B(H) subunit variant (K7E) with decreased heat
+      stability and slightly lower LDH activity was characterized, confirming LDHB as the
+      H subunit of human LDH.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Abstract-only cache; source of the TAS L-lactate dehydrogenase (NAD+)
+      activity annotation and confirms LDHB = H subunit.
+- id: Reactome:R-HSA-70510
+  title: LDH tetramer oxidises LACT to PYR
+  findings: []
+- id: Reactome:R-HSA-71849
+  title: LDH tetramer reduces PYR to LACT
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PGAM2/PGAM2-ai-review.html
+++ b/genes/human/PGAM2/PGAM2-ai-review.html
@@ -1,0 +1,4802 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PGAM2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PGAM2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P15259" target="_blank" class="term-link">
+                        P15259
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PGAM2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P15259" data-a="DESCRIPTION: PGAM2 is the muscle (M) isoform of phosphoglycerat..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PGAM2 is the muscle (M) isoform of phosphoglycerate mutase, a cytosolic enzyme of the cofactor-dependent phosphoglycerate mutase (histidine-phosphatase) superfamily. It catalyzes the reversible interconversion of 3-phosphoglycerate and 2-phosphoglycerate, the eighth step of the glycolytic payoff phase (and the corresponding reverse step in gluconeogenesis). Catalysis proceeds through a phospho-histidine enzyme intermediate and requires 2,3-bisphosphoglycerate as a cofactor/primer; the enzyme also displays a minor bisphosphoglycerate mutase/phosphatase side activity. Active human phosphoglycerate mutase is a dimer assembled from muscle (PGAM2/M) and brain (PGAM1/B) subunits; skeletal muscle expresses essentially the PGAM2 homodimer, whereas erythrocytes express PGAM1. PGAM2 is expressed predominantly in heart and skeletal muscle. Loss-of-function variants cause glycogen storage disease type X (muscle phosphoglycerate mutase deficiency), manifesting as exercise intolerance, muscle cramps, and myoglobinuria/rhabdomyolysis.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004619" target="_blank" class="term-link">
+                                    GO:0004619
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0004619" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of the core catalytic activity of PGAM2: reversible interconversion of 3- and 2-phosphoglycerate. This is the defining molecular function of the muscle phosphoglycerate mutase subunit and is strongly corroborated by experimental and UniProt evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function, correct at the right level of specificity, and consistent across independent evidence lines (IBA, EXP, IMP, ISS, IEA) and the UniProt catalytic-activity record (EC 5.4.2.11).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic assignment of the cytosol as the site of action. Phosphoglycerate mutase is a soluble cytosolic glycolytic enzyme, consistent with Reactome and UniProt.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct subcellular location for a soluble glycolytic enzyme; agrees with Reactome TAS cytosol annotations and with the entire glycolytic pathway being cytosolic.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71445
+
+                                </span>
+
+                                <div class="support-text">Cytosolic phosphoglycerate mutase dimers (PGAM1,2) catalyze the reversible isomerisation of 2- and 3-phosphoglycerate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061621" target="_blank" class="term-link">
+                                    GO:0061621
+                                </a>
+                            </span>
+                            <span class="term-label">canonical glycolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0061621" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic assignment of PGAM2 to canonical glycolysis (the ATP-generating glucose-to-pyruvate route). PGAM catalyzes step 8 (3-PG to 2-PG) of the glycolytic payoff phase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process for the muscle glycolytic isoform, at an appropriate level of specificity; corroborated by the Reactome Glycolysis pathway and by the IMP glycolytic-process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-70171
+
+                                </span>
+
+                                <div class="support-text">The reactions of glycolysis (e.g., van Wijk and van Solinge 2005) convert</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003824" target="_blank" class="term-link">
+                                    GO:0003824
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0003824" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Root-level InterPro2GO mapping asserting generic catalytic activity. Not incorrect but entirely uninformative given the specific mutase activity is already annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;catalytic activity&#34; is a top-level MF placeholder subsumed by the specific phosphoglycerate mutase activity annotation; it adds no functional information.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004082" target="_blank" class="term-link">
+                                    GO:0004082
+                                </a>
+                            </span>
+                            <span class="term-label">bisphosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0004082" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping (EC 5.4.2.4 / RHEA:17765) of the minor bisphosphoglycerate mutase side activity. UniProt records that the enzyme &#34;can also catalyze the interconversion of (2R)-2,3-bisphosphoglycerate and (2R)-3-phospho-glyceroyl phosphate, but with a reduced activity.&#34;
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine, documented secondary catalytic activity of the BPG-dependent PGAM subfamily; correctly captured, though it is the reduced-activity side reaction rather than the primary physiological function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC       3-phospho-glyceroyl phosphate, but with a reduced activity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004619" target="_blank" class="term-link">
+                                    GO:0004619
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0004619" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping (EC 5.4.2.11 / RHEA:15901 / ARBA) of the core phosphoglycerate mutase activity. Duplicate of the core MF from an automated pipeline.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function; the automated EC/RHEA mapping agrees with the experimental and phylogenetic annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0006096" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment to the glycolytic process. Correct core pathway for PGAM2, also supported experimentally by the deficiency phenotype (IMP).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; consistent with the IMP annotation from the muscle PGAM deficiency case and with the canonical-glycolysis annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6262916" target="_blank" class="term-link">
+                                        PMID:6262916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Muscle phosphoglycerate mutase activity was decreased (5.7 percent of the lowest</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016868" target="_blank" class="term-link">
+                                    GO:0016868
+                                </a>
+                            </span>
+                            <span class="term-label">intramolecular phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0016868" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping to intramolecular phosphotransferase activity, the isomerase parent class (EC 5.4.2.-) that includes phosphoglycerate mutase. Correct but more general than the specific mutase term already annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate parent-level molecular function; an IEA term is permitted to be broader than the specific mutase activity, and it correctly reflects the isomerase reaction chemistry (intramolecular phospho group transfer).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput AP-MS interactome (BioPlex 2.0) reporting a PGAM2-BPGM (P07738) co-complex. Bare &#34;protein binding&#34; is uninformative about molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidance, bare &#34;protein binding&#34; is not an informative molecular function and this is an interactome-screen IPI. The recurrent BPGM partner is biologically plausible (both enzymes act on 2,3-bisphosphoglycerate) but does not itself define a specific molecular function; retained (not removed) as an experimental IPI.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                                        PMID:28514442
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">BioPlex 2.0 is the largest collection of human co-complex data assembled from a single pipeline to date</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Binary interactome map (HuRI, yeast two-hybrid) reporting PGAM2 interactions (e.g. BPGM, CLVS2, DYNC1LI1, KATNAL1). Bare &#34;protein binding&#34; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic &#34;protein binding&#34; from a systematic binary-interactome screen; retained as an experimental IPI but not treated as a defining function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A reference map of the human binary protein interactome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput AP-MS interactome (BioPlex 3.0) again reporting a PGAM2-BPGM (P07738) association. Bare &#34;protein binding&#34; is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic &#34;protein binding&#34; from an interactome screen; consistent with the other BioPlex/HuRI evidence but non-specific; retained as an experimental IPI.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dual proteome-scale networks reveal cell-specific remodeling of the human</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0042802" data-r="PMID:32296183" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Self-interaction of PGAM2 (P15259-P15259) detected in the binary interactome map, consistent with the established homodimeric quaternary structure of phosphoglycerate mutase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Informative self-association annotation that matches the documented homodimer; UniProt SUBUNIT states &#34;Homodimer&#34; and Reactome describes the active enzyme as a dimer.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC   -!- SUBUNIT: Homodimer. Interacts with ENO1. {ECO:0000250|UniProtKB:O70250,</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0005634" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Orthology-based (Ensembl Compara, from rat P16290) transfer of a nuclear localization. PGAM2 is a soluble cytosolic glycolytic enzyme; a nuclear location is not associated with any established nuclear function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is not part of the core biology of this cytosolic enzyme; it derives from orthology transfer plus proteomic detection in sperm nuclei and likely reflects contamination/moonlighting rather than a functional nuclear role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC   -!- SUBUNIT: Homodimer. Interacts with ENO1. {ECO:0000250|UniProtKB:O70250,</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0005829" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Orthology-based (Ensembl Compara, from mouse O70250) assignment of the cytosol as site of action. Correct core location for a glycolytic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Agrees with the IBA and Reactome TAS cytosol annotations; correct compartment for phosphoglycerate mutase activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71445
+
+                                </span>
+
+                                <div class="support-text">Cytosolic phosphoglycerate mutase dimers (PGAM1,2) catalyze the reversible isomerisation of 2- and 3-phosphoglycerate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0006094" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Orthology-based (Ensembl Compara) assignment to gluconeogenesis. The phosphoglycerate mutase reaction is reversible and is shared with the gluconeogenic direction, but physiological gluconeogenesis is confined to liver and kidney, which express PGAM1 rather than the muscle PGAM2 isoform.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The reaction chemistry participates in gluconeogenesis, but the muscle isoform&#39;s core in-vivo role is glycolytic; muscle does not perform gluconeogenesis, so this is retained as a non-core, reaction-shared process rather than PGAM2&#39;s primary physiological function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-70263
+
+                                </span>
+
+                                <div class="support-text">Gluconeogenesis is confined to cells of the liver and kidney</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007283" target="_blank" class="term-link">
+                                    GO:0007283
+                                </a>
+                            </span>
+                            <span class="term-label">spermatogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0007283" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Orthology-based (Ensembl Compara, from rat P16290) transfer of a spermatogenesis role. Sperm rely heavily on glycolysis, but a direct role of the muscle PGAM2 isoform in spermatogenesis is not established in human.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Speculative context transferred by orthology; not a core molecular/biological function of the human muscle isoform. Retained as non-core rather than removed, since it is a plausible tissue context for a glycolytic enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC   -!- TISSUE SPECIFICITY: Expressed in the heart and muscle. Not found in the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046689" target="_blank" class="term-link">
+                                    GO:0046689
+                                </a>
+                            </span>
+                            <span class="term-label">response to mercury ion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0046689" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Orthology-based (Ensembl Compara, from rat P16290) transfer of a &#34;response to mercury ion&#34; process. The M subunit is mercury-inhibitable in vitro (historically used to distinguish M from BB isozymes), but this is an enzyme-property observation, not a biological response process of human PGAM2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;response to mercury ion&#34; as a biological process is an orthology artifact and does not represent a core biological role of PGAM2; in-vitro Hg sensitivity of the catalytic His does not constitute a cellular mercury-response pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6262916" target="_blank" class="term-link">
+                                        PMID:6262916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Electrophoretic, </div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061621" target="_blank" class="term-link">
+                                    GO:0061621
+                                </a>
+                            </span>
+                            <span class="term-label">canonical glycolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0061621" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Orthology-based (Ensembl Compara, from mouse O70250) assignment to canonical glycolysis. Correct core process; duplicate of the IBA/TAS glycolysis annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core glycolytic process for the muscle isoform, consistent with all other glycolysis evidence lines.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-70171
+
+                                </span>
+
+                                <div class="support-text">The reactions of glycolysis (e.g., van Wijk and van Solinge 2005) convert</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990917" target="_blank" class="term-link">
+                                    GO:1990917
+                                </a>
+                            </span>
+                            <span class="term-label">ooplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:1990917" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Orthology-based (Ensembl Compara, from rat P16290) transfer of an ooplasm (oocyte cytoplasm) location. This is a tissue-context transfer; the compartment (cytoplasm) is consistent with a cytosolic enzyme, but the specific ooplasmic localization is not established for the human muscle isoform.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytoplasmic location is consistent with PGAM2 biology, but &#34;ooplasm&#34; is an orthology-derived tissue-specific location not relevant to the muscle isoform&#39;s core role; retained as non-core rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71445
+
+                                </span>
+
+                                <div class="support-text">Cytosolic phosphoglycerate mutase dimers (PGAM1,2) catalyze the reversible isomerisation of 2- and 3-phosphoglycerate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70263
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0006094" data-r="Reactome:R-HSA-70263" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome pathway annotation placing the reversible phosphoglycerate mutase reaction within gluconeogenesis. The reaction is genuinely part of the gluconeogenic sequence (a reverse-of-glycolysis step).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The PGAM reaction participates in the gluconeogenesis pathway as modeled by Reactome, so the annotation is not wrong; however gluconeogenesis is a liver/kidney process (PGAM1), so it is not the core physiological role of the muscle PGAM2 isoform. Retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-70263
+
+                                </span>
+
+                                <div class="support-text">Gluconeogenesis is confined to cells of the liver and kidney</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061621" target="_blank" class="term-link">
+                                    GO:0061621
+                                </a>
+                            </span>
+                            <span class="term-label">canonical glycolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70171
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0061621" data-r="Reactome:R-HSA-70171" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome pathway annotation placing PGAM within canonical glycolysis (the cytosolic glucose-to-pyruvate route). Core process for PGAM2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Authoritative pathway (TAS) annotation for the core glycolytic role; consistent with all other glycolysis evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-70171
+
+                                </span>
+
+                                <div class="support-text">The reactions of glycolysis (e.g., van Wijk and van Solinge 2005) convert</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004619" target="_blank" class="term-link">
+                                    GO:0004619
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/4827367" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:4827367
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphoglycerate mutase isozyme marker for tissue differenti...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0004619" data-r="PMID:4827367" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation of phosphoglycerate mutase activity based on characterization of the human PGAM isozymes as tissue-differentiation markers (Omenn &amp; Cheung 1974), which established the muscle (M) versus brain (B) subunit isozyme system.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental support for the core catalytic activity of the muscle phosphoglycerate mutase isozyme; foundational isozyme-characterization work.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/4827367" target="_blank" class="term-link">
+                                        PMID:4827367
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Phosphoglycerate mutase isozyme marker for tissue differentiation in man.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Human Protein Atlas immunofluorescence (IDA) reporting nucleoplasmic signal. PGAM2 is an abundant soluble cytosolic enzyme; nucleoplasmic staining is not linked to any established nuclear function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A single-technique IF localization for an abundant cytosolic glycolytic enzyme, without a corresponding nuclear function; likely reflects the diffuse distribution/permeabilization artifacts common for soluble enzymes rather than a core nucleoplasmic role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC   -!- SUBUNIT: Homodimer. Interacts with ENO1. {ECO:0000250|UniProtKB:O70250,</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004082" target="_blank" class="term-link">
+                                    GO:0004082
+                                </a>
+                            </span>
+                            <span class="term-label">bisphosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0004082" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer (from PGAM1, P18669) of the minor bisphosphoglycerate mutase activity. Consistent with the UniProt-documented reduced-activity side reaction of the BPG-dependent PGAM subfamily.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine secondary catalytic activity supported by family membership and the UniProt catalytic-activity record (EC 5.4.2.4); appropriately marked as a similarity-based inference.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC       3-phospho-glyceroyl phosphate, but with a reduced activity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004619" target="_blank" class="term-link">
+                                    GO:0004619
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0004619" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer (from PGAM1, P18669) of the core phosphoglycerate mutase activity. Duplicate of the well-supported core MF.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core molecular function; the ISS inference agrees with experimental, phylogenetic, and automated evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGAM2/PGAM2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23533145
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In-depth proteomic analyses of exosomes isolated from expres...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0070062" data-r="PMID:23533145" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection in exosomes from expressed prostatic secretions in urine. PGAM2 is a ubiquitous soluble cytosolic enzyme that commonly co-purifies in exosome/secretome proteomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A single high-throughput exosome-proteome detection does not establish extracellular exosome as a functional location for this cytosolic glycolytic enzyme; frequent contaminant in such datasets.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                                        PMID:23533145
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In-depth proteomic analyses of exosomes isolated from expressed prostatic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21630459
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteomic characterization of the human sperm nucleus.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0005634" data-r="PMID:21630459" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of PGAM in isolated human sperm nuclei. Nuclear detection of an abundant soluble glycolytic enzyme in a whole-organelle proteome does not establish a functional nuclear role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proteomic co-detection in a sperm-nucleus preparation is prone to soluble-enzyme carryover; there is no established nuclear function for PGAM2, so this is an over-annotation of its core cytosolic biology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
+                                        PMID:21630459
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">sperm nuclei were obtained </div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71445
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0005829" data-r="Reactome:R-HSA-71445" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation of the cytosol as the location where PGAM dimers isomerise 2PG to 3PG. Core, correct location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Authoritative pathway annotation of the correct compartment for a cytosolic glycolytic enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71445
+
+                                </span>
+
+                                <div class="support-text">Cytosolic phosphoglycerate mutase dimers (PGAM1,2) catalyze the reversible isomerisation of 2- and 3-phosphoglycerate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71654
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0005829" data-r="Reactome:R-HSA-71654" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation of the cytosol as the location where PGAM dimers isomerise 3PG to 2PG. Core, correct location (duplicate direction of the same reversible reaction).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Authoritative pathway annotation of the correct cytosolic compartment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-71654
+
+                                </span>
+
+                                <div class="support-text">Cytosolic phosphoglycerate mutase catalyzes the reversible isomerisation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004619" target="_blank" class="term-link">
+                                    GO:0004619
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate mutase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6262916" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:6262916
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human muscle phosphoglycerate mutase deficiency: newly disco...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0004619" data-r="PMID:6262916" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) support from the first described human muscle phosphoglycerate mutase deficiency: muscle PGAM activity was reduced to 5.7% of the lowest control value, with the residual activity being the brain (BB) isoenzyme, implicating loss of the M subunit encoded by PGAM2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct genetic/biochemical evidence in humans that PGAM2 provides phosphoglycerate mutase activity in muscle; the disease phenotype tracks the loss of M-subunit activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6262916" target="_blank" class="term-link">
+                                        PMID:6262916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Muscle phosphoglycerate mutase activity was decreased (5.7 percent of the lowest</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6262916" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:6262916
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human muscle phosphoglycerate mutase deficiency: newly disco...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0006096" data-r="PMID:6262916" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) support that PGAM2 functions in glycolysis: the muscle PGAM deficiency produces a block at the phosphoglycerate mutase step of glycolysis while all other glycolytic enzymes had normal activities.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Human loss-of-function evidence directly linking PGAM2 to the glycolytic process; the specific enzymatic block defines its glycolytic role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6262916" target="_blank" class="term-link">
+                                        PMID:6262916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">All of the other enzymes of glycolysis </div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006941" target="_blank" class="term-link">
+                                    GO:0006941
+                                </a>
+                            </span>
+                            <span class="term-label">striated muscle contraction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6262916" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:6262916
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human muscle phosphoglycerate mutase deficiency: newly disco...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P15259" data-a="GO:0006941" data-r="PMID:6262916" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation to striated muscle contraction derived from the muscle PGAM deficiency phenotype (exercise intolerance, cramps, pigmenturia). PGAM2 is a glycolytic enzyme, not a component of the contractile apparatus.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Exercise intolerance and cramps in PGAM deficiency are downstream consequences of impaired muscle glycolytic ATP supply, not evidence that PGAM2 participates directly in the muscle-contraction process; the causal role is glycolysis. This is an over-annotation of a phenotype (retained rather than removed as it derives from an experimental report).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/6262916" target="_blank" class="term-link">
+                                        PMID:6262916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intolerance for strenuous exercise and </div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalyzes the reversible, 2,3-bisphosphoglycerate-dependent interconversion of 3-phosphoglycerate and 2-phosphoglycerate via a phospho-histidine intermediate, the eighth step of glycolysis, in the cytosol of skeletal and cardiac muscle.</h3>
+                <span class="vote-buttons" data-g="P15259" data-a="FUNCTION: Catalyzes the reversible, 2,3-bisphosphoglycerate-..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004619" target="_blank" class="term-link">
+                            phosphoglycerate mutase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                glycolytic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PGAM2/PGAM2-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/6262916" target="_blank" class="term-link">
+                                PMID:6262916
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Muscle phosphoglycerate mutase activity was decreased (5.7 percent of the lowest</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21630459" target="_blank" class="term-link">
+                            PMID:21630459
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteomic characterization of the human sperm nucleus.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                            PMID:23533145
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/4827367" target="_blank" class="term-link">
+                            PMID:4827367
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phosphoglycerate mutase isozyme marker for tissue differentiation in man.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/6262916" target="_blank" class="term-link">
+                            PMID:6262916
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human muscle phosphoglycerate mutase deficiency: newly discovered metabolic myopathy.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70171
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Glycolysis</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70263
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gluconeogenesis</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71445
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PGAM dimers isomerise 2PG to 3PG</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71654
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PGAM dimers isomerise 3PG to 2PG</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PGAM2/PGAM2-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt entry P15259 (PGAM2_HUMAN)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PGAM2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P15259" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pgam2-human-gene-review-notes">PGAM2 (human) — gene review notes</h1>
+<p>UniProtKB: P15259 (PGAM2_HUMAN). HGNC:8889. Gene on chromosome 7.<br />
+Synonyms: PGAMM; "muscle-specific phosphoglycerate mutase"; "phosphoglycerate mutase isozyme M" (PGAM-M).</p>
+<h2 id="core-biology-from-pgam2-uniprottxt-and-reactome">Core biology (from PGAM2-uniprot.txt and Reactome)</h2>
+<ul>
+<li>PGAM2 is the <strong>muscle (M) subunit</strong> of phosphoglycerate mutase, a member of the<br />
+<strong>cofactor-dependent phosphoglycerate mutase / histidine-phosphatase superfamily</strong><br />
+  (BPG-dependent PGAM subfamily). UniProt SIMILARITY: "Belongs to the phosphoglycerate<br />
+  mutase family. BPG-dependent PGAM subfamily."</li>
+<li>FUNCTION (UniProt): "Catalyzes the interconversion of 3- and 2-phosphoglycerate with<br />
+  2,3-bisphosphoglycerate as the primer of the reaction. Can also catalyze the<br />
+  interconversion of (2R)-2,3-bisphosphoglycerate and (2R)-3-phospho-glyceroyl phosphate,<br />
+  but with a reduced activity." → primary EC 5.4.2.11 (PGAM, GO:0004619); minor<br />
+  EC 5.4.2.4 (bisphosphoglycerate mutase, GO:0004082).</li>
+<li>Mechanism: phospho-histidine intermediate. ACT_SITE 11 = "Tele-phosphohistidine<br />
+  intermediate"; ACT_SITE 89 = "Proton donor/acceptor". Catalytic His at position 11 is<br />
+  the classic His-phosphatase-fold catalytic residue; 2,3-BPG is the required cofactor/primer.</li>
+<li>Reaction (Rhea:RHEA:15901): (2R)-2-phosphoglycerate = (2R)-3-phosphoglycerate. Reversible;<br />
+  step 8 of the glycolytic payoff phase (3-PG → 2-PG going toward pyruvate) and the reverse<br />
+  step in gluconeogenesis.</li>
+<li>Cytosolic. Human PGAM is a <strong>dimer</strong> of M (PGAM2) and B (PGAM1) subunits; muscle is<br />
+  essentially the PGAM2 homodimer (SUBUNIT: "Homodimer"). Reactome R-HSA-71445/71654:<br />
+  "erythrocytes express only PGAM1, while skeletal muscle expresses only PGAM2."</li>
+<li>TISSUE SPECIFICITY (UniProt, PubMed:2822696): "Expressed in the heart and muscle. Not<br />
+  found in the liver and brain." HPA: group-enriched heart muscle, skeletal muscle, tongue.</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li><strong>Glycogen storage disease X (GSD10 / GSD X); muscle phosphoglycerate mutase deficiency</strong><br />
+  (MIM:261670). UniProt DISEASE: "characterized by myoglobinuria, increased serum creatine<br />
+  kinase levels, decreased phosphoglycerate mutase activity, myalgia, muscle pain, muscle<br />
+  cramps, exercise intolerance." Variants: Glu89Ala, Arg90Trp (PubMed:8447317), Gly97Asp<br />
+  (PubMed:10545043).</li>
+<li>Original clinical description: DiMauro et al. 1981 (PMID:6262916) — first human muscle<br />
+  PGAM deficiency: muscle PGAM activity 5.7% of lowest control in a patient with exercise<br />
+  intolerance and recurrent pigmenturia (myoglobinuria); residual activity was the brain<br />
+  (BB) isoenzyme, "suggesting a genetic defect of the M subunit which predominates in<br />
+  normal muscle." This grounds the IMP GO:0004619 / GO:0006096 annotations. The<br />
+  striated-muscle-contraction annotation (GO:0006941) from the same paper is a phenotype<br />
+  (exercise intolerance/cramps) rather than a direct role of PGAM2 in the contractile<br />
+  mechanism → MARK_AS_OVER_ANNOTATED.</li>
+</ul>
+<h2 id="go-annotation-assessment-summary">GO annotation assessment summary</h2>
+<p>Molecular function — CORE:<br />
+- GO:0004619 phosphoglycerate mutase activity: multiply supported (IBA, IEA×2, EXP, ISS, IMP).<br />
+  ACCEPT the well-grounded ones (IBA anchor; EXP PMID:4827367 isozyme/enzyme-marker; IMP<br />
+  PMID:6262916 deficiency). This is the core MF.<br />
+- GO:0004082 bisphosphoglycerate mutase activity (IEA GO_REF:0000120 EC 5.4.2.4; ISS<br />
+  GO_REF:0000024 from PGAM1 P18669): real minor/secondary activity per UniProt FUNCTION.<br />
+  ACCEPT but note it is the reduced-activity side reaction, not the core physiological role.<br />
+- GO:0016868 intramolecular phosphotransferase activity (IEA InterPro): correct parent<br />
+  (isomerase EC 5.4.2.-); a bit general → ACCEPT (IEA allowed to be broader).<br />
+- GO:0003824 catalytic activity (IEA InterPro): root-level, uninformative but not wrong.<br />
+  MARK_AS_OVER_ANNOTATED (root filler).<br />
+- GO:0005515 protein binding (IPI ×3: PMID:28514442 BioPlex2, PMID:33961781 BioPlex3,<br />
+  PMID:32296183 HuRI). Bare "protein binding" is uninformative. Per policy: do NOT REMOVE<br />
+  IPI protein-binding; MARK_AS_OVER_ANNOTATED. Note the recurrent BPGM (P07738) partner is<br />
+  biologically sensible (both act on 2,3-BPG / glycerate phosphates).<br />
+- GO:0042802 identical protein binding (IPI PMID:32296183, self P15259): consistent with<br />
+  the documented homodimer → ACCEPT (informative self-association / dimerisation).</p>
+<p>Biological process:<br />
+- GO:0006096 glycolytic process (IEA GO_REF:0000120; IMP PMID:6262916): core. ACCEPT.<br />
+- GO:0061621 canonical glycolysis (IBA; IEA GO_REF:0000107; TAS Reactome): more specific<br />
+  glycolysis child, core. ACCEPT (IBA).<br />
+- GO:0006094 gluconeogenesis (IEA Ensembl; TAS Reactome R-HSA-70263): PGAM catalyses the<br />
+  reversible step also used in gluconeogenesis. Physiologically gluconeogenesis is<br />
+  liver/kidney (which express PGAM1, not PGAM2 — muscle does not do gluconeogenesis).<br />
+  Reaction chemistry is shared but the muscle isoform's physiological role is glycolysis.<br />
+  Keep the Reactome TAS as ACCEPT (reaction participates in the pathway) and KEEP_AS_NON_CORE<br />
+  for the Ensembl-orthology IEA (not the muscle isoform's core in-vivo role).<br />
+- GO:0007283 spermatogenesis (IEA Ensembl, from rat P16290): orthology-transfer, not a<br />
+  direct PGAM2 function; sperm express glycolytic enzymes but this is a phenotypic/context<br />
+  transfer. KEEP_AS_NON_CORE.<br />
+- GO:0046689 response to mercury ion (IEA Ensembl, rat P16290): PGAM M subunit is<br />
+  Hg-inhibitable (DiMauro 1981 used mercury inhibition to distinguish M vs BB isozymes),<br />
+  but "response to mercury ion" as a BP is an orthology artifact, not a core biological role<br />
+  → MARK_AS_OVER_ANNOTATED.<br />
+- GO:0006941 striated muscle contraction (IMP PMID:6262916): the deficiency causes<br />
+  exercise intolerance/cramps, but PGAM2 is not part of the contractile machinery; this is<br />
+  a downstream phenotype → MARK_AS_OVER_ANNOTATED.</p>
+<p>Cellular component:<br />
+- GO:0005829 cytosol (IBA; IEA GO_REF:0000107; TAS Reactome ×2): core location. ACCEPT (IBA).<br />
+- GO:0005634 nucleus (IEA Ensembl; HDA PMID:21630459 sperm-nucleus proteome): proteomic<br />
+  detection in isolated sperm nuclei; likely soluble-enzyme contamination / not the site of<br />
+  its enzymatic action → MARK_AS_OVER_ANNOTATED.<br />
+- GO:0005654 nucleoplasm (IDA HPA immunofluorescence, GO_REF:0000052): HPA IF; abundant<br />
+  glycolytic enzyme, nuclear signal not linked to a nuclear function → MARK_AS_OVER_ANNOTATED.<br />
+- GO:1990917 ooplasm (IEA Ensembl, rat P16290): orthology transfer to oocyte cytoplasm;<br />
+  not established for human muscle isoform → KEEP_AS_NON_CORE (it is still cytoplasm).<br />
+- GO:0070062 extracellular exosome (HDA PMID:23533145 prostatic-secretion exosomes):<br />
+  high-throughput exosome proteome; ubiquitous cytosolic enzyme frequently co-purifies →<br />
+  MARK_AS_OVER_ANNOTATED.</p>
+<h2 id="interactome-partners-from-uniprot-interaction-ipi-refs">Interactome partners (from UniProt INTERACTION + IPI refs)</h2>
+<ul>
+<li>BPGM P07738 (bisphosphoglycerate mutase) — recurrent, NbExp=6; biologically related enzyme.</li>
+<li>CLVS2 Q5SYC1, DYNC1LI1 Q9Y6G9, KATNAL1 Q9BW62 — Y2H/AP-MS partners, unclear functional link.</li>
+<li>PGAM2 P15259 self — homodimer.<br />
+These support only generic protein binding + identical protein binding; no informative<br />
+complex/adapter MF is warranted.</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<p>falcon deep-research provider is OUT OF CREDITS (HTTP 402) at review time; no<br />
+-deep-research-falcon.md was generated. Review grounded in UniProt (P15259), the seeded GOA,<br />
+cached PMIDs, and cached Reactome entries.<br />
+</content></p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P15259
+gene_symbol: PGAM2
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PGAM2 is the muscle (M) isoform of phosphoglycerate mutase, a cytosolic enzyme
+  of the cofactor-dependent phosphoglycerate mutase (histidine-phosphatase)
+  superfamily. It catalyzes the reversible interconversion of 3-phosphoglycerate
+  and 2-phosphoglycerate, the eighth step of the glycolytic payoff phase (and the
+  corresponding reverse step in gluconeogenesis). Catalysis proceeds through a
+  phospho-histidine enzyme intermediate and requires 2,3-bisphosphoglycerate as a
+  cofactor/primer; the enzyme also displays a minor bisphosphoglycerate
+  mutase/phosphatase side activity. Active human phosphoglycerate mutase is a
+  dimer assembled from muscle (PGAM2/M) and brain (PGAM1/B) subunits; skeletal
+  muscle expresses essentially the PGAM2 homodimer, whereas erythrocytes express
+  PGAM1. PGAM2 is expressed predominantly in heart and skeletal muscle.
+  Loss-of-function variants cause glycogen storage disease type X (muscle
+  phosphoglycerate mutase deficiency), manifesting as exercise intolerance,
+  muscle cramps, and myoglobinuria/rhabdomyolysis.
+existing_annotations:
+- term:
+    id: GO:0004619
+    label: phosphoglycerate mutase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of the core catalytic activity of PGAM2:
+      reversible interconversion of 3- and 2-phosphoglycerate. This is the
+      defining molecular function of the muscle phosphoglycerate mutase subunit
+      and is strongly corroborated by experimental and UniProt evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Core molecular function, correct at the right level of specificity, and
+      consistent across independent evidence lines (IBA, EXP, IMP, ISS, IEA) and
+      the UniProt catalytic-activity record (EC 5.4.2.11).
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate&#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic assignment of the cytosol as the site of action. Phosphoglycerate
+      mutase is a soluble cytosolic glycolytic enzyme, consistent with Reactome and
+      UniProt.
+    action: ACCEPT
+    reason: &gt;-
+      Correct subcellular location for a soluble glycolytic enzyme; agrees with
+      Reactome TAS cytosol annotations and with the entire glycolytic pathway being
+      cytosolic.
+    supported_by:
+    - reference_id: Reactome:R-HSA-71445
+      supporting_text: &#34;Cytosolic phosphoglycerate mutase dimers (PGAM1,2) catalyze the reversible isomerisation of 2- and 3-phosphoglycerate&#34;
+- term:
+    id: GO:0061621
+    label: canonical glycolysis
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic assignment of PGAM2 to canonical glycolysis (the ATP-generating
+      glucose-to-pyruvate route). PGAM catalyzes step 8 (3-PG to 2-PG) of the
+      glycolytic payoff phase.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process for the muscle glycolytic isoform, at an appropriate
+      level of specificity; corroborated by the Reactome Glycolysis pathway and by
+      the IMP glycolytic-process annotation.
+    supported_by:
+    - reference_id: Reactome:R-HSA-70171
+      supporting_text: &#34;The reactions of glycolysis (e.g., van Wijk and van Solinge 2005) convert&#34;
+- term:
+    id: GO:0003824
+    label: catalytic activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Root-level InterPro2GO mapping asserting generic catalytic activity. Not
+      incorrect but entirely uninformative given the specific mutase activity is
+      already annotated.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;catalytic activity&#34; is a top-level MF placeholder subsumed by the specific
+      phosphoglycerate mutase activity annotation; it adds no functional information.
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate&#34;
+- term:
+    id: GO:0004082
+    label: bisphosphoglycerate mutase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic mapping (EC 5.4.2.4 / RHEA:17765) of the minor bisphosphoglycerate
+      mutase side activity. UniProt records that the enzyme &#34;can also catalyze the
+      interconversion of (2R)-2,3-bisphosphoglycerate and (2R)-3-phospho-glyceroyl
+      phosphate, but with a reduced activity.&#34;
+    action: ACCEPT
+    reason: &gt;-
+      Genuine, documented secondary catalytic activity of the BPG-dependent PGAM
+      subfamily; correctly captured, though it is the reduced-activity side reaction
+      rather than the primary physiological function.
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC       3-phospho-glyceroyl phosphate, but with a reduced activity.&#34;
+- term:
+    id: GO:0004619
+    label: phosphoglycerate mutase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic mapping (EC 5.4.2.11 / RHEA:15901 / ARBA) of the core
+      phosphoglycerate mutase activity. Duplicate of the core MF from an automated
+      pipeline.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core molecular function; the automated EC/RHEA mapping agrees with the
+      experimental and phylogenetic annotations.
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate&#34;
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic assignment to the glycolytic process. Correct core pathway for
+      PGAM2, also supported experimentally by the deficiency phenotype (IMP).
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process; consistent with the IMP annotation from the muscle
+      PGAM deficiency case and with the canonical-glycolysis annotations.
+    supported_by:
+    - reference_id: PMID:6262916
+      supporting_text: &#34;Muscle phosphoglycerate mutase activity was decreased (5.7 percent of the lowest&#34;
+- term:
+    id: GO:0016868
+    label: intramolecular phosphotransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO mapping to intramolecular phosphotransferase activity, the
+      isomerase parent class (EC 5.4.2.-) that includes phosphoglycerate mutase.
+      Correct but more general than the specific mutase term already annotated.
+    action: ACCEPT
+    reason: &gt;-
+      Accurate parent-level molecular function; an IEA term is permitted to be
+      broader than the specific mutase activity, and it correctly reflects the
+      isomerase reaction chemistry (intramolecular phospho group transfer).
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: &gt;-
+      High-throughput AP-MS interactome (BioPlex 2.0) reporting a PGAM2-BPGM
+      (P07738) co-complex. Bare &#34;protein binding&#34; is uninformative about molecular
+      function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation guidance, bare &#34;protein binding&#34; is not an informative molecular
+      function and this is an interactome-screen IPI. The recurrent BPGM partner is
+      biologically plausible (both enzymes act on 2,3-bisphosphoglycerate) but does
+      not itself define a specific molecular function; retained (not removed) as an
+      experimental IPI.
+    supported_by:
+    - reference_id: PMID:28514442
+      supporting_text: &#34;BioPlex 2.0 is the largest collection of human co-complex data assembled from a single pipeline to date&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Binary interactome map (HuRI, yeast two-hybrid) reporting PGAM2 interactions
+      (e.g. BPGM, CLVS2, DYNC1LI1, KATNAL1). Bare &#34;protein binding&#34; is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative generic &#34;protein binding&#34; from a systematic binary-interactome
+      screen; retained as an experimental IPI but not treated as a defining function.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &#34;A reference map of the human binary protein interactome.&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      High-throughput AP-MS interactome (BioPlex 3.0) again reporting a PGAM2-BPGM
+      (P07738) association. Bare &#34;protein binding&#34; is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic &#34;protein binding&#34; from an interactome screen; consistent with the
+      other BioPlex/HuRI evidence but non-specific; retained as an experimental IPI.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: &#34;Dual proteome-scale networks reveal cell-specific remodeling of the human&#34;
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Self-interaction of PGAM2 (P15259-P15259) detected in the binary interactome
+      map, consistent with the established homodimeric quaternary structure of
+      phosphoglycerate mutase.
+    action: ACCEPT
+    reason: &gt;-
+      Informative self-association annotation that matches the documented homodimer;
+      UniProt SUBUNIT states &#34;Homodimer&#34; and Reactome describes the active enzyme as
+      a dimer.
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC   -!- SUBUNIT: Homodimer. Interacts with ENO1. {ECO:0000250|UniProtKB:O70250,&#34;
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Orthology-based (Ensembl Compara, from rat P16290) transfer of a nuclear
+      localization. PGAM2 is a soluble cytosolic glycolytic enzyme; a nuclear
+      location is not associated with any established nuclear function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Nuclear localization is not part of the core biology of this cytosolic enzyme;
+      it derives from orthology transfer plus proteomic detection in sperm nuclei and
+      likely reflects contamination/moonlighting rather than a functional nuclear role.
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC   -!- SUBUNIT: Homodimer. Interacts with ENO1. {ECO:0000250|UniProtKB:O70250,&#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Orthology-based (Ensembl Compara, from mouse O70250) assignment of the cytosol
+      as site of action. Correct core location for a glycolytic enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Agrees with the IBA and Reactome TAS cytosol annotations; correct compartment
+      for phosphoglycerate mutase activity.
+    supported_by:
+    - reference_id: Reactome:R-HSA-71445
+      supporting_text: &#34;Cytosolic phosphoglycerate mutase dimers (PGAM1,2) catalyze the reversible isomerisation of 2- and 3-phosphoglycerate&#34;
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Orthology-based (Ensembl Compara) assignment to gluconeogenesis. The
+      phosphoglycerate mutase reaction is reversible and is shared with the
+      gluconeogenic direction, but physiological gluconeogenesis is confined to
+      liver and kidney, which express PGAM1 rather than the muscle PGAM2 isoform.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The reaction chemistry participates in gluconeogenesis, but the muscle isoform&#39;s
+      core in-vivo role is glycolytic; muscle does not perform gluconeogenesis, so this
+      is retained as a non-core, reaction-shared process rather than PGAM2&#39;s primary
+      physiological function.
+    supported_by:
+    - reference_id: Reactome:R-HSA-70263
+      supporting_text: &#34;Gluconeogenesis is confined to cells of the liver and kidney&#34;
+- term:
+    id: GO:0007283
+    label: spermatogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Orthology-based (Ensembl Compara, from rat P16290) transfer of a spermatogenesis
+      role. Sperm rely heavily on glycolysis, but a direct role of the muscle PGAM2
+      isoform in spermatogenesis is not established in human.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Speculative context transferred by orthology; not a core molecular/biological
+      function of the human muscle isoform. Retained as non-core rather than removed,
+      since it is a plausible tissue context for a glycolytic enzyme.
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC   -!- TISSUE SPECIFICITY: Expressed in the heart and muscle. Not found in the&#34;
+- term:
+    id: GO:0046689
+    label: response to mercury ion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Orthology-based (Ensembl Compara, from rat P16290) transfer of a
+      &#34;response to mercury ion&#34; process. The M subunit is mercury-inhibitable in vitro
+      (historically used to distinguish M from BB isozymes), but this is an
+      enzyme-property observation, not a biological response process of human PGAM2.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;response to mercury ion&#34; as a biological process is an orthology artifact and
+      does not represent a core biological role of PGAM2; in-vitro Hg sensitivity of the
+      catalytic His does not constitute a cellular mercury-response pathway.
+    supported_by:
+    - reference_id: PMID:6262916
+      supporting_text: &#34;Electrophoretic, &#34;
+- term:
+    id: GO:0061621
+    label: canonical glycolysis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Orthology-based (Ensembl Compara, from mouse O70250) assignment to canonical
+      glycolysis. Correct core process; duplicate of the IBA/TAS glycolysis
+      annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Core glycolytic process for the muscle isoform, consistent with all other
+      glycolysis evidence lines.
+    supported_by:
+    - reference_id: Reactome:R-HSA-70171
+      supporting_text: &#34;The reactions of glycolysis (e.g., van Wijk and van Solinge 2005) convert&#34;
+- term:
+    id: GO:1990917
+    label: ooplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Orthology-based (Ensembl Compara, from rat P16290) transfer of an ooplasm
+      (oocyte cytoplasm) location. This is a tissue-context transfer; the compartment
+      (cytoplasm) is consistent with a cytosolic enzyme, but the specific ooplasmic
+      localization is not established for the human muscle isoform.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Cytoplasmic location is consistent with PGAM2 biology, but &#34;ooplasm&#34; is an
+      orthology-derived tissue-specific location not relevant to the muscle isoform&#39;s
+      core role; retained as non-core rather than removed.
+    supported_by:
+    - reference_id: Reactome:R-HSA-71445
+      supporting_text: &#34;Cytosolic phosphoglycerate mutase dimers (PGAM1,2) catalyze the reversible isomerisation of 2- and 3-phosphoglycerate&#34;
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70263
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome pathway annotation placing the reversible phosphoglycerate mutase
+      reaction within gluconeogenesis. The reaction is genuinely part of the
+      gluconeogenic sequence (a reverse-of-glycolysis step).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The PGAM reaction participates in the gluconeogenesis pathway as modeled by
+      Reactome, so the annotation is not wrong; however gluconeogenesis is a
+      liver/kidney process (PGAM1), so it is not the core physiological role of the
+      muscle PGAM2 isoform. Retained as non-core.
+    supported_by:
+    - reference_id: Reactome:R-HSA-70263
+      supporting_text: &#34;Gluconeogenesis is confined to cells of the liver and kidney&#34;
+- term:
+    id: GO:0061621
+    label: canonical glycolysis
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70171
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome pathway annotation placing PGAM within canonical glycolysis (the
+      cytosolic glucose-to-pyruvate route). Core process for PGAM2.
+    action: ACCEPT
+    reason: &gt;-
+      Authoritative pathway (TAS) annotation for the core glycolytic role; consistent
+      with all other glycolysis evidence.
+    supported_by:
+    - reference_id: Reactome:R-HSA-70171
+      supporting_text: &#34;The reactions of glycolysis (e.g., van Wijk and van Solinge 2005) convert&#34;
+- term:
+    id: GO:0004619
+    label: phosphoglycerate mutase activity
+  evidence_type: EXP
+  original_reference_id: PMID:4827367
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental annotation of phosphoglycerate mutase activity based on
+      characterization of the human PGAM isozymes as tissue-differentiation markers
+      (Omenn &amp; Cheung 1974), which established the muscle (M) versus brain (B) subunit
+      isozyme system.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental support for the core catalytic activity of the muscle
+      phosphoglycerate mutase isozyme; foundational isozyme-characterization work.
+    supported_by:
+    - reference_id: PMID:4827367
+      supporting_text: &#34;Phosphoglycerate mutase isozyme marker for tissue differentiation in man.&#34;
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Human Protein Atlas immunofluorescence (IDA) reporting nucleoplasmic signal.
+      PGAM2 is an abundant soluble cytosolic enzyme; nucleoplasmic staining is not
+      linked to any established nuclear function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      A single-technique IF localization for an abundant cytosolic glycolytic enzyme,
+      without a corresponding nuclear function; likely reflects the diffuse
+      distribution/permeabilization artifacts common for soluble enzymes rather than a
+      core nucleoplasmic role.
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC   -!- SUBUNIT: Homodimer. Interacts with ENO1. {ECO:0000250|UniProtKB:O70250,&#34;
+- term:
+    id: GO:0004082
+    label: bisphosphoglycerate mutase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-similarity transfer (from PGAM1, P18669) of the minor
+      bisphosphoglycerate mutase activity. Consistent with the UniProt-documented
+      reduced-activity side reaction of the BPG-dependent PGAM subfamily.
+    action: ACCEPT
+    reason: &gt;-
+      Genuine secondary catalytic activity supported by family membership and the
+      UniProt catalytic-activity record (EC 5.4.2.4); appropriately marked as a
+      similarity-based inference.
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC       3-phospho-glyceroyl phosphate, but with a reduced activity.&#34;
+- term:
+    id: GO:0004619
+    label: phosphoglycerate mutase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-similarity transfer (from PGAM1, P18669) of the core phosphoglycerate
+      mutase activity. Duplicate of the well-supported core MF.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core molecular function; the ISS inference agrees with experimental,
+      phylogenetic, and automated evidence.
+    supported_by:
+    - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+      supporting_text: &#34;CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate&#34;
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:23533145
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomic detection in exosomes from expressed prostatic
+      secretions in urine. PGAM2 is a ubiquitous soluble cytosolic enzyme that
+      commonly co-purifies in exosome/secretome proteomes.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      A single high-throughput exosome-proteome detection does not establish
+      extracellular exosome as a functional location for this cytosolic glycolytic
+      enzyme; frequent contaminant in such datasets.
+    supported_by:
+    - reference_id: PMID:23533145
+      supporting_text: &#34;In-depth proteomic analyses of exosomes isolated from expressed prostatic&#34;
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: HDA
+  original_reference_id: PMID:21630459
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomic detection of PGAM in isolated human sperm nuclei.
+      Nuclear detection of an abundant soluble glycolytic enzyme in a whole-organelle
+      proteome does not establish a functional nuclear role.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Proteomic co-detection in a sperm-nucleus preparation is prone to soluble-enzyme
+      carryover; there is no established nuclear function for PGAM2, so this is an
+      over-annotation of its core cytosolic biology.
+    supported_by:
+    - reference_id: PMID:21630459
+      supporting_text: &#34;sperm nuclei were obtained &#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71445
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation of the cytosol as the location where PGAM dimers
+      isomerise 2PG to 3PG. Core, correct location.
+    action: ACCEPT
+    reason: &gt;-
+      Authoritative pathway annotation of the correct compartment for a cytosolic
+      glycolytic enzyme.
+    supported_by:
+    - reference_id: Reactome:R-HSA-71445
+      supporting_text: &#34;Cytosolic phosphoglycerate mutase dimers (PGAM1,2) catalyze the reversible isomerisation of 2- and 3-phosphoglycerate&#34;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71654
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation of the cytosol as the location where PGAM dimers
+      isomerise 3PG to 2PG. Core, correct location (duplicate direction of the same
+      reversible reaction).
+    action: ACCEPT
+    reason: &gt;-
+      Authoritative pathway annotation of the correct cytosolic compartment.
+    supported_by:
+    - reference_id: Reactome:R-HSA-71654
+      supporting_text: &#34;Cytosolic phosphoglycerate mutase catalyzes the reversible isomerisation&#34;
+- term:
+    id: GO:0004619
+    label: phosphoglycerate mutase activity
+  evidence_type: IMP
+  original_reference_id: PMID:6262916
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (IMP) support from the first described human muscle
+      phosphoglycerate mutase deficiency: muscle PGAM activity was reduced to 5.7% of
+      the lowest control value, with the residual activity being the brain (BB)
+      isoenzyme, implicating loss of the M subunit encoded by PGAM2.
+    action: ACCEPT
+    reason: &gt;-
+      Direct genetic/biochemical evidence in humans that PGAM2 provides
+      phosphoglycerate mutase activity in muscle; the disease phenotype tracks the
+      loss of M-subunit activity.
+    supported_by:
+    - reference_id: PMID:6262916
+      supporting_text: &#34;Muscle phosphoglycerate mutase activity was decreased (5.7 percent of the lowest&#34;
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IMP
+  original_reference_id: PMID:6262916
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) support that PGAM2 functions in glycolysis: the muscle PGAM
+      deficiency produces a block at the phosphoglycerate mutase step of glycolysis
+      while all other glycolytic enzymes had normal activities.
+    action: ACCEPT
+    reason: &gt;-
+      Human loss-of-function evidence directly linking PGAM2 to the glycolytic
+      process; the specific enzymatic block defines its glycolytic role.
+    supported_by:
+    - reference_id: PMID:6262916
+      supporting_text: &#34;All of the other enzymes of glycolysis &#34;
+- term:
+    id: GO:0006941
+    label: striated muscle contraction
+  evidence_type: IMP
+  original_reference_id: PMID:6262916
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Annotation to striated muscle contraction derived from the muscle PGAM
+      deficiency phenotype (exercise intolerance, cramps, pigmenturia). PGAM2 is a
+      glycolytic enzyme, not a component of the contractile apparatus.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Exercise intolerance and cramps in PGAM deficiency are downstream consequences
+      of impaired muscle glycolytic ATP supply, not evidence that PGAM2 participates
+      directly in the muscle-contraction process; the causal role is glycolysis. This
+      is an over-annotation of a phenotype (retained rather than removed as it derives
+      from an experimental report).
+    supported_by:
+    - reference_id: PMID:6262916
+      supporting_text: &#34;intolerance for strenuous exercise and &#34;
+core_functions:
+- description: &gt;-
+    Catalyzes the reversible, 2,3-bisphosphoglycerate-dependent interconversion of
+    3-phosphoglycerate and 2-phosphoglycerate via a phospho-histidine intermediate,
+    the eighth step of glycolysis, in the cytosol of skeletal and cardiac muscle.
+  molecular_function:
+    id: GO:0004619
+    label: phosphoglycerate mutase activity
+  directly_involved_in:
+  - id: GO:0006096
+    label: glycolytic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: file:human/PGAM2/PGAM2-uniprot.txt
+    supporting_text: &#34;CC   -!- FUNCTION: Catalyzes the interconversion of 3- and 2-phosphoglycerate&#34;
+  - reference_id: PMID:6262916
+    supporting_text: &#34;Muscle phosphoglycerate mutase activity was decreased (5.7 percent of the lowest&#34;
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:21630459
+  title: Proteomic characterization of the human sperm nucleus.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Sperm-nucleus proteome; PGAM detected as one of 403 proteins. Supports the
+      nucleus HDA localization but is a high-throughput co-detection with no
+      functional nuclear role; over-annotation for a cytosolic enzyme.
+- id: PMID:23533145
+  title: In-depth proteomic analyses of exosomes isolated from expressed prostatic
+    secretions in urine.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Exosome proteome from prostatic secretions; PGAM detected as a high-throughput
+      co-purifying protein. Supports the exosome HDA localization only; over-annotation.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex 2.0 AP-MS interactome; source of a PGAM2-BPGM protein-binding IPI.
+      Supports only generic protein binding, not a specific molecular function.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      HuRI binary (Y2H) interactome; source of protein-binding IPIs and the PGAM2
+      self-interaction (identical protein binding), consistent with the homodimer.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex 3.0 AP-MS interactome; source of a PGAM2-BPGM protein-binding IPI.
+      Generic protein binding only.
+- id: PMID:4827367
+  title: Phosphoglycerate mutase isozyme marker for tissue differentiation in man.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Foundational characterization of human PGAM isozymes (M vs B subunits) as
+      tissue-differentiation markers; underpins the EXP phosphoglycerate mutase
+      activity annotation.
+- id: PMID:6262916
+  title: &#39;Human muscle phosphoglycerate mutase deficiency: newly discovered metabolic
+    myopathy.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      First description of human muscle PGAM deficiency (GSD X): muscle PGAM activity
+      5.7% of control, residual activity is BB isozyme, implicating the M subunit.
+      Directly supports the core catalytic and glycolytic roles of PGAM2; the
+      muscle-contraction annotation from this paper is a downstream phenotype.
+- id: Reactome:R-HSA-70171
+  title: Glycolysis
+  findings: []
+- id: Reactome:R-HSA-70263
+  title: Gluconeogenesis
+  findings: []
+- id: Reactome:R-HSA-71445
+  title: PGAM dimers isomerise 2PG to 3PG
+  findings: []
+- id: Reactome:R-HSA-71654
+  title: PGAM dimers isomerise 3PG to 2PG
+  findings: []
+- id: file:human/PGAM2/PGAM2-uniprot.txt
+  title: UniProt entry P15259 (PGAM2_HUMAN)
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PGK1/PGK1-ai-review.html
+++ b/genes/human/PGK1/PGK1-ai-review.html
@@ -1,0 +1,7655 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PGK1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PGK1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P00558" target="_blank" class="term-link">
+                        P00558
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PGK1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P00558" data-a="DESCRIPTION: Phosphoglycerate kinase 1 is the enzyme that catal..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Phosphoglycerate kinase 1 is the enzyme that catalyzes the first ATP-generating (substrate-level phosphorylation) step of the glycolytic payoff phase, reversibly transferring a phosphate between 1,3-bisphosphoglycerate + ADP and 3-phosphoglycerate + ATP (EC 2.7.2.3); the reverse reaction operates in gluconeogenesis. It is a cytosolic, monomeric, Mg2+-dependent enzyme that is X-linked and ubiquitously expressed. Beyond glycolysis, PGK1 has documented moonlighting activities, including a secreted extracellular disulfide-reductase activity that liberates the angiogenesis inhibitor angiostatin from plasmin, and, under hypoxic or oncogenic conditions, a mitochondrially-translocated protein kinase activity that phosphorylates PDHK1 to suppress pyruvate oxidation and promote aerobic glycolysis (the Warburg effect). Loss-of-function variants cause phosphoglycerate kinase 1 deficiency, an X-linked disorder combining hemolytic anemia, myopathy (exercise intolerance and rhabdomyolysis) and central nervous system involvement.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004618" target="_blank" class="term-link">
+                                    GO:0004618
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0004618" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation of the core catalytic molecular function, phosphoglycerate kinase activity, shared across the PGK family. This is the defining, well-supported function of PGK1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core molecular function of PGK1, catalyzing the reversible 1,3-bisphosphoglycerate + ADP &lt;-&gt; 3-phosphoglycerate + ATP reaction, and is independently supported by direct experimental and structural evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                        PMID:26942675
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Phosphoglycerate kinase 1 (PGK1), the first ATP-generating enzyme in the glycolytic pathway, catalyzes the transfer of the high-energy phosphate from the 1-position of 1,3-diphosphoglycerate (1,3-BPG) to ADP, which leads to the generation of 3-phosphoglycerate (3-PG) and ATP</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043531" target="_blank" class="term-link">
+                                    GO:0043531
+                                </a>
+                            </span>
+                            <span class="term-label">ADP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0043531" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic annotation of ADP binding, reflecting the substrate/product nucleotide bound during catalysis (ADP is the phosphate acceptor in the glycolytic direction).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ADP is a bona fide substrate of the phosphoglycerate kinase reaction, and structural studies confirm nucleotide binding in the C-terminal domain. This supports the core catalytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Reaction=(2R)-3-phosphoglycerate + ATP = (2R)-3-phospho-glyceroyl phosphate + ADP</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005829" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic annotation placing PGK1 activity in the cytosol, the principal compartment where glycolysis occurs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytosol is the true core cellular location of PGK1&#39;s glycolytic activity, consistent with direct experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm, cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0006096" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic annotation of involvement in the glycolytic process, the central biological role of PGK1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PGK1 catalyzes step 2/5 of the conversion of glyceraldehyde-3-phosphate to pyruvate and is one of only two ATP-generating enzymes in glycolysis. This is a core biological process for the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from D-glyceraldehyde 3-phosphate: step 2/5.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005524" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic annotation of ATP binding, reflecting the nucleotide substrate/product of the phosphoglycerate kinase reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP is a direct substrate/product of the catalyzed reaction and its binding is documented by kinetic (KM for ATP) and structural analyses. Supports the core catalytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">KM=0.56 mM for ATP</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0006094" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic annotation of involvement in gluconeogenesis, the biosynthetic direction of the reversible PGK reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The phosphoglycerate kinase reaction is reversible, and the right-to-left (ATP-consuming) direction is used in gluconeogenesis. This is a legitimate core biological role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:14803</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004618" target="_blank" class="term-link">
+                                    GO:0004618
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0004618" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (multiple IEA methods, incl. ARBA, InterPro, RHEA, EC 2.7.2.3) of the core phosphoglycerate kinase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with, and consistent with, experimental and phylogenetic support for the core catalytic function; the InterPro/EC/RHEA mapping is correct for this family.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.7.2.3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    GO:0004674
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000003
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0004674" data-r="GO_REF:0000003" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation derived from the EC 2.7.11.1 mapping, corresponding to the documented moonlighting protein kinase activity of PGK1 (phosphorylating PDHK1). The generic EC-to-GO mapping is broad but the underlying activity is real.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PGK1 has an experimentally validated moonlighting protein kinase activity, but this is a context-specific (hypoxia/oncogenic, mitochondrial) function, distinct from its core cytosolic glycolytic role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                        PMID:26942675
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mitochondrial PGK1, acting as a protein kinase, phosphorylates and activates PDHK1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (UniProt SubCell mapping) of mitochondrial matrix localization, matching the experimentally documented hypoxia/oncogene-induced mitochondrial translocation of PGK1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PGK1 is imported into the mitochondrial matrix only under specific conditions (hypoxia, oncogenic signalling) as part of its moonlighting protein kinase role; it is not the core cytosolic glycolytic location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                        PMID:26942675
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mitochondrial translocation of PGK1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005829" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation of cytosolic localization, consistent with the core glycolytic compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytosol is the principal, core subcellular location of PGK1, agreeing with direct experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm, cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0006096" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (InterPro/UniPathway) of involvement in glycolysis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the core glycolytic role of PGK1; the pathway mapping is correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PATHWAY: Carbohydrate degradation; glycolysis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106310" target="_blank" class="term-link">
+                                    GO:0106310
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000116
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0106310" data-r="GO_REF:0000116" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (RHEA:17989) annotation of protein serine kinase activity, corresponding to the documented moonlighting phosphorylation of PDHK1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This reflects a real but context-specific, non-core moonlighting activity of mitochondria-translocated PGK1, distinct from its principal glycolytic role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                        PMID:26942675
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mitochondrial PGK1, acting as a protein kinase, phosphorylates and activates PDHK1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20392205" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20392205
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Loose interaction between glyceraldehyde-3-phosphate dehydro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:20392205" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction of PGK1 with GAPDH (P04406), captured only as the uninformative generic term protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding does not convey a specific molecular function. The GAPDH-PGK1 interaction reflects the physical proximity of consecutive glycolytic enzymes but is not annotated to an informative function term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20392205" target="_blank" class="term-link">
+                                        PMID:20392205
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Loose interaction between glyceraldehyde-3-phosphate dehydrogenase and phosphoglycerate kinase revealed by fluorescence resonance energy transfer-fluorescence lifetime imaging microscopy in living cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20849852" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20849852
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proliferating cell nuclear antigen in the cytoplasm interact...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:20849852" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction of PGK1 with PCNA (P12004), captured only as the generic term protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative. The interaction with PCNA relates to cytoplasmic PCNA associating with glycolytic enzymes but is not tied to a specific molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20849852" target="_blank" class="term-link">
+                                        PMID:20849852
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Proliferating cell nuclear antigen in the cytoplasm interacts with components of glycolysis and cancer.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26030842" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26030842
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A fluorescent bimolecular complementation screen reveals MAF...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:26030842" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction of PGK1 with PCNA (P12004) from a bimolecular complementation screen, captured only as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding provides no informative molecular function for PGK1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26030842" target="_blank" class="term-link">
+                                        PMID:26030842
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A fluorescent bimolecular complementation screen reveals MAF1, RNF7 and SETD3 as PCNA-associated proteins in human cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26356530" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26356530
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Insulin and mTOR Pathway Regulate HDAC3-Mediated Deacetylati...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:26356530" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction of PGK1 with HDAC3 (O15379). HDAC3 deacetylates PGK1 at K220 to activate it; a regulatory interaction, but here captured only as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative. The functionally meaningful content (HDAC3-mediated deacetylation/activation of PGK1) is regulatory and is better described elsewhere; the term itself conveys no specific PGK1 molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26356530" target="_blank" class="term-link">
+                                        PMID:26356530
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">HDAC3 deacetylates and activates PGK1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput interactome interaction with PGK2 (P07205), captured only as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative; PGK2 is the closely related testis paralog and this high-throughput interaction conveys no specific function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                                        PMID:28514442
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32707033" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32707033
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Kinase Interaction Network Expands Functional and Disease Ro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:32707033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Kinase interaction-network interaction with NEK7 (Q8TDX7), captured only as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative for molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32707033" target="_blank" class="term-link">
+                                        PMID:32707033
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Kinase Interaction Network Expands Functional and Disease Roles of Human Kinases.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proteome-scale interactome interaction with PGK2 (P07205), captured only as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative; a high-throughput paralog interaction with no specified function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35271311
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    OpenCell: Endogenous tagging for the cartography of human ce...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:35271311" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Endogenous-tagging (OpenCell) interaction with PGK2 (P07205), captured only as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative for molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
+                                        PMID:35271311
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0006094" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl orthology (from mouse P09411) electronic transfer of involvement in gluconeogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the reversible PGK reaction being used in the gluconeogenic direction; the orthology transfer is appropriate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:14803</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044325" target="_blank" class="term-link">
+                                    GO:0044325
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transporter binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0044325" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl orthology (from mouse P09411) electronic transfer of transmembrane transporter binding. There is no strong human evidence for a specific transporter-binding function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is an orthology-transferred electronic annotation with no corroborating human experimental evidence and no specific transporter named; it is uninformative and not part of the core function of PGK1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SIMILARITY: Belongs to the phosphoglycerate kinase family.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061621" target="_blank" class="term-link">
+                                    GO:0061621
+                                </a>
+                            </span>
+                            <span class="term-label">canonical glycolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0061621" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (ARBA) of involvement in canonical glycolysis, a more specific child of glycolytic process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Canonical glycolysis (Embden-Meyerhof-Parnas) is precisely the pathway in which PGK1 operates; this is a correct, appropriately specific core BP term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from D-glyceraldehyde 3-phosphate: step 2/5.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                    GO:0006094
+                                </a>
+                            </span>
+                            <span class="term-label">gluconeogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70263
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0006094" data-r="Reactome:R-HSA-70263" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement annotation of involvement in gluconeogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PGK1 is a Reactome-curated participant in the gluconeogenesis pathway (the reverse glycolytic direction); a legitimate core biological role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:14803</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061621" target="_blank" class="term-link">
+                                    GO:0061621
+                                </a>
+                            </span>
+                            <span class="term-label">canonical glycolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70171
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0061621" data-r="Reactome:R-HSA-70171" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement annotation of involvement in canonical glycolysis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PGK1 is a Reactome-curated participant in the glycolysis pathway; an appropriately specific core biological process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from D-glyceraldehyde 3-phosphate: step 2/5.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004618" target="_blank" class="term-link">
+                                    GO:0004618
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1278465" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1278465
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of phosphoglycerate kinase from human sperm...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0004618" data-r="PMID:1278465" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental characterization of phosphoglycerate kinase activity from human tissue (spermatozoa), confirming the core enzymatic function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for phosphoglycerate kinase activity; this is the core molecular function of PGK1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1278465" target="_blank" class="term-link">
+                                        PMID:1278465
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We have confirmed the presence of a unique electrophoretic isoenzyme of phosphoglycerate kinase (PGK) in homogenate extracts of human sperm.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004618" target="_blank" class="term-link">
+                                    GO:0004618
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/5009693" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:5009693
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human phosphoglycerate kinase. I. Crystallization and charac...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0004618" data-r="PMID:5009693" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental crystallization and characterization of the normal human phosphoglycerate kinase enzyme, establishing the core catalytic function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental characterization of the purified enzyme supports the core phosphoglycerate kinase molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/5009693" target="_blank" class="term-link">
+                                        PMID:5009693
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human phosphoglycerate kinase. I. Crystallization and characterization of normal enzyme.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    GO:0004674
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9975250
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0004674" data-r="Reactome:R-HSA-9975250" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement annotation of the moonlighting protein serine/threonine kinase activity (PGK1 phosphorylating AKT1S1/PRAS40).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects the documented but context-specific moonlighting protein kinase activity of PGK1, not its core glycolytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                        PMID:26942675
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mitochondrial PGK1, acting as a protein kinase, phosphorylates and activates PDHK1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004618" target="_blank" class="term-link">
+                                    GO:0004618
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30323285" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30323285
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A metabolite-derived protein modification integrates glycoly...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0004618" data-r="PMID:30323285" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental study characterizing PGK1 as a glycolytic enzyme and identifying a small-molecule inhibitor (CBR-470-0), confirming its catalytic activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for the core phosphoglycerate kinase activity (EC 2.7.2.3); the inhibitor study depends on and confirms the enzymatic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30323285" target="_blank" class="term-link">
+                                        PMID:30323285
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identify a small-molecule inhibitor of the glycolytic enzyme PGK1, and reveal</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106310" target="_blank" class="term-link">
+                                    GO:0106310
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26942675
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-Translocated PGK1 Functions as a Protein Kinase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0106310" data-r="PMID:26942675" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental demonstration that mitochondria-translocated PGK1 acts as a protein kinase, phosphorylating PDHK1 on a serine/threonine residue.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a genuine, experimentally validated moonlighting activity, but it is context-specific (hypoxia/oncogenic, mitochondrial) and distinct from the core cytosolic glycolytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                        PMID:26942675
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The current study shows that highly purified PGK1 with no obvious protein kinase contamination phosphorylated highly purified PDHK1 supporting that glycolytic enzymes can possess dual enzymatic activities, functioning both as metabolic enzymes and protein kinases.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    GO:0004674
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26942675
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-Translocated PGK1 Functions as a Protein Kinase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0004674" data-r="PMID:26942675" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay demonstrating PGK1 protein serine/threonine kinase activity toward PDHK1 (T338).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally validated moonlighting protein kinase activity of mitochondrial PGK1; non-core relative to the principal glycolytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                        PMID:26942675
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">protein kinase to phosphorylate pyruvate dehydrogenase kinase 1 (PDHK1) at T338</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160218" target="_blank" class="term-link">
+                                    GO:0160218
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of pyruvate decarboxylation to acetyl-CoA</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26942675
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-Translocated PGK1 Functions as a Protein Kinase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0160218" data-r="PMID:26942675" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence that PGK1-mediated phosphorylation/activation of PDHK1 leads to inhibition of the pyruvate dehydrogenase complex, suppressing pyruvate decarboxylation to acetyl-CoA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A biologically meaningful consequence of the moonlighting mitochondrial kinase activity; it is a context-specific regulatory role rather than the core glycolytic function of PGK1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                        PMID:26942675
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which activates PDHK1 to phosphorylate and inhibit the pyruvate dehydrogenase (PDH) complex. This reduces mitochondrial pyruvate utilization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26942675
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-Translocated PGK1 Functions as a Protein Kinase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:26942675" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curated interaction of PGK1 with MAPK1/ERK2 (P28482), captured only as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative. The MAPK1 interaction (which phosphorylates PGK1 at S203 to promote mitochondrial import) is regulatory, but the term itself conveys no specific PGK1 molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interacts with kinase MAPK1/ERK2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26942675
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-Translocated PGK1 Functions as a Protein Kinase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:26942675" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curated interaction of PGK1 with peptidyl-prolyl isomerase PIN1 (Q13526), captured only as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative for molecular function; the PIN1 interaction is regulatory (targeting to mitochondrion) rather than a specific function term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">peptidyl-prolyl cis-trans isomerase PIN1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26942675
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-Translocated PGK1 Functions as a Protein Kinase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005515" data-r="PMID:26942675" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curated interaction of PGK1 with pyruvate dehydrogenase kinase PDK1/PDHK1 (Q15118), captured only as generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding is uninformative; the functionally relevant content (PGK1 phosphorylating PDHK1) is already captured by the kinase and pyruvate regulation annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interacts with pyruvate dehydrogenase kinase PDK1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26942675
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-Translocated PGK1 Functions as a Protein Kinase...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005759" data-r="PMID:26942675" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence that PGK1 is translocated to the mitochondrion under hypoxic/oncogenic conditions where it acts as a protein kinase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mitochondrial matrix localization is condition-dependent and tied to the moonlighting kinase role, not the core cytosolic glycolytic location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                        PMID:26942675
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mitochondrial translocation of PGK1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36849569" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36849569
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    mcPGK1-dependent mitochondrial import of PGK1 promotes metab...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005759" data-r="PMID:36849569" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence that the mitochondrial circRNA mcPGK1 promotes import of PGK1 into mitochondria in liver tumour-initiating cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Confirms condition-dependent mitochondrial localization of PGK1, part of its moonlighting function; not the core cytosolic location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36849569" target="_blank" class="term-link">
+                                        PMID:36849569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mcPGK1 promotes the mitochondrial localization of PGK1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36849569" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36849569
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    mcPGK1-dependent mitochondrial import of PGK1 promotes metab...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005829" data-r="PMID:36849569" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence that PGK1 is present in the cytosol (with a fraction redistributing to mitochondria).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytosol is the principal, core subcellular location of PGK1 where it performs glycolysis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36849569" target="_blank" class="term-link">
+                                        PMID:36849569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mcPGK1 was predominantly localized in mitochondria and also detectable in cytoplasm</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004618" target="_blank" class="term-link">
+                                    GO:0004618
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7391028" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7391028
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A single amino acid substitution (Asp leads to Asn) in a pho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0004618" data-r="PMID:7391028" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Characterization of the PGK Munchen deficiency variant (Asp268Asn), linking a single amino acid substitution to reduced enzyme activity and thereby confirming the phosphoglycerate kinase molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A loss-of-function disease variant that reduces enzymatic activity provides genetic (IMP) support for the core phosphoglycerate kinase function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7391028" target="_blank" class="term-link">
+                                        PMID:7391028
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A single amino acid substitution (Asp leads to Asn) in a phosphoglycerate kinase variant (PGK München) associated with enzyme deficiency.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7391028" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7391028
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A single amino acid substitution (Asp leads to Asn) in a pho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0006096" data-r="PMID:7391028" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The PGK Munchen deficiency variant impairs glycolytic flux, supporting PGK1&#39;s involvement in the glycolytic process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genetic evidence from an enzyme-deficiency variant supports the core biological role of PGK1 in glycolysis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7391028" target="_blank" class="term-link">
+                                        PMID:7391028
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">phosphoglycerate kinase variant (PGK München) associated with enzyme deficiency</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11130727" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11130727
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphoglycerate kinase acts in tumour angiogenesis as a dis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005576" data-r="PMID:11130727" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PGK1 is secreted by tumour cells into the extracellular milieu, where it acts as a plasmin/disulfide reductase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A documented moonlighting extracellular localization tied to the secreted disulfide-reductase/angiogenesis function; not the core cytosolic glycolytic location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11130727" target="_blank" class="term-link">
+                                        PMID:11130727
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">phosphoglycerate kinase not only functions in glycolysis but is secreted by tumour cells and participates in the angiogenic process as a disulphide reductase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016525" target="_blank" class="term-link">
+                                    GO:0016525
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of angiogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11130727" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11130727
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphoglycerate kinase acts in tumour angiogenesis as a dis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0016525" data-r="PMID:11130727" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Administration of PGK1 to tumour-bearing mice increased plasma angiostatin and reduced tumour vascularity, implicating secreted PGK1 in negative regulation of angiogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A moonlighting function of secreted PGK1 (via angiostatin release), not the core glycolytic role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11130727" target="_blank" class="term-link">
+                                        PMID:11130727
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Administration of phosphoglycerate kinase to tumour-bearing mice caused an increase in plasma levels of angiostatin, and a decrease in tumour vascularity and rate of tumour growth.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031639" target="_blank" class="term-link">
+                                    GO:0031639
+                                </a>
+                            </span>
+                            <span class="term-label">plasminogen activation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11130727" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11130727
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphoglycerate kinase acts in tumour angiogenesis as a dis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0031639" data-r="PMID:11130727" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Secreted PGK1 reduces disulfide bonds in plasmin, initiating proteolytic cleavage and angiostatin release.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Part of the secreted disulfide-reductase moonlighting function; not the core glycolytic role. The term captures PGK1&#39;s action on the plasmin(ogen) system.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11130727" target="_blank" class="term-link">
+                                        PMID:11130727
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Reduction of plasmin initiates proteolytic cleavage in the kringle 5 domain and release of the tumour blood vessel inhibitor angiostatin.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0047134" target="_blank" class="term-link">
+                                    GO:0047134
+                                </a>
+                            </span>
+                            <span class="term-label">protein-disulfide reductase [NAD(P)H] activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11130727" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11130727
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphoglycerate kinase acts in tumour angiogenesis as a dis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0047134" data-r="PMID:11130727" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PGK1 secreted from fibrosarcoma cells was identified as the plasmin reductase, exhibiting protein-disulfide reductase activity in the extracellular space.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A well-documented moonlighting molecular function of secreted PGK1, distinct from its core phosphoglycerate kinase activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11130727" target="_blank" class="term-link">
+                                        PMID:11130727
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the plasmin reductase isolated from conditioned medium of fibrosarcoma cells is the glycolytic enzyme phosphoglycerate kinase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071456" target="_blank" class="term-link">
+                                    GO:0071456
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to hypoxia</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11130727" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11130727
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphoglycerate kinase acts in tumour angiogenesis as a dis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0071456" data-r="PMID:11130727" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Annotation of PGK1 in the cellular response to hypoxia. PGK1 is a HIF-1 target gene, and hypoxia promotes its mitochondrial targeting and moonlighting functions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Hypoxia responsiveness is a physiologically relevant context for PGK1 (both as a HIF target and via hypoxia-induced mitochondrial translocation), but it is a regulatory/context annotation rather than the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                        PMID:26942675
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hypoxia, EGFR activation, and expression of K-Ras G12V and B-Raf V600E induce mitochondrial translocation of phosphoglycerate kinase 1 (PGK1)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11487543" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11487543
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Intestinal epithelial cells secrete exosome-like vesicles.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0070062" data-r="PMID:11487543" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of PGK1 in extracellular exosome-like vesicles.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PGK1 is an abundant cytosolic protein commonly detected in exosome proteomes; this reflects its secretion/exosomal presence rather than the core cytosolic glycolytic location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11487543" target="_blank" class="term-link">
+                                        PMID:11487543
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Intestinal epithelial cells secrete exosome-like vesicles.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045121" target="_blank" class="term-link">
+                                    GO:0045121
+                                </a>
+                            </span>
+                            <span class="term-label">membrane raft</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25204797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25204797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Flotillin-1 facilitates toll-like receptor 3 signaling in hu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0045121" data-r="PMID:25204797" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PGK1 was detected by SILAC mass spectrometry in the detergent-resistant (membrane raft) fraction of endothelial cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a proteomic co-purification of an abundant cytosolic protein in a detergent-resistant membrane fraction, not evidence of a specific membrane-raft function; it over-represents an incidental localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25204797" target="_blank" class="term-link">
+                                        PMID:25204797
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shRNA against flotillin-1 reduced the abundance of the structural caveolae proteins caveolin-1, cavin-1 and cavin-2 in the detergent-resistant fraction.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23533145
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In-depth proteomic analyses of exosomes isolated from expres...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0070062" data-r="PMID:23533145" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of PGK1 in exosomes from prostatic secretions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects incidental presence of an abundant cytosolic protein in exosome proteomes rather than the core function or location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                                        PMID:23533145
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of PGK1 in an NK-cell membrane proteome.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A generic membrane localization from a membrane-proteome dataset for an abundant cytosolic protein; uninformative and not part of the core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Defining the membrane proteome of NK cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030855" target="_blank" class="term-link">
+                                    GO:0030855
+                                </a>
+                            </span>
+                            <span class="term-label">epithelial cell differentiation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21492153" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21492153
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of proteomic changes induced upon cellular differen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0030855" data-r="PMID:21492153" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Expression-based (IEP) annotation from a proteomic comparison of proliferating versus differentiated Caco-2 intestinal cells, where PGK1 was among the differentially regulated proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Differential abundance of PGK1 during Caco-2 differentiation reflects a general metabolic shift, not a specific role of PGK1 in epithelial cell differentiation; an over-annotation of a correlative expression change.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21492153" target="_blank" class="term-link">
+                                        PMID:21492153
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Analysis of proteomic changes induced upon cellular differentiation of the human intestinal cell line Caco-2.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19199708
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteomic analysis of human parotid gland exosomes by multid...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0070062" data-r="PMID:19199708" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of PGK1 in parotid gland exosomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects incidental exosomal presence of an abundant cytosolic protein, not the core function or location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link">
+                                        PMID:19199708
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Proteomic analysis of human parotid gland exosomes by multidimensional protein identification technology (MudPIT).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20458337
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MHC class II-associated proteins in B-cell exosomes and pote...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0070062" data-r="PMID:20458337" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of PGK1 in B-cell exosomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects incidental exosomal presence of an abundant cytosolic protein, not the core function or location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link">
+                                        PMID:20458337
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MHC class II-associated proteins in B-cell exosomes and potential functional implications for exosome biogenesis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70486
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005829" data-r="Reactome:R-HSA-70486" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement annotation of cytosolic localization (PGK complexes phosphorylating 3PG).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytosol is the core subcellular location where PGK1 performs glycolysis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm, cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71850
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005829" data-r="Reactome:R-HSA-71850" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement annotation of cytosolic localization (PGK complexes dephosphorylating 1,3BPG, the gluconeogenic direction).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytosol is the core subcellular location of PGK1 activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm, cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9636658
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005829" data-r="Reactome:R-HSA-9636658" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement annotation of cytosolic localization (in the context of EsxA binding PGK1).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytosol is the core subcellular location of PGK1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm, cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9975250
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005829" data-r="Reactome:R-HSA-9975250" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement annotation of cytosolic localization (in the context of PGK1 phosphorylating AKT1S1).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytosol is the core subcellular location of PGK1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm, cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004618" target="_blank" class="term-link">
+                                    GO:0004618
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoglycerate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0004618" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity annotation (from UniProtKB:P41759) of the core phosphoglycerate kinase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with, and redundant to, the strong experimental support for the core catalytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.7.2.3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P00558" data-a="GO:0005524" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity annotation (from UniProtKB:P00559) of ATP binding, the nucleotide substrate/product of the reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP binding is intrinsic to the phosphoglycerate kinase reaction and is supported by kinetic and structural data; supports the core catalytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PGK1/PGK1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">KM=0.56 mM for ATP</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalyzes the reversible, Mg2+-dependent transfer of a phosphate between 1,3-bisphosphoglycerate + ADP and 3-phosphoglycerate + ATP, the first ATP-generating step of the glycolytic payoff phase (and the reverse step in gluconeogenesis), acting in the cytosol.</h3>
+                <span class="vote-buttons" data-g="P00558" data-a="FUNCTION: Catalyzes the reversible, Mg2+-dependent transfer ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004618" target="_blank" class="term-link">
+                            phosphoglycerate kinase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                glycolytic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                                PMID:26942675
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Phosphoglycerate kinase 1 (PGK1), the first ATP-generating enzyme in the glycolytic pathway, catalyzes the transfer of the high-energy phosphate from the 1-position of 1,3-diphosphoglycerate (1,3-BPG) to ADP, which leads to the generation of 3-phosphoglycerate (3-PG) and ATP</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PGK1/PGK1-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from D-glyceraldehyde 3-phosphate: step 2/5.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>In the gluconeogenic direction, uses the reverse phosphoglycerate kinase reaction (3-phosphoglycerate + ATP -&gt; 1,3-bisphosphoglycerate + ADP) to contribute to glucose biosynthesis in the cytosol.</h3>
+                <span class="vote-buttons" data-g="P00558" data-a="FUNCTION: In the gluconeogenic direction, uses the reverse p..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004618" target="_blank" class="term-link">
+                            phosphoglycerate kinase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006094" target="_blank" class="term-link">
+                                gluconeogenesis
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PGK1/PGK1-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:14803</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000003.md" target="_blank" class="term-link">
+                            GO_REF:0000003
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on Enzyme Commission mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000116.md" target="_blank" class="term-link">
+                            GO_REF:0000116
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic Gene Ontology annotation based on Rhea mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PGK1/PGK1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry P00558 (PGK1_HUMAN)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11130727" target="_blank" class="term-link">
+                            PMID:11130727
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phosphoglycerate kinase acts in tumour angiogenesis as a disulphide reductase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11487543" target="_blank" class="term-link">
+                            PMID:11487543
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Intestinal epithelial cells secrete exosome-like vesicles.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1278465" target="_blank" class="term-link">
+                            PMID:1278465
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Characterization of phosphoglycerate kinase from human spermatozoa.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19199708" target="_blank" class="term-link">
+                            PMID:19199708
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteomic analysis of human parotid gland exosomes by multidimensional protein identification technology (MudPIT).</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20392205" target="_blank" class="term-link">
+                            PMID:20392205
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Loose interaction between glyceraldehyde-3-phosphate dehydrogenase and phosphoglycerate kinase revealed by fluorescence resonance energy transfer-fluorescence lifetime imaging microscopy in living cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20458337" target="_blank" class="term-link">
+                            PMID:20458337
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MHC class II-associated proteins in B-cell exosomes and potential functional implications for exosome biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20849852" target="_blank" class="term-link">
+                            PMID:20849852
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proliferating cell nuclear antigen in the cytoplasm interacts with components of glycolysis and cancer.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21492153" target="_blank" class="term-link">
+                            PMID:21492153
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of proteomic changes induced upon cellular differentiation of the human intestinal cell line Caco-2.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                            PMID:23533145
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25204797" target="_blank" class="term-link">
+                            PMID:25204797
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Flotillin-1 facilitates toll-like receptor 3 signaling in human endothelial cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26030842" target="_blank" class="term-link">
+                            PMID:26030842
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A fluorescent bimolecular complementation screen reveals MAF1, RNF7 and SETD3 as PCNA-associated proteins in human cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26356530" target="_blank" class="term-link">
+                            PMID:26356530
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Insulin and mTOR Pathway Regulate HDAC3-Mediated Deacetylation and Activation of PGK1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
+                            PMID:26942675
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondria-Translocated PGK1 Functions as a Protein Kinase to Coordinate Glycolysis and the TCA Cycle in Tumorigenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30323285" target="_blank" class="term-link">
+                            PMID:30323285
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A metabolite-derived protein modification integrates glycolysis with KEAP1-NRF2 signalling.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32707033" target="_blank" class="term-link">
+                            PMID:32707033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Kinase Interaction Network Expands Functional and Disease Roles of Human Kinases.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
+                            PMID:35271311
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36849569" target="_blank" class="term-link">
+                            PMID:36849569
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">mcPGK1-dependent mitochondrial import of PGK1 promotes metabolic reprogramming and self-renewal of liver TICs.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/5009693" target="_blank" class="term-link">
+                            PMID:5009693
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human phosphoglycerate kinase. I. Crystallization and characterization of normal enzyme.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7391028" target="_blank" class="term-link">
+                            PMID:7391028
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A single amino acid substitution (Asp leads to Asn) in a phosphoglycerate kinase variant (PGK München) associated with enzyme deficiency.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70171
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Glycolysis</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70263
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gluconeogenesis</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70486
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PGK complexes (PGK1,2) phosphorylate 3PG to form 1,3BPG</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71850
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PGK complexes dephosphorylate 1,3BPG</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9636658
+
+                    </span>
+                </div>
+
+                <div class="reference-title">EsxA binds PGK1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9975250
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PGK1 phosphorylates AKT1S1</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PGK1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P00558" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pgk1-human-review-notes">PGK1 (human) review notes</h1>
+<p>UniProtKB: P00558. X-linked (Xq21.1), ubiquitously expressed. 417 aa monomer.<br />
+PANTHER: PTHR11406:SF14 (PHOSPHOGLYCERATE KINASE 1). EC 2.7.2.3.</p>
+<h2 id="core-function">Core function</h2>
+<p>Phosphoglycerate kinase 1 catalyses the first ATP-generating (substrate-level<br />
+phosphorylation) step of the glycolytic payoff phase: reversible transfer of a<br />
+phosphate between 1,3-bisphosphoglycerate + ADP and 3-phosphoglycerate + ATP.<br />
+UniProt CATALYTIC ACTIVITY: "(2R)-3-phosphoglycerate + ATP = (2R)-3-phospho-glyceroyl<br />
+phosphate + ADP" (RHEA:14801, EC 2.7.2.3). The reverse (right-to-left, RHEA:14803)<br />
+direction operates in gluconeogenesis. Requires Mg2+ (PMID:18463139).</p>
+<ul>
+<li>Core MF: GO:0004618 phosphoglycerate kinase activity (well supported by EXP/IMP/IBA/ISS/IEA).</li>
+<li>Core BP: GO:0006096 glycolytic process; GO:0006094 gluconeogenesis (reverse direction).</li>
+<li>Core CC: GO:0005829 cytosol.</li>
+<li>Nucleotide binding: ATP binding (GO:0005524), ADP binding (GO:0043531) are direct substrate<br />
+  binding for the reaction — accept as supporting/core.</li>
+</ul>
+<p>Verbatim (PMID:26942675 full text): "Phosphoglycerate kinase 1 (PGK1), the first<br />
+ATP-generating enzyme in the glycolytic pathway, catalyzes the transfer of the high-energy<br />
+phosphate from the 1-position of 1,3-diphosphoglycerate (1,3-BPG) to ADP, which leads to<br />
+the generation of 3-phosphoglycerate (3-PG) and ATP".</p>
+<h2 id="moonlighting-non-core-functions">Moonlighting / non-core functions</h2>
+<ul>
+<li><strong>Protein kinase (moonlighting).</strong> Mitochondria-translocated PGK1 phosphorylates PDHK1<br />
+  (T338), activating it to inhibit the PDH complex; suppresses pyruvate-&gt;acetyl-CoA,<br />
+  promotes Warburg-effect glycolysis (PMID:26942675, IDA/EXP). UniProt lists EC 2.7.11.1<br />
+  and RHEA:17989 (protein Ser kinase). This is a context-specific (hypoxia/oncogenic,<br />
+  mitochondrial) moonlighting activity — KEEP_AS_NON_CORE. Terms: GO:0004674 protein<br />
+  ser/thr kinase, GO:0106310 protein serine kinase, GO:0160218 neg reg of pyruvate<br />
+  decarboxylation to acetyl-CoA, GO:0005759 mitochondrial matrix.</li>
+<li><strong>Secreted disulfide reductase / angiogenesis.</strong> Secreted by tumour cells; reduces plasmin<br />
+  disulfides -&gt; angiostatin release, inhibits angiogenesis (PMID:11130727, Nature 2000, IMP/IDA).<br />
+  Terms: GO:0047134 protein-disulfide reductase, GO:0005576 extracellular region,<br />
+  GO:0016525 neg reg angiogenesis, GO:0031639 plasminogen activation, GO:0071456 response to<br />
+  hypoxia. Non-core moonlighting.</li>
+<li><strong>Primer recognition protein / pol-alpha cofactor</strong> (PMID:2324090) — noted in UniProt, not GOA.</li>
+<li><strong>Sperm motility</strong> (PMID:26677959) — testis PGK; note PGK2 is the testis paralog.</li>
+</ul>
+<h2 id="ppi-protein-binding-bare-go0005515">PPI / protein binding (bare GO:0005515)</h2>
+<p>Multiple IntAct/HT IPIs to GAPDH (P04406), PCNA (P12004), HDAC3 (O15379), PGK2 (P07205),<br />
+NEK7 (Q8TDX7), and 26942675 partners MAPK1/PIN1/PDHK1 (P28482/Q13526/Q15118). Per curation<br />
+policy, bare "protein binding" is uninformative -&gt; MARK_AS_OVER_ANNOTATED (not REMOVE for<br />
+experimental IPIs). HDAC3 (26356530) deacetylates/activates PGK1 (regulatory).</p>
+<h2 id="localization-proteomics-hda">Localization (proteomics / HDA)</h2>
+<p>Extracellular exosome (multiple HDA PMIDs), membrane (HDA), membrane raft/detergent-resistant<br />
+fraction (PMID:25204797, PGK1 in DRM list). These reflect abundant cytosolic protein<br />
+co-purifying; KEEP_AS_NON_CORE / MARK_AS_OVER_ANNOTATED. Cytosol is the true core CC.</p>
+<h2 id="disease">Disease</h2>
+<p>PGK1 deficiency (PGK1D, MIM:300653): X-linked; hemolytic anemia, myopathy (exercise<br />
+intolerance / rhabdomyolysis), CNS/neurologic involvement, some parkinsonism.</p>
+<h2 id="wrong-to-remove">Wrong / to-remove</h2>
+<ul>
+<li>GO:0004674 protein ser/thr kinase IEA via GO_REF:0000003 EC:2.7.11.1 — this generic<br />
+  EC-&gt;GO mapping is over-broad; the real activity is the specific moonlighting kinase; keep<br />
+  the experimental ones, mark the EC-mapping IEA as over-annotated (accept level too generic).</li>
+<li>GO:0005759 mitochondrial matrix IEA GO_REF:0000044 SubCell — same as experimental IDA;<br />
+  non-core (moonlighting-dependent import).</li>
+<li>GO:0044325 transmembrane transporter binding (Ensembl IEA GO_REF:0000107, from mouse) —<br />
+  weak orthology transfer, uninformative -&gt; MARK_AS_OVER_ANNOTATED.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P00558
+gene_symbol: PGK1
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: Phosphoglycerate kinase 1 is the enzyme that catalyzes the first
+  ATP-generating (substrate-level phosphorylation) step of the glycolytic payoff
+  phase, reversibly transferring a phosphate between 1,3-bisphosphoglycerate + ADP
+  and 3-phosphoglycerate + ATP (EC 2.7.2.3); the reverse reaction operates in
+  gluconeogenesis. It is a cytosolic, monomeric, Mg2+-dependent enzyme that is
+  X-linked and ubiquitously expressed. Beyond glycolysis, PGK1 has documented
+  moonlighting activities, including a secreted extracellular disulfide-reductase
+  activity that liberates the angiogenesis inhibitor angiostatin from plasmin, and,
+  under hypoxic or oncogenic conditions, a mitochondrially-translocated protein
+  kinase activity that phosphorylates PDHK1 to suppress pyruvate oxidation and
+  promote aerobic glycolysis (the Warburg effect). Loss-of-function variants cause
+  phosphoglycerate kinase 1 deficiency, an X-linked disorder combining hemolytic
+  anemia, myopathy (exercise intolerance and rhabdomyolysis) and central nervous
+  system involvement.
+alternative_products:
+- name: &#39;1&#39;
+  id: P00558-1
+- name: &#39;2&#39;
+  id: P00558-2
+  sequence_note: VSP_056159
+existing_annotations:
+- term:
+    id: GO:0004618
+    label: phosphoglycerate kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) annotation of the core catalytic molecular function,
+      phosphoglycerate kinase activity, shared across the PGK family. This is the
+      defining, well-supported function of PGK1.
+    action: ACCEPT
+    reason: This is the core molecular function of PGK1, catalyzing the reversible
+      1,3-bisphosphoglycerate + ADP &lt;-&gt; 3-phosphoglycerate + ATP reaction, and is
+      independently supported by direct experimental and structural evidence.
+    supported_by:
+    - reference_id: PMID:26942675
+      supporting_text: Phosphoglycerate kinase 1 (PGK1), the first ATP-generating
+        enzyme in the glycolytic pathway, catalyzes the transfer of the high-energy
+        phosphate from the 1-position of 1,3-diphosphoglycerate (1,3-BPG) to ADP,
+        which leads to the generation of 3-phosphoglycerate (3-PG) and ATP
+- term:
+    id: GO:0043531
+    label: ADP binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic annotation of ADP binding, reflecting the substrate/product
+      nucleotide bound during catalysis (ADP is the phosphate acceptor in the
+      glycolytic direction).
+    action: ACCEPT
+    reason: ADP is a bona fide substrate of the phosphoglycerate kinase reaction, and
+      structural studies confirm nucleotide binding in the C-terminal domain. This
+      supports the core catalytic function.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: Reaction=(2R)-3-phosphoglycerate + ATP = (2R)-3-phospho-glyceroyl
+        phosphate + ADP
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic annotation placing PGK1 activity in the cytosol, the
+      principal compartment where glycolysis occurs.
+    action: ACCEPT
+    reason: The cytosol is the true core cellular location of PGK1&#39;s glycolytic
+      activity, consistent with direct experimental evidence.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm, cytosol&#39;
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic annotation of involvement in the glycolytic process, the
+      central biological role of PGK1.
+    action: ACCEPT
+    reason: PGK1 catalyzes step 2/5 of the conversion of glyceraldehyde-3-phosphate
+      to pyruvate and is one of only two ATP-generating enzymes in glycolysis. This
+      is a core biological process for the gene.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from
+        D-glyceraldehyde 3-phosphate: step 2/5.&#39;
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic annotation of ATP binding, reflecting the nucleotide
+      substrate/product of the phosphoglycerate kinase reaction.
+    action: ACCEPT
+    reason: ATP is a direct substrate/product of the catalyzed reaction and its
+      binding is documented by kinetic (KM for ATP) and structural analyses. Supports
+      the core catalytic function.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: KM=0.56 mM for ATP
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic annotation of involvement in gluconeogenesis, the
+      biosynthetic direction of the reversible PGK reaction.
+    action: ACCEPT
+    reason: The phosphoglycerate kinase reaction is reversible, and the right-to-left
+      (ATP-consuming) direction is used in gluconeogenesis. This is a legitimate core
+      biological role.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:14803
+- term:
+    id: GO:0004618
+    label: phosphoglycerate kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic annotation (multiple IEA methods, incl. ARBA, InterPro, RHEA,
+      EC 2.7.2.3) of the core phosphoglycerate kinase activity.
+    action: ACCEPT
+    reason: Redundant with, and consistent with, experimental and phylogenetic
+      support for the core catalytic function; the InterPro/EC/RHEA mapping is
+      correct for this family.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: EC=2.7.2.3
+- term:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000003
+  qualifier: enables
+  review:
+    summary: Electronic annotation derived from the EC 2.7.11.1 mapping, corresponding
+      to the documented moonlighting protein kinase activity of PGK1 (phosphorylating
+      PDHK1). The generic EC-to-GO mapping is broad but the underlying activity is real.
+    action: KEEP_AS_NON_CORE
+    reason: PGK1 has an experimentally validated moonlighting protein kinase activity,
+      but this is a context-specific (hypoxia/oncogenic, mitochondrial) function,
+      distinct from its core cytosolic glycolytic role.
+    supported_by:
+    - reference_id: PMID:26942675
+      supporting_text: Mitochondrial PGK1, acting as a protein kinase, phosphorylates
+        and activates PDHK1.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic annotation (UniProt SubCell mapping) of mitochondrial matrix
+      localization, matching the experimentally documented hypoxia/oncogene-induced
+      mitochondrial translocation of PGK1.
+    action: KEEP_AS_NON_CORE
+    reason: PGK1 is imported into the mitochondrial matrix only under specific
+      conditions (hypoxia, oncogenic signalling) as part of its moonlighting protein
+      kinase role; it is not the core cytosolic glycolytic location.
+    supported_by:
+    - reference_id: PMID:26942675
+      supporting_text: mitochondrial translocation of PGK1
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Electronic annotation of cytosolic localization, consistent with the
+      core glycolytic compartment.
+    action: ACCEPT
+    reason: The cytosol is the principal, core subcellular location of PGK1, agreeing
+      with direct experimental evidence.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm, cytosol&#39;
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic annotation (InterPro/UniPathway) of involvement in glycolysis.
+    action: ACCEPT
+    reason: Consistent with the core glycolytic role of PGK1; the pathway mapping is
+      correct.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;PATHWAY: Carbohydrate degradation; glycolysis&#39;
+- term:
+    id: GO:0106310
+    label: protein serine kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000116
+  qualifier: enables
+  review:
+    summary: Electronic (RHEA:17989) annotation of protein serine kinase activity,
+      corresponding to the documented moonlighting phosphorylation of PDHK1.
+    action: KEEP_AS_NON_CORE
+    reason: This reflects a real but context-specific, non-core moonlighting activity
+      of mitochondria-translocated PGK1, distinct from its principal glycolytic role.
+    supported_by:
+    - reference_id: PMID:26942675
+      supporting_text: Mitochondrial PGK1, acting as a protein kinase, phosphorylates
+        and activates PDHK1.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20392205
+  qualifier: enables
+  review:
+    summary: IntAct-curated interaction of PGK1 with GAPDH (P04406), captured only as
+      the uninformative generic term protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding does not convey a specific molecular function. The
+      GAPDH-PGK1 interaction reflects the physical proximity of consecutive glycolytic
+      enzymes but is not annotated to an informative function term.
+    supported_by:
+    - reference_id: PMID:20392205
+      supporting_text: Loose interaction between glyceraldehyde-3-phosphate
+        dehydrogenase and phosphoglycerate kinase revealed by fluorescence resonance
+        energy transfer-fluorescence lifetime imaging microscopy in living cells.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20849852
+  qualifier: enables
+  review:
+    summary: IntAct-curated interaction of PGK1 with PCNA (P12004), captured only as
+      the generic term protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding is uninformative. The interaction with PCNA relates
+      to cytoplasmic PCNA associating with glycolytic enzymes but is not tied to a
+      specific molecular function.
+    supported_by:
+    - reference_id: PMID:20849852
+      supporting_text: Proliferating cell nuclear antigen in the cytoplasm interacts
+        with components of glycolysis and cancer.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26030842
+  qualifier: enables
+  review:
+    summary: IntAct-curated interaction of PGK1 with PCNA (P12004) from a bimolecular
+      complementation screen, captured only as generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding provides no informative molecular function for PGK1.
+    supported_by:
+    - reference_id: PMID:26030842
+      supporting_text: A fluorescent bimolecular complementation screen reveals MAF1,
+        RNF7 and SETD3 as PCNA-associated proteins in human cells.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26356530
+  qualifier: enables
+  review:
+    summary: IntAct-curated interaction of PGK1 with HDAC3 (O15379). HDAC3
+      deacetylates PGK1 at K220 to activate it; a regulatory interaction, but here
+      captured only as generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding is uninformative. The functionally meaningful content
+      (HDAC3-mediated deacetylation/activation of PGK1) is regulatory and is better
+      described elsewhere; the term itself conveys no specific PGK1 molecular function.
+    supported_by:
+    - reference_id: PMID:26356530
+      supporting_text: HDAC3 deacetylates and activates PGK1.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: High-throughput interactome interaction with PGK2 (P07205), captured only
+      as generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding is uninformative; PGK2 is the closely related testis
+      paralog and this high-throughput interaction conveys no specific function.
+    supported_by:
+    - reference_id: PMID:28514442
+      supporting_text: Architecture of the human interactome defines protein
+        communities and disease networks.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32707033
+  qualifier: enables
+  review:
+    summary: Kinase interaction-network interaction with NEK7 (Q8TDX7), captured only
+      as generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding is uninformative for molecular function.
+    supported_by:
+    - reference_id: PMID:32707033
+      supporting_text: Kinase Interaction Network Expands Functional and Disease Roles
+        of Human Kinases.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: Proteome-scale interactome interaction with PGK2 (P07205), captured only
+      as generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding is uninformative; a high-throughput paralog
+      interaction with no specified function.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: Dual proteome-scale networks reveal cell-specific remodeling of
+        the human interactome.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35271311
+  qualifier: enables
+  review:
+    summary: Endogenous-tagging (OpenCell) interaction with PGK2 (P07205), captured
+      only as generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding is uninformative for molecular function.
+    supported_by:
+    - reference_id: PMID:35271311
+      supporting_text: &#39;OpenCell: Endogenous tagging for the cartography of human
+        cellular organization.&#39;
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Ensembl orthology (from mouse P09411) electronic transfer of
+      involvement in gluconeogenesis.
+    action: ACCEPT
+    reason: Consistent with the reversible PGK reaction being used in the
+      gluconeogenic direction; the orthology transfer is appropriate.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:14803
+- term:
+    id: GO:0044325
+    label: transmembrane transporter binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: Ensembl orthology (from mouse P09411) electronic transfer of
+      transmembrane transporter binding. There is no strong human evidence for a
+      specific transporter-binding function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: This is an orthology-transferred electronic annotation with no
+      corroborating human experimental evidence and no specific transporter named; it
+      is uninformative and not part of the core function of PGK1.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;SIMILARITY: Belongs to the phosphoglycerate kinase family.&#39;
+- term:
+    id: GO:0061621
+    label: canonical glycolysis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic annotation (ARBA) of involvement in canonical glycolysis, a
+      more specific child of glycolytic process.
+    action: ACCEPT
+    reason: Canonical glycolysis (Embden-Meyerhof-Parnas) is precisely the pathway in
+      which PGK1 operates; this is a correct, appropriately specific core BP term.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from
+        D-glyceraldehyde 3-phosphate: step 2/5.&#39;
+- term:
+    id: GO:0006094
+    label: gluconeogenesis
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70263
+  qualifier: involved_in
+  review:
+    summary: Reactome traceable-author-statement annotation of involvement in
+      gluconeogenesis.
+    action: ACCEPT
+    reason: PGK1 is a Reactome-curated participant in the gluconeogenesis pathway (the
+      reverse glycolytic direction); a legitimate core biological role.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:14803
+- term:
+    id: GO:0061621
+    label: canonical glycolysis
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70171
+  qualifier: involved_in
+  review:
+    summary: Reactome traceable-author-statement annotation of involvement in
+      canonical glycolysis.
+    action: ACCEPT
+    reason: PGK1 is a Reactome-curated participant in the glycolysis pathway; an
+      appropriately specific core biological process.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from
+        D-glyceraldehyde 3-phosphate: step 2/5.&#39;
+- term:
+    id: GO:0004618
+    label: phosphoglycerate kinase activity
+  evidence_type: EXP
+  original_reference_id: PMID:1278465
+  qualifier: enables
+  review:
+    summary: Experimental characterization of phosphoglycerate kinase activity from
+      human tissue (spermatozoa), confirming the core enzymatic function.
+    action: ACCEPT
+    reason: Direct experimental evidence for phosphoglycerate kinase activity; this is
+      the core molecular function of PGK1.
+    supported_by:
+    - reference_id: PMID:1278465
+      supporting_text: We have confirmed the presence of a unique electrophoretic
+        isoenzyme of phosphoglycerate kinase (PGK) in homogenate extracts of human
+        sperm.
+- term:
+    id: GO:0004618
+    label: phosphoglycerate kinase activity
+  evidence_type: EXP
+  original_reference_id: PMID:5009693
+  qualifier: enables
+  review:
+    summary: Experimental crystallization and characterization of the normal human
+      phosphoglycerate kinase enzyme, establishing the core catalytic function.
+    action: ACCEPT
+    reason: Direct experimental characterization of the purified enzyme supports the
+      core phosphoglycerate kinase molecular function.
+    supported_by:
+    - reference_id: PMID:5009693
+      supporting_text: Human phosphoglycerate kinase. I. Crystallization and
+        characterization of normal enzyme.
+- term:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9975250
+  qualifier: enables
+  review:
+    summary: Reactome traceable-author-statement annotation of the moonlighting
+      protein serine/threonine kinase activity (PGK1 phosphorylating AKT1S1/PRAS40).
+    action: KEEP_AS_NON_CORE
+    reason: Reflects the documented but context-specific moonlighting protein kinase
+      activity of PGK1, not its core glycolytic function.
+    supported_by:
+    - reference_id: PMID:26942675
+      supporting_text: Mitochondrial PGK1, acting as a protein kinase, phosphorylates
+        and activates PDHK1.
+- term:
+    id: GO:0004618
+    label: phosphoglycerate kinase activity
+  evidence_type: EXP
+  original_reference_id: PMID:30323285
+  qualifier: enables
+  review:
+    summary: Experimental study characterizing PGK1 as a glycolytic enzyme and
+      identifying a small-molecule inhibitor (CBR-470-0), confirming its catalytic
+      activity.
+    action: ACCEPT
+    reason: Direct experimental evidence for the core phosphoglycerate kinase activity
+      (EC 2.7.2.3); the inhibitor study depends on and confirms the enzymatic
+      function.
+    supported_by:
+    - reference_id: PMID:30323285
+      supporting_text: we identify a small-molecule inhibitor of the glycolytic enzyme
+        PGK1, and reveal
+- term:
+    id: GO:0106310
+    label: protein serine kinase activity
+  evidence_type: EXP
+  original_reference_id: PMID:26942675
+  qualifier: enables
+  review:
+    summary: Experimental demonstration that mitochondria-translocated PGK1 acts as a
+      protein kinase, phosphorylating PDHK1 on a serine/threonine residue.
+    action: KEEP_AS_NON_CORE
+    reason: This is a genuine, experimentally validated moonlighting activity, but it
+      is context-specific (hypoxia/oncogenic, mitochondrial) and distinct from the
+      core cytosolic glycolytic function.
+    supported_by:
+    - reference_id: PMID:26942675
+      supporting_text: The current study shows that highly purified PGK1 with no
+        obvious protein kinase contamination phosphorylated highly purified PDHK1
+        supporting that glycolytic enzymes can possess dual enzymatic activities,
+        functioning both as metabolic enzymes and protein kinases.
+- term:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  evidence_type: IDA
+  original_reference_id: PMID:26942675
+  qualifier: enables
+  review:
+    summary: Direct assay demonstrating PGK1 protein serine/threonine kinase activity
+      toward PDHK1 (T338).
+    action: KEEP_AS_NON_CORE
+    reason: Experimentally validated moonlighting protein kinase activity of
+      mitochondrial PGK1; non-core relative to the principal glycolytic function.
+    supported_by:
+    - reference_id: PMID:26942675
+      supporting_text: protein kinase to phosphorylate pyruvate dehydrogenase kinase 1
+        (PDHK1) at T338
+- term:
+    id: GO:0160218
+    label: negative regulation of pyruvate decarboxylation to acetyl-CoA
+  evidence_type: IDA
+  original_reference_id: PMID:26942675
+  qualifier: involved_in
+  review:
+    summary: Direct evidence that PGK1-mediated phosphorylation/activation of PDHK1
+      leads to inhibition of the pyruvate dehydrogenase complex, suppressing pyruvate
+      decarboxylation to acetyl-CoA.
+    action: KEEP_AS_NON_CORE
+    reason: A biologically meaningful consequence of the moonlighting mitochondrial
+      kinase activity; it is a context-specific regulatory role rather than the core
+      glycolytic function of PGK1.
+    supported_by:
+    - reference_id: PMID:26942675
+      supporting_text: which activates PDHK1 to phosphorylate and inhibit the pyruvate
+        dehydrogenase (PDH) complex. This reduces mitochondrial pyruvate utilization
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26942675
+  qualifier: enables
+  review:
+    summary: Curated interaction of PGK1 with MAPK1/ERK2 (P28482), captured only as
+      generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding is uninformative. The MAPK1 interaction (which
+      phosphorylates PGK1 at S203 to promote mitochondrial import) is regulatory, but
+      the term itself conveys no specific PGK1 molecular function.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: Interacts with kinase MAPK1/ERK2
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26942675
+  qualifier: enables
+  review:
+    summary: Curated interaction of PGK1 with peptidyl-prolyl isomerase PIN1
+      (Q13526), captured only as generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding is uninformative for molecular function; the PIN1
+      interaction is regulatory (targeting to mitochondrion) rather than a specific
+      function term.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: peptidyl-prolyl cis-trans isomerase PIN1
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26942675
+  qualifier: enables
+  review:
+    summary: Curated interaction of PGK1 with pyruvate dehydrogenase kinase PDK1/PDHK1
+      (Q15118), captured only as generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding is uninformative; the functionally relevant content
+      (PGK1 phosphorylating PDHK1) is already captured by the kinase and pyruvate
+      regulation annotations.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: Interacts with pyruvate dehydrogenase kinase PDK1
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:26942675
+  qualifier: located_in
+  review:
+    summary: Direct evidence that PGK1 is translocated to the mitochondrion under
+      hypoxic/oncogenic conditions where it acts as a protein kinase.
+    action: KEEP_AS_NON_CORE
+    reason: Mitochondrial matrix localization is condition-dependent and tied to the
+      moonlighting kinase role, not the core cytosolic glycolytic location.
+    supported_by:
+    - reference_id: PMID:26942675
+      supporting_text: mitochondrial translocation of PGK1
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:36849569
+  qualifier: located_in
+  review:
+    summary: Direct evidence that the mitochondrial circRNA mcPGK1 promotes import of
+      PGK1 into mitochondria in liver tumour-initiating cells.
+    action: KEEP_AS_NON_CORE
+    reason: Confirms condition-dependent mitochondrial localization of PGK1, part of
+      its moonlighting function; not the core cytosolic location.
+    supported_by:
+    - reference_id: PMID:36849569
+      supporting_text: mcPGK1 promotes the mitochondrial localization of PGK1
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: PMID:36849569
+  qualifier: located_in
+  review:
+    summary: Direct evidence that PGK1 is present in the cytosol (with a fraction
+      redistributing to mitochondria).
+    action: ACCEPT
+    reason: The cytosol is the principal, core subcellular location of PGK1 where it
+      performs glycolysis.
+    supported_by:
+    - reference_id: PMID:36849569
+      supporting_text: mcPGK1 was predominantly localized in mitochondria and also
+        detectable in cytoplasm
+- term:
+    id: GO:0004618
+    label: phosphoglycerate kinase activity
+  evidence_type: IMP
+  original_reference_id: PMID:7391028
+  qualifier: enables
+  review:
+    summary: Characterization of the PGK Munchen deficiency variant (Asp268Asn),
+      linking a single amino acid substitution to reduced enzyme activity and thereby
+      confirming the phosphoglycerate kinase molecular function.
+    action: ACCEPT
+    reason: A loss-of-function disease variant that reduces enzymatic activity
+      provides genetic (IMP) support for the core phosphoglycerate kinase function.
+    supported_by:
+    - reference_id: PMID:7391028
+      supporting_text: A single amino acid substitution (Asp leads to Asn) in a
+        phosphoglycerate kinase variant (PGK München) associated with enzyme
+        deficiency.
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IMP
+  original_reference_id: PMID:7391028
+  qualifier: involved_in
+  review:
+    summary: The PGK Munchen deficiency variant impairs glycolytic flux, supporting
+      PGK1&#39;s involvement in the glycolytic process.
+    action: ACCEPT
+    reason: Genetic evidence from an enzyme-deficiency variant supports the core
+      biological role of PGK1 in glycolysis.
+    supported_by:
+    - reference_id: PMID:7391028
+      supporting_text: phosphoglycerate kinase variant (PGK München) associated with
+        enzyme deficiency
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IDA
+  original_reference_id: PMID:11130727
+  qualifier: located_in
+  review:
+    summary: PGK1 is secreted by tumour cells into the extracellular milieu, where it
+      acts as a plasmin/disulfide reductase.
+    action: KEEP_AS_NON_CORE
+    reason: A documented moonlighting extracellular localization tied to the secreted
+      disulfide-reductase/angiogenesis function; not the core cytosolic glycolytic
+      location.
+    supported_by:
+    - reference_id: PMID:11130727
+      supporting_text: phosphoglycerate kinase not only functions in glycolysis but is
+        secreted by tumour cells and participates in the angiogenic process as a
+        disulphide reductase
+- term:
+    id: GO:0016525
+    label: negative regulation of angiogenesis
+  evidence_type: IMP
+  original_reference_id: PMID:11130727
+  qualifier: involved_in
+  review:
+    summary: Administration of PGK1 to tumour-bearing mice increased plasma
+      angiostatin and reduced tumour vascularity, implicating secreted PGK1 in
+      negative regulation of angiogenesis.
+    action: KEEP_AS_NON_CORE
+    reason: A moonlighting function of secreted PGK1 (via angiostatin release), not
+      the core glycolytic role.
+    supported_by:
+    - reference_id: PMID:11130727
+      supporting_text: Administration of phosphoglycerate kinase to tumour-bearing
+        mice caused an increase in plasma levels of angiostatin, and a decrease in
+        tumour vascularity and rate of tumour growth.
+- term:
+    id: GO:0031639
+    label: plasminogen activation
+  evidence_type: IMP
+  original_reference_id: PMID:11130727
+  qualifier: involved_in
+  review:
+    summary: Secreted PGK1 reduces disulfide bonds in plasmin, initiating proteolytic
+      cleavage and angiostatin release.
+    action: KEEP_AS_NON_CORE
+    reason: Part of the secreted disulfide-reductase moonlighting function; not the
+      core glycolytic role. The term captures PGK1&#39;s action on the plasmin(ogen)
+      system.
+    supported_by:
+    - reference_id: PMID:11130727
+      supporting_text: Reduction of plasmin initiates proteolytic cleavage in the
+        kringle 5 domain and release of the tumour blood vessel inhibitor angiostatin.
+- term:
+    id: GO:0047134
+    label: protein-disulfide reductase [NAD(P)H] activity
+  evidence_type: IMP
+  original_reference_id: PMID:11130727
+  qualifier: enables
+  review:
+    summary: PGK1 secreted from fibrosarcoma cells was identified as the plasmin
+      reductase, exhibiting protein-disulfide reductase activity in the extracellular
+      space.
+    action: KEEP_AS_NON_CORE
+    reason: A well-documented moonlighting molecular function of secreted PGK1,
+      distinct from its core phosphoglycerate kinase activity.
+    supported_by:
+    - reference_id: PMID:11130727
+      supporting_text: the plasmin reductase isolated from conditioned medium of
+        fibrosarcoma cells is the glycolytic enzyme phosphoglycerate kinase
+- term:
+    id: GO:0071456
+    label: cellular response to hypoxia
+  evidence_type: IDA
+  original_reference_id: PMID:11130727
+  qualifier: involved_in
+  review:
+    summary: Annotation of PGK1 in the cellular response to hypoxia. PGK1 is a HIF-1
+      target gene, and hypoxia promotes its mitochondrial targeting and moonlighting
+      functions.
+    action: KEEP_AS_NON_CORE
+    reason: Hypoxia responsiveness is a physiologically relevant context for PGK1
+      (both as a HIF target and via hypoxia-induced mitochondrial translocation), but
+      it is a regulatory/context annotation rather than the core molecular function.
+    supported_by:
+    - reference_id: PMID:26942675
+      supporting_text: hypoxia, EGFR activation, and expression of K-Ras G12V and
+        B-Raf V600E induce mitochondrial translocation of phosphoglycerate kinase 1
+        (PGK1)
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:11487543
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of PGK1 in extracellular
+      exosome-like vesicles.
+    action: KEEP_AS_NON_CORE
+    reason: PGK1 is an abundant cytosolic protein commonly detected in exosome
+      proteomes; this reflects its secretion/exosomal presence rather than the core
+      cytosolic glycolytic location.
+    supported_by:
+    - reference_id: PMID:11487543
+      supporting_text: Intestinal epithelial cells secrete exosome-like vesicles.
+- term:
+    id: GO:0045121
+    label: membrane raft
+  evidence_type: IDA
+  original_reference_id: PMID:25204797
+  qualifier: located_in
+  review:
+    summary: PGK1 was detected by SILAC mass spectrometry in the detergent-resistant
+      (membrane raft) fraction of endothelial cells.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: This is a proteomic co-purification of an abundant cytosolic protein in a
+      detergent-resistant membrane fraction, not evidence of a specific membrane-raft
+      function; it over-represents an incidental localization.
+    supported_by:
+    - reference_id: PMID:25204797
+      supporting_text: shRNA against flotillin-1 reduced the abundance of the
+        structural caveolae proteins caveolin-1, cavin-1 and cavin-2 in the
+        detergent-resistant fraction.
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:23533145
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of PGK1 in exosomes from prostatic
+      secretions.
+    action: KEEP_AS_NON_CORE
+    reason: Reflects incidental presence of an abundant cytosolic protein in exosome
+      proteomes rather than the core function or location.
+    supported_by:
+    - reference_id: PMID:23533145
+      supporting_text: In-depth proteomic analyses of exosomes isolated from expressed
+        prostatic secretions in urine.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of PGK1 in an NK-cell membrane
+      proteome.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: A generic membrane localization from a membrane-proteome dataset for an
+      abundant cytosolic protein; uninformative and not part of the core function.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: Defining the membrane proteome of NK cells.
+- term:
+    id: GO:0030855
+    label: epithelial cell differentiation
+  evidence_type: IEP
+  original_reference_id: PMID:21492153
+  qualifier: involved_in
+  review:
+    summary: Expression-based (IEP) annotation from a proteomic comparison of
+      proliferating versus differentiated Caco-2 intestinal cells, where PGK1 was
+      among the differentially regulated proteins.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Differential abundance of PGK1 during Caco-2 differentiation reflects a
+      general metabolic shift, not a specific role of PGK1 in epithelial cell
+      differentiation; an over-annotation of a correlative expression change.
+    supported_by:
+    - reference_id: PMID:21492153
+      supporting_text: Analysis of proteomic changes induced upon cellular
+        differentiation of the human intestinal cell line Caco-2.
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19199708
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of PGK1 in parotid gland exosomes.
+    action: KEEP_AS_NON_CORE
+    reason: Reflects incidental exosomal presence of an abundant cytosolic protein,
+      not the core function or location.
+    supported_by:
+    - reference_id: PMID:19199708
+      supporting_text: Proteomic analysis of human parotid gland exosomes by
+        multidimensional protein identification technology (MudPIT).
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:20458337
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of PGK1 in B-cell exosomes.
+    action: KEEP_AS_NON_CORE
+    reason: Reflects incidental exosomal presence of an abundant cytosolic protein,
+      not the core function or location.
+    supported_by:
+    - reference_id: PMID:20458337
+      supporting_text: MHC class II-associated proteins in B-cell exosomes and
+        potential functional implications for exosome biogenesis.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70486
+  qualifier: located_in
+  review:
+    summary: Reactome traceable-author-statement annotation of cytosolic localization
+      (PGK complexes phosphorylating 3PG).
+    action: ACCEPT
+    reason: The cytosol is the core subcellular location where PGK1 performs
+      glycolysis.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm, cytosol&#39;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71850
+  qualifier: located_in
+  review:
+    summary: Reactome traceable-author-statement annotation of cytosolic localization
+      (PGK complexes dephosphorylating 1,3BPG, the gluconeogenic direction).
+    action: ACCEPT
+    reason: The cytosol is the core subcellular location of PGK1 activity.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm, cytosol&#39;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9636658
+  qualifier: located_in
+  review:
+    summary: Reactome traceable-author-statement annotation of cytosolic localization
+      (in the context of EsxA binding PGK1).
+    action: ACCEPT
+    reason: The cytosol is the core subcellular location of PGK1.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm, cytosol&#39;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9975250
+  qualifier: located_in
+  review:
+    summary: Reactome traceable-author-statement annotation of cytosolic localization
+      (in the context of PGK1 phosphorylating AKT1S1).
+    action: ACCEPT
+    reason: The cytosol is the core subcellular location of PGK1.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm, cytosol&#39;
+- term:
+    id: GO:0004618
+    label: phosphoglycerate kinase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: Sequence-similarity annotation (from UniProtKB:P41759) of the core
+      phosphoglycerate kinase activity.
+    action: ACCEPT
+    reason: Consistent with, and redundant to, the strong experimental support for
+      the core catalytic function.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: EC=2.7.2.3
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: Sequence-similarity annotation (from UniProtKB:P00559) of ATP binding,
+      the nucleotide substrate/product of the reaction.
+    action: ACCEPT
+    reason: ATP binding is intrinsic to the phosphoglycerate kinase reaction and is
+      supported by kinetic and structural data; supports the core catalytic function.
+    supported_by:
+    - reference_id: file:human/PGK1/PGK1-uniprot.txt
+      supporting_text: KM=0.56 mM for ATP
+core_functions:
+- description: Catalyzes the reversible, Mg2+-dependent transfer of a phosphate
+    between 1,3-bisphosphoglycerate + ADP and 3-phosphoglycerate + ATP, the first
+    ATP-generating step of the glycolytic payoff phase (and the reverse step in
+    gluconeogenesis), acting in the cytosol.
+  molecular_function:
+    id: GO:0004618
+    label: phosphoglycerate kinase activity
+  directly_involved_in:
+  - id: GO:0006096
+    label: glycolytic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:26942675
+    supporting_text: Phosphoglycerate kinase 1 (PGK1), the first ATP-generating
+      enzyme in the glycolytic pathway, catalyzes the transfer of the high-energy
+      phosphate from the 1-position of 1,3-diphosphoglycerate (1,3-BPG) to ADP, which
+      leads to the generation of 3-phosphoglycerate (3-PG) and ATP
+  - reference_id: file:human/PGK1/PGK1-uniprot.txt
+    supporting_text: &#39;PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from
+      D-glyceraldehyde 3-phosphate: step 2/5.&#39;
+- description: In the gluconeogenic direction, uses the reverse phosphoglycerate
+    kinase reaction (3-phosphoglycerate + ATP -&gt; 1,3-bisphosphoglycerate + ADP) to
+    contribute to glucose biosynthesis in the cytosol.
+  molecular_function:
+    id: GO:0004618
+    label: phosphoglycerate kinase activity
+  directly_involved_in:
+  - id: GO:0006094
+    label: gluconeogenesis
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: file:human/PGK1/PGK1-uniprot.txt
+    supporting_text: PhysiologicalDirection=right-to-left; Xref=Rhea:RHEA:14803
+references:
+- id: GO_REF:0000003
+  title: Gene Ontology annotation based on Enzyme Commission mapping
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000116
+  title: Automatic Gene Ontology annotation based on Rhea mapping
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: file:human/PGK1/PGK1-uniprot.txt
+  title: UniProtKB entry P00558 (PGK1_HUMAN)
+  findings: []
+- id: PMID:11130727
+  title: Phosphoglycerate kinase acts in tumour angiogenesis as a disulphide reductase.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Establishes the secreted disulfide-reductase
+      moonlighting function (plasmin reduction -&gt; angiostatin -&gt; anti-angiogenesis).
+      Abstract fully supports the extracellular, disulfide reductase, angiogenesis
+      and plasminogen annotations.
+- id: PMID:11487543
+  title: Intestinal epithelial cells secrete exosome-like vesicles.
+  findings: []
+- id: PMID:1278465
+  title: Characterization of phosphoglycerate kinase from human spermatozoa.
+  findings: []
+- id: PMID:19199708
+  title: Proteomic analysis of human parotid gland exosomes by multidimensional protein
+    identification technology (MudPIT).
+  findings: []
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+- id: PMID:20392205
+  title: Loose interaction between glyceraldehyde-3-phosphate dehydrogenase and phosphoglycerate
+    kinase revealed by fluorescence resonance energy transfer-fluorescence lifetime
+    imaging microscopy in living cells.
+  findings: []
+- id: PMID:20458337
+  title: MHC class II-associated proteins in B-cell exosomes and potential functional
+    implications for exosome biogenesis.
+  findings: []
+- id: PMID:20849852
+  title: Proliferating cell nuclear antigen in the cytoplasm interacts with components
+    of glycolysis and cancer.
+  findings: []
+- id: PMID:21492153
+  title: Analysis of proteomic changes induced upon cellular differentiation of the
+    human intestinal cell line Caco-2.
+  findings: []
+- id: PMID:23533145
+  title: In-depth proteomic analyses of exosomes isolated from expressed prostatic
+    secretions in urine.
+  findings: []
+- id: PMID:25204797
+  title: Flotillin-1 facilitates toll-like receptor 3 signaling in human endothelial
+    cells.
+  findings: []
+- id: PMID:26030842
+  title: A fluorescent bimolecular complementation screen reveals MAF1, RNF7 and SETD3
+    as PCNA-associated proteins in human cells.
+  findings: []
+- id: PMID:26356530
+  title: Insulin and mTOR Pathway Regulate HDAC3-Mediated Deacetylation and Activation
+    of PGK1.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Full text shows HDAC3 directly deacetylates PGK1
+      at K220 to activate it; supports a regulatory interaction but the GOA annotation
+      only captures generic protein binding.
+- id: PMID:26942675
+  title: Mitochondria-Translocated PGK1 Functions as a Protein Kinase to Coordinate
+    Glycolysis and the TCA Cycle in Tumorigenesis.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Definitive study of the PGK1 moonlighting protein
+      kinase activity (phosphorylates PDHK1 T338), mitochondrial translocation, and
+      the resulting suppression of pyruvate oxidation. Full text also states the core
+      glycolytic reaction verbatim.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+- id: PMID:30323285
+  title: A metabolite-derived protein modification integrates glycolysis with KEAP1-NRF2
+    signalling.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Identifies a PGK1 small-molecule inhibitor and
+      confirms PGK1 as the glycolytic enzyme (EC 2.7.2.3); supports the core catalytic
+      activity annotation.
+- id: PMID:32707033
+  title: Kinase Interaction Network Expands Functional and Disease Roles of Human
+    Kinases.
+  findings: []
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+- id: PMID:35271311
+  title: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization.&#39;
+  findings: []
+- id: PMID:36849569
+  title: mcPGK1-dependent mitochondrial import of PGK1 promotes metabolic reprogramming
+    and self-renewal of liver TICs.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Shows mitochondrial circRNA mcPGK1 drives PGK1
+      import into mitochondria in liver tumour-initiating cells; supports the
+      condition-dependent mitochondrial and cytosolic localization annotations.
+- id: PMID:5009693
+  title: Human phosphoglycerate kinase. I. Crystallization and characterization of
+    normal enzyme.
+  findings: []
+- id: PMID:7391028
+  title: A single amino acid substitution (Asp leads to Asn) in a phosphoglycerate
+    kinase variant (PGK München) associated with enzyme deficiency.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. PGK Munchen (Asp268Asn) deficiency variant with
+      reduced enzyme activity; genetic (IMP) support for the core phosphoglycerate
+      kinase function and glycolytic role.
+- id: Reactome:R-HSA-70171
+  title: Glycolysis
+  findings: []
+- id: Reactome:R-HSA-70263
+  title: Gluconeogenesis
+  findings: []
+- id: Reactome:R-HSA-70486
+  title: PGK complexes (PGK1,2) phosphorylate 3PG to form 1,3BPG
+  findings: []
+- id: Reactome:R-HSA-71850
+  title: PGK complexes dephosphorylate 1,3BPG
+  findings: []
+- id: Reactome:R-HSA-9636658
+  title: EsxA binds PGK1
+  findings: []
+- id: Reactome:R-HSA-9975250
+  title: PGK1 phosphorylates AKT1S1
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PKLR/PKLR-ai-review.html
+++ b/genes/human/PKLR/PKLR-ai-review.html
@@ -1,0 +1,4039 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PKLR - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PKLR</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P30613" target="_blank" class="term-link">
+                        P30613
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PKLR";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P30613" data-a="DESCRIPTION: PKLR encodes the liver (L) and red-blood-cell (R) ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PKLR encodes the liver (L) and red-blood-cell (R) isozymes of pyruvate kinase, produced from a single gene by alternative promoters and splicing. It catalyses the final, essentially irreversible, second ATP-generating step of glycolysis, transferring a phosphate from phosphoenolpyruvate (PEP) to ADP to form pyruvate and ATP (EC 2.7.1.40). The enzyme is a cytosolic homotetramer that requires Mg2+ (or Mn2+) and K+, is allosterically activated in a feed-forward manner by fructose 1,6-bisphosphate, and (in the liver isoform) is inhibited by ATP and alanine and by phosphorylation via the glucagon/PKA axis. The separate PKM gene encodes the muscle/M1-M2 isozymes. Because mature erythrocytes lack mitochondria and depend entirely on glycolysis for ATP, loss-of-function variants cause pyruvate kinase deficiency, the most common glycolytic-enzyme cause of hereditary nonspherocytic hemolytic anemia; rare hyperactivating variants raise red-cell ATP.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004743" target="_blank" class="term-link">
+                                    GO:0004743
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0004743" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred pyruvate kinase activity, the defining molecular function of PKLR and the entire pyruvate kinase family.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core molecular function of the gene product, catalysing PEP + ADP -&gt; pyruvate + ATP (EC 2.7.1.40). It is directly supported by biochemical and structural characterization of human RPK and by the UniProt catalytic-activity annotation, and is consistent across the pyruvate kinase phylogeny.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PKLR/PKLR-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Pyruvate kinase that catalyzes the conversion of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic assignment of cytoplasmic localization; correct but less informative than the specific cytosol term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PKLR is a soluble glycolytic enzyme active in the cytosol. Cytoplasm is correct but is subsumed by the more informative GO:0005829 cytosol annotation (TAS, Reactome), so it is retained as a non-core, general localization statement.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0006096" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred participation in glycolysis; PKLR catalyses the final ATP-generating step of the pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Pyruvate kinase catalyses glycolysis step 5/5 (pyruvate from D-glyceraldehyde 3-phosphate), the committed, essentially irreversible PEP -&gt; pyruvate reaction that generates ATP. This is a core biological process for the gene product.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PKLR/PKLR-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from D-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032869" target="_blank" class="term-link">
+                                    GO:0032869
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to insulin stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0032869" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically projected involvement in the cellular insulin response, reflecting hormonal regulation of the liver isoform rather than PKLR&#39;s own molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The liver (L) isoform&#39;s expression and phosphorylation state are modulated by insulin/glucagon signalling, but this describes upstream regulation of the enzyme, not a process PKLR itself carries out. The phylogenetic support is thin (only two source annotations, PANTHER + rat RGD) and the term over-states PKLR&#39;s role in insulin signalling; it is retained but flagged as an over-annotation.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">ROLE CONFLATION</span>
+
+                                <span class="badge">CONTEXT OR TISSUE MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">RGD:3336</span>
+
+                                    &middot; Pklr (rat)
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Rat ortholog regulatory/physiological context; captures hormonal regulation of the hepatic enzyme, not a molecular process PKLR itself performs.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000212861</span>
+
+                                    &middot; pyruvate kinase family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Family-node projection of a regulatory biological process, thinly supported (two source annotations only).</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000287" target="_blank" class="term-link">
+                                    GO:0000287
+                                </a>
+                            </span>
+                            <span class="term-label">magnesium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0000287" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based assignment of magnesium ion binding, the catalytic divalent metal cofactor of pyruvate kinase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Pyruvate kinase requires a divalent metal cofactor (Mg2+, or Mn2+ in vitro) for catalysis; UniProt lists Mg(2+) and Mn(2+) as cofactors and the human RPK crystal structure resolves the catalytic divalent-metal site. The InterPro mapping is structurally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PKLR/PKLR-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Name=Mg(2+); Xref=ChEBI:CHEBI:18420;</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004743" target="_blank" class="term-link">
+                                    GO:0004743
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0004743" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated multi-method assignment of pyruvate kinase activity (EC 2.7.1.40, RHEA:18157), the core catalytic function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant electronic support (mapping via EC 2.7.1.40, RHEA:18157 and PK InterPro domains) for the experimentally established pyruvate kinase activity; correct and consistent with the EXP/TAS/IBA evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PKLR/PKLR-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.7.1.40 {ECO:0000269|PubMed:11960989}</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                    GO:0006096
+                                </a>
+                            </span>
+                            <span class="term-label">glycolytic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0006096" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated multi-method assignment (via UniPathway glycolysis) of participation in the glycolytic process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant electronic support for PKLR&#39;s role in glycolysis, consistent with the UniProt pathway annotation and the IBA glycolytic process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PKLR/PKLR-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from D-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030955" target="_blank" class="term-link">
+                                    GO:0030955
+                                </a>
+                            </span>
+                            <span class="term-label">potassium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0030955" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based assignment of potassium ion binding, the required monovalent cation cofactor of pyruvate kinase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Pyruvate kinase activity requires K+; the human RPK structure resolves the K+ site (binding residues 118, 120, 156, 157) and UniProt lists K(+) as a cofactor. The InterPro mapping is structurally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PKLR/PKLR-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Name=K(+); Xref=ChEBI:CHEBI:29103;</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Single high-throughput yeast two-hybrid interaction (with CPNE7, UniProt Q9UBL6-2) from the HuRI reference interactome; uninformative bare protein-binding term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0005515 protein binding conveys no specific molecular function and derives from a single systematic Y2H screen (HuRI) reporting a PKLR-CPNE7 interaction with no functional characterization or independent orthogonal validation for PKLR. Per curation guidance this bare protein-binding IPI is retained but flagged as an over-annotation rather than treated as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">With approximately 53,000 protein-protein interactions, HuRI has approximately four times as many such interactions as there are high-quality curated interactions from small-scale studies.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001666" target="_blank" class="term-link">
+                                    GO:0001666
+                                </a>
+                            </span>
+                            <span class="term-label">response to hypoxia</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0001666" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Response to hypoxia projected electronically from the rat ortholog (P12928) via Ensembl Compara orthology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is an orthology-transferred physiological/regulatory context (glycolytic flux is modulated under hypoxia), not PKLR&#39;s own molecular function. Biologically plausible for a glycolytic enzyme but peripheral to the core catalytic role, so retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007584" target="_blank" class="term-link">
+                                    GO:0007584
+                                </a>
+                            </span>
+                            <span class="term-label">response to nutrient</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0007584" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Response to nutrient projected electronically from the rat ortholog (P12928) via Ensembl Compara orthology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reflects nutritional/dietary regulation of the hepatic pyruvate kinase isoform&#39;s expression rather than PKLR&#39;s molecular function. Retained as a non-core, orthology-inferred regulatory context.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009749" target="_blank" class="term-link">
+                                    GO:0009749
+                                </a>
+                            </span>
+                            <span class="term-label">response to glucose</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0009749" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Response to glucose projected electronically from the rat ortholog (P12928) via Ensembl Compara orthology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Hepatic pyruvate kinase (L isoform) transcription is induced by dietary glucose/carbohydrate; this is a regulatory context transferred from the rat ortholog, not PKLR&#39;s molecular activity. Retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010038" target="_blank" class="term-link">
+                                    GO:0010038
+                                </a>
+                            </span>
+                            <span class="term-label">response to metal ion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0010038" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Response to metal ion projected electronically from the rat ortholog (P12928) via Ensembl Compara orthology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Pyruvate kinase depends on Mg2+/Mn2+ and K+ as catalytic cofactors, so metal-ion sensitivity is biologically plausible, but this orthology-transferred biological-process term overlaps with the more precise metal-ion-binding molecular-function annotations and is peripheral to the core function. Retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032869" target="_blank" class="term-link">
+                                    GO:0032869
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to insulin stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0032869" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cellular insulin response projected electronically from the rat ortholog (P12928); reflects hormonal regulation of the liver isoform, not PKLR&#39;s molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicates the IBA cellular-response-to-insulin annotation via orthology transfer. It captures upstream insulin/glucagon regulation of hepatic pyruvate kinase expression and phosphorylation rather than a process PKLR itself performs; retained but flagged as an over-annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033198" target="_blank" class="term-link">
+                                    GO:0033198
+                                </a>
+                            </span>
+                            <span class="term-label">response to ATP</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0033198" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Response to ATP projected electronically from the rat ortholog (P12928) via Ensembl Compara orthology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP is both a product of the pyruvate kinase reaction and a classic allosteric inhibitor of the enzyme, so ATP-sensitivity is biologically real, but this orthology-transferred biological-process term is peripheral to the core catalytic function. Retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042866" target="_blank" class="term-link">
+                                    GO:0042866
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0042866" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pyruvate biosynthesis projected electronically from the rat ortholog (P12928); an alternative process framing of the pyruvate kinase reaction, whose product is pyruvate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Pyruvate is the direct product of the pyruvate kinase reaction, so this is a correct but redundant restatement of the glycolytic function. It duplicates the Reactome TAS pyruvate-biosynthetic-process annotation and is subsumed by the glycolytic-process core annotation; retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048029" target="_blank" class="term-link">
+                                    GO:0048029
+                                </a>
+                            </span>
+                            <span class="term-label">monosaccharide binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0048029" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Monosaccharide binding projected electronically from the rat ortholog (P12928); likely a misleading generalization of fructose 1,6-bisphosphate allosteric binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PKLR is allosterically activated by fructose 1,6-bisphosphate, a bisphosphorylated hexose, via a dedicated allosteric site. Generalizing this to broad monosaccharide binding is misleading (FBP is a phosphorylated sugar bisphosphate, not a free monosaccharide) and adds no informative molecular function. Retained but flagged as an over-annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051591" target="_blank" class="term-link">
+                                    GO:0051591
+                                </a>
+                            </span>
+                            <span class="term-label">response to cAMP</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0051591" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Response to cAMP projected electronically from the rat ortholog (P12928) via Ensembl Compara orthology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Glucagon raises hepatic cAMP, activating PKA, which phosphorylates and inhibits the liver pyruvate kinase isoform; cAMP-responsiveness is therefore biologically plausible but represents upstream regulation rather than PKLR&#39;s molecular function. Retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071872" target="_blank" class="term-link">
+                                    GO:0071872
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to epinephrine stimulus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0071872" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cellular epinephrine response projected electronically from the rat ortholog (P12928) via Ensembl Compara orthology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Epinephrine, like glucagon, elevates cAMP/PKA signalling that regulates hepatic pyruvate kinase activity by phosphorylation; this is an orthology-transferred regulatory context peripheral to PKLR&#39;s core catalytic function. Retained as non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042866" target="_blank" class="term-link">
+                                    GO:0042866
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70268
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0042866" data-r="Reactome:R-HSA-70268" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted involvement in pyruvate biosynthesis, reflecting that pyruvate is the product of the pyruvate kinase reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct product-oriented framing of the same PEP -&gt; pyruvate reaction that is captured more informatively by the glycolytic-process and pyruvate-kinase-activity core annotations. Retained as non-core to avoid redundancy with the core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061621" target="_blank" class="term-link">
+                                    GO:0061621
+                                </a>
+                            </span>
+                            <span class="term-label">canonical glycolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-70171
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0061621" data-r="Reactome:R-HSA-70171" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted participation in canonical glycolysis (Embden-Meyerhof-Parnas pathway), the final ATP-generating step of which PKLR catalyses.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Canonical glycolysis is a precise subtype of glycolytic process describing the classic glucose-to-pyruvate EMP pathway, of which pyruvate kinase catalyses the terminal committed step. This accurately captures PKLR&#39;s biological process role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004743" target="_blank" class="term-link">
+                                    GO:0004743
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11960989" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11960989
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure and function of human erythrocyte pyruvate kinase....
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0004743" data-r="PMID:11960989" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally demonstrated pyruvate kinase activity of human erythrocyte RPK, characterized structurally and kinetically together with disease mutants.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This study solved the crystal structure of human RPK in complex with fructose 1,6-bisphosphate and a substrate analogue and functionally characterized wild-type and mutant enzymes, directly establishing the pyruvate kinase catalytic activity that is the core molecular function of PKLR.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11960989" target="_blank" class="term-link">
+                                        PMID:11960989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we have solved the 2.7 A resolution crystal structure of human RPK in complex with fructose 1,6-bisphosphate, the allosteric activator, and phosphoglycolate, a substrate analogue</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004743" target="_blank" class="term-link">
+                                    GO:0004743
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15996096" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15996096
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for tumor pyruvate kinase M2 allosteric reg...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0004743" data-r="PMID:15996096" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pyruvate kinase activity supported by a structural/mechanistic study; the cited paper characterizes the human M2 isozyme (PKM gene), applied to PKLR by isozyme analogy via Reactome.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The pyruvate kinase catalytic activity assignment is correct for PKLR and independently established by human RPK biochemistry (PMID:11960989). This particular Reactome-sourced EXP citation is the PKM2 crystallography paper (a paralog); the catalytic mechanism, cofactor (Mg2+/K+) and FBP allostery are conserved across the L/R/M1/M2 isozymes, so it does not conflict with the annotation. Per curation policy the experimental annotation is retained rather than removed; reference relevance is flagged as MEDIUM (paralog-derived).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15996096" target="_blank" class="term-link">
+                                        PMID:15996096
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The X-ray structure of human hPKM2 complexed with Mg(2+), K(+), the inhibitor oxalate, and the allosteric activator fructose 1,6-bisphosphate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19056867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Large-scale proteomics and phosphoproteomics of urinary exos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0070062" data-r="PMID:19056867" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection of PKLR in urinary exosomes; a common MS finding for abundant cytosolic enzymes rather than a functional location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Detection in an exosome/extracellular-vesicle proteome is a frequent incidental finding for highly abundant soluble glycolytic enzymes and does not reflect where PKLR performs its catalytic function (the cytosol). Retained as a non-core localization observation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                                        PMID:19056867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we used LC-MS/MS to profile the proteome of human urinary exosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-71670
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0005829" data-r="Reactome:R-HSA-71670" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted cytosolic localization, the compartment where PKLR catalyses the glycolytic pyruvate kinase reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PKLR is a soluble cytosolic enzyme; glycolysis occurs in the cytosol and the pyruvate kinase step is cytosolic. This is the informative subcellular location and represents the core cellular component for the gene product.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9727857
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0005829" data-r="Reactome:R-HSA-9727857" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted cytosolic localization (from a SARS-CoV-1 host-interaction model), consistent with PKLR being a soluble cytosolic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicate cytosol localization from a different Reactome reaction; correct and consistent with the primary glycolysis-based cytosol annotation. Cytosol is the core cellular component for PKLR.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004743" target="_blank" class="term-link">
+                                    GO:0004743
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3126495" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3126495
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human liver type pyruvate kinase: complete amino acid sequen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0004743" data-r="PMID:3126495" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated pyruvate kinase activity from the study that cloned and expressed human liver (L)-type PK, detecting enzymatic activity in transfected cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This paper determined the full-length human L-type PK cDNA and expressed it in COS cells, where L-type PK activity was detected, corroborating the core pyruvate kinase molecular function of PKLR.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3126495" target="_blank" class="term-link">
+                                        PMID:3126495
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human L-type PK activity was detected in the extract of COS cells by the classical PK electrophoresis method.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004743" target="_blank" class="term-link">
+                                    GO:0004743
+                                </a>
+                            </span>
+                            <span class="term-label">pyruvate kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1445295" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1445295
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural analysis of human pyruvate kinase L-gene and iden...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P30613" data-a="GO:0004743" data-r="PMID:1445295" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable author statement of pyruvate kinase identity from a study of the human PK L-gene structure and its erythroid promoter.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This paper characterizes the human pyruvate kinase L-gene (12 exons, R- and L-type transcripts from alternative first exons) and its promoter; the pyruvate kinase activity assignment is correct for the gene, though the evidence here is genomic/promoter rather than a direct activity assay. Consistent with the stronger EXP/TAS evidence, so accepted.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1445295" target="_blank" class="term-link">
+                                        PMID:1445295
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human pyruvate kinase (PK) L-gene is organized in 12 exons over 9.5</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalyses the final, committed, essentially irreversible ATP-generating step of glycolysis, transferring phosphate from phosphoenolpyruvate to ADP to form pyruvate and ATP (EC 2.7.1.40), requiring Mg2+/Mn2+ and K+ as cofactors and allosterically activated by fructose 1,6-bisphosphate.</h3>
+                <span class="vote-buttons" data-g="P30613" data-a="FUNCTION: Catalyses the final, committed, essentially irreve..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004743" target="_blank" class="term-link">
+                            pyruvate kinase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006096" target="_blank" class="term-link">
+                                glycolytic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11960989" target="_blank" class="term-link">
+                                PMID:11960989
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">we have solved the 2.7 A resolution crystal structure of human RPK in complex with fructose 1,6-bisphosphate, the allosteric activator, and phosphoglycolate, a substrate analogue</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PKLR/PKLR-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Pyruvate kinase that catalyzes the conversion of</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PKLR/PKLR-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB P30613 (KPYR_HUMAN) Pyruvate kinase PKLR</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11960989" target="_blank" class="term-link">
+                            PMID:11960989
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure and function of human erythrocyte pyruvate kinase. Molecular basis of nonspherocytic hemolytic anemia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1445295" target="_blank" class="term-link">
+                            PMID:1445295
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural analysis of human pyruvate kinase L-gene and identification of the promoter activity in erythroid cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15996096" target="_blank" class="term-link">
+                            PMID:15996096
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for tumor pyruvate kinase M2 allosteric regulation and catalysis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                            PMID:19056867
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/3126495" target="_blank" class="term-link">
+                            PMID:3126495
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human liver type pyruvate kinase: complete amino acid sequence and the expression in mammalian cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70171
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Glycolysis</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-70268
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Pyruvate metabolism</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-71670
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Pyruvate kinase dephosphorylates PEP to PYR</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9727857
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SARS-CoV-1 SUMO1-K62-p-S177-N dimer binds to PKL</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PKLR-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P30613" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pklr-human-review-notes">PKLR (human) review notes</h1>
+<p>UniProtKB: P30613 (KPYR_HUMAN). HGNC:9020. Gene: PKLR (synonyms PK1, PKL).<br />
+No falcon deep-research file (falcon out of credits, HTTP 402). Review grounded in<br />
+<code>PKLR-uniprot.txt</code>, <code>PKLR-goa.tsv</code>, and cached <code>publications/PMID_*.md</code>.</p>
+<h2 id="core-biology-from-uniprot-literature">Core biology (from UniProt + literature)</h2>
+<ul>
+<li>PKLR encodes the <strong>L (liver) and R (red-blood-cell) isozymes</strong> of pyruvate kinase,<br />
+  produced by alternative promoters/splicing of a single gene (exon 1 = R mRNA, exon 2 =<br />
+  L mRNA) <a href="https://pubmed.ncbi.nlm.nih.gov/1445295">PMID:1445295</a>. The separate <strong>PKM</strong> gene encodes the M1/M2 isozymes.<br />
+  UniProt MISCELLANEOUS: "There are 4 isozymes of pyruvate kinase in mammals: L, R, M1<br />
+  and M2. L type is major isozyme in the liver, R is found in red cells, M1 is the main<br />
+  form in muscle, heart and brain, and M2 is found in early fetal tissues."</li>
+<li><strong>Reaction (EC 2.7.1.40):</strong> phosphoenolpyruvate (PEP) + ADP → pyruvate + ATP; the<br />
+  final, essentially irreversible, second ATP-generating step of glycolysis<br />
+  (glycolysis step 5/5, pyruvate from D-glyceraldehyde 3-phosphate; UniPathway UPA00109).<br />
+  UniProt CATALYTIC ACTIVITY: "Reaction=pyruvate + ATP = phosphoenolpyruvate + ADP + H(+)".<br />
+  FUNCTION: "Pyruvate kinase that catalyzes the conversion of phosphoenolpyruvate to<br />
+  pyruvate with the synthesis of ATP, and which plays a key role in glycolysis<br />
+  (PubMed:11960989)." <a href="https://pubmed.ncbi.nlm.nih.gov/11960989">PMID:11960989</a></li>
+<li><strong>Cofactors:</strong> Mg2+ (or Mn2+ in vitro) and K+ required. UniProt COFACTOR lists Mg(2+),<br />
+  Mn(2+), K(+). Crystal structure (2VGB/2VGF, 2.73 A) solved with K+ and Mn2+ ions;<br />
+  K+ binding residues 118/120/156/157, Mn2+ (catalytic divalent) at 315/339 <a href="https://pubmed.ncbi.nlm.nih.gov/11960989">PMID:11960989</a>.<br />
+  GO magnesium ion binding GO:0000287 and potassium ion binding GO:0030955 (IEA/InterPro)<br />
+  are structurally supported.</li>
+<li><strong>Allosteric regulation:</strong> activated by fructose 1,6-bisphosphate (feed-forward);<br />
+  FBP-binding residues 475-480, 525, 532, 559-564 <a href="https://pubmed.ncbi.nlm.nih.gov/11960989">PMID:11960989</a>. UniProt ACTIVITY<br />
+  REGULATION: "Allosterically activated by fructose 1,6-bisphosphate." Homotetramer<br />
+  (UniProt SUBUNIT). Liver isoform additionally inhibited by phosphorylation<br />
+  (glucagon/PKA) and by ATP/alanine (classic biochemistry).</li>
+<li><strong>Side reaction / metabolite repair:</strong> also produces the side product 2-phospholactate<br />
+  ((S)-lactate + ATP = (2S)-2-phospholactate + ADP + H+), removed by PGP <a href="https://pubmed.ncbi.nlm.nih.gov/27294321">PMID:27294321</a>.<br />
+  (PMID:27294321 not cached; UniProt-only, so not used as a supporting_text.)</li>
+<li><strong>Structure:</strong> 574 aa homotetramer; classic PK fold (Pfam PK PF00224 + PK_C PF02887;<br />
+  InterPro IPR001697). Many X-ray structures (2VGB, 4IMA, 6NN4, etc.).</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li><strong>CNSHA2 / pyruvate kinase deficiency</strong> (MIM:266200): autosomal recessive; most common<br />
+  glycolytic-enzyme cause of hereditary nonspherocytic hemolytic anemia. Mature<br />
+  erythrocytes lack mitochondria and depend entirely on glycolytic ATP, so RPK loss is<br />
+  hemolytic. Dozens of CNSHA2 missense variants in UniProt. <a href="https://pubmed.ncbi.nlm.nih.gov/11960989">PMID:11960989</a> abstract:<br />
+  "Deficiency of human erythrocyte isozyme (RPK) is, together with glucose-6-phosphate<br />
+  dehydrogenase deficiency, the most common cause of the nonspherocytic hemolytic anemia."</li>
+<li><strong>PKHYP</strong> (MIM:102900): autosomal dominant increase of RBC ATP (variant K37Q/G37E)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9090535">PMID:9090535</a>.</li>
+<li>Drug: mitapivat (PK activator) approved for PK deficiency (UniProt DrugBank DB16236).</li>
+</ul>
+<h2 id="annotation-review-decisions-summary">Annotation review decisions (summary)</h2>
+<p>Core, accepted:<br />
+- GO:0004743 pyruvate kinase activity — multiple EXP/TAS/IBA/IEA; core MF. ACCEPT all.<br />
+- GO:0006096 glycolytic process — IBA + IEA; core BP. ACCEPT.<br />
+- GO:0005829 cytosol — TAS Reactome; correct cellular location. ACCEPT.<br />
+- GO:0000287 magnesium ion binding (IEA/InterPro) — structurally supported cofactor. ACCEPT.<br />
+- GO:0030955 potassium ion binding (IEA/InterPro) — structurally supported cofactor. ACCEPT.<br />
+- GO:0005737 cytoplasm (IBA) — correct but general; cytosol is the informative term. KEEP_AS_NON_CORE.</p>
+<p>Accepted non-core / kept:<br />
+- GO:0042866 pyruvate biosynthetic process (TAS Reactome, IEA) — pyruvate is the product;<br />
+  acceptable framing of the same reaction. KEEP_AS_NON_CORE.<br />
+- GO:0061621 canonical glycolysis (TAS Reactome) — more specific glycolysis term; ACCEPT.<br />
+- GO:0070062 extracellular exosome (HDA) — high-throughput proteomics localization; a<br />
+  common HDA finding for abundant cytosolic enzymes, not a functional site. KEEP_AS_NON_CORE.</p>
+<p>Over-annotations (kept, flagged):<br />
+- GO:0005515 protein binding (IPI, HuRI Y2H hit vs CPNE7, Q9UBL6-2) — bare protein binding,<br />
+  uninformative, single large-scale Y2H. MARK_AS_OVER_ANNOTATED (policy: not REMOVE).<br />
+- GO:0032869 cellular response to insulin stimulus (IBA + IEA) — regulatory/physiological<br />
+  context transferred from rat ortholog; not PKLR's molecular function. MARK_AS_OVER_ANNOTATED.<br />
+- GO:0048029 monosaccharide binding (IEA/Ensembl from rat) — over-broad; FBP is a<br />
+  bisphosphorylated sugar allosteric activator, but "monosaccharide binding" is a<br />
+  misleading generalization of that. MARK_AS_OVER_ANNOTATED.</p>
+<p>IEA physiological-response transfers from the rat ortholog (P12928) via GO_REF:0000107<br />
+(Ensembl Compara orthology projection) — these describe regulation of the liver enzyme's<br />
+expression/activity by hormones/nutrients, not PKLR's own molecular activity. Keep as<br />
+non-core where biologically plausible:<br />
+- GO:0001666 response to hypoxia — KEEP_AS_NON_CORE<br />
+- GO:0007584 response to nutrient — KEEP_AS_NON_CORE<br />
+- GO:0009749 response to glucose — KEEP_AS_NON_CORE<br />
+- GO:0010038 response to metal ion — KEEP_AS_NON_CORE (Mg/K/Mn are cofactors; plausible)<br />
+- GO:0033198 response to ATP — KEEP_AS_NON_CORE (ATP is substrate/product + inhibitor)<br />
+- GO:0051591 response to cAMP — KEEP_AS_NON_CORE (glucagon/PKA regulation of L isoform)<br />
+- GO:0071872 cellular response to epinephrine stimulus — KEEP_AS_NON_CORE</p>
+<h2 id="reference-notes">Reference notes</h2>
+<ul>
+<li>PMID:15996096 is a structure paper on <strong>PKM2</strong> (the PKM gene isozyme), used by Reactome<br />
+  to support GO:0004743 for PKLR by family analogy. Per curation policy, EXP annotation is<br />
+  not removed on abstract-only grounds; the M2/R isozymes share the catalytic mechanism.<br />
+  ACCEPT the pyruvate kinase activity annotation; flag the reference relevance as MEDIUM.</li>
+<li>PMID:19056867 (urinary exosome proteomics) supports the HDA extracellular exosome<br />
+  localization; PKLR is not named in the cached abstract (large proteome list). Kept<br />
+  non-core; reference is LOW relevance to core function.<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P30613
+gene_symbol: PKLR
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PKLR encodes the liver (L) and red-blood-cell (R) isozymes of pyruvate
+  kinase, produced from a single gene by alternative promoters and splicing. It catalyses
+  the final, essentially irreversible, second ATP-generating step of glycolysis, transferring
+  a phosphate from phosphoenolpyruvate (PEP) to ADP to form pyruvate and ATP (EC 2.7.1.40).
+  The enzyme is a cytosolic homotetramer that requires Mg2+ (or Mn2+) and K+, is allosterically
+  activated in a feed-forward manner by fructose 1,6-bisphosphate, and (in the liver isoform)
+  is inhibited by ATP and alanine and by phosphorylation via the glucagon/PKA axis. The
+  separate PKM gene encodes the muscle/M1-M2 isozymes. Because mature erythrocytes lack
+  mitochondria and depend entirely on glycolysis for ATP, loss-of-function variants cause
+  pyruvate kinase deficiency, the most common glycolytic-enzyme cause of hereditary
+  nonspherocytic hemolytic anemia; rare hyperactivating variants raise red-cell ATP.
+alternative_products:
+- name: R-type (PKR)
+  id: P30613-1
+- name: L-type (PKL)
+  id: P30613-2
+  sequence_note: VSP_002883
+existing_annotations:
+- term:
+    id: GO:0004743
+    label: pyruvate kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetically inferred pyruvate kinase activity, the defining molecular
+      function of PKLR and the entire pyruvate kinase family.
+    action: ACCEPT
+    reason: This is the core molecular function of the gene product, catalysing PEP
+      + ADP -&gt; pyruvate + ATP (EC 2.7.1.40). It is directly supported by biochemical
+      and structural characterization of human RPK and by the UniProt catalytic-activity
+      annotation, and is consistent across the pyruvate kinase phylogeny.
+    supported_by:
+    - reference_id: file:human/PKLR/PKLR-uniprot.txt
+      supporting_text: Pyruvate kinase that catalyzes the conversion of
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic assignment of cytoplasmic localization; correct but less
+      informative than the specific cytosol term.
+    action: KEEP_AS_NON_CORE
+    reason: PKLR is a soluble glycolytic enzyme active in the cytosol. Cytoplasm is
+      correct but is subsumed by the more informative GO:0005829 cytosol annotation
+      (TAS, Reactome), so it is retained as a non-core, general localization statement.
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetically inferred participation in glycolysis; PKLR catalyses
+      the final ATP-generating step of the pathway.
+    action: ACCEPT
+    reason: Pyruvate kinase catalyses glycolysis step 5/5 (pyruvate from D-glyceraldehyde
+      3-phosphate), the committed, essentially irreversible PEP -&gt; pyruvate reaction
+      that generates ATP. This is a core biological process for the gene product.
+    supported_by:
+    - reference_id: file:human/PKLR/PKLR-uniprot.txt
+      supporting_text: &#39;PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from
+        D-&#39;
+- term:
+    id: GO:0032869
+    label: cellular response to insulin stimulus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetically projected involvement in the cellular insulin response,
+      reflecting hormonal regulation of the liver isoform rather than PKLR&#39;s own molecular
+      function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The liver (L) isoform&#39;s expression and phosphorylation state are modulated
+      by insulin/glucagon signalling, but this describes upstream regulation of the
+      enzyme, not a process PKLR itself carries out. The phylogenetic support is thin
+      (only two source annotations, PANTHER + rat RGD) and the term over-states PKLR&#39;s
+      role in insulin signalling; it is retained but flagged as an over-annotation.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - ROLE_CONFLATION
+      - CONTEXT_OR_TISSUE_MISMATCH
+      source_entities:
+      - source_id: RGD:3336
+        source_label: Pklr (rat)
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Rat ortholog regulatory/physiological context; captures hormonal
+          regulation of the hepatic enzyme, not a molecular process PKLR itself performs.
+      - source_id: PANTHER:PTN000212861
+        source_label: pyruvate kinase family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Family-node projection of a regulatory biological process, thinly
+          supported (two source annotations only).
+- term:
+    id: GO:0000287
+    label: magnesium ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro-based assignment of magnesium ion binding, the catalytic divalent
+      metal cofactor of pyruvate kinase.
+    action: ACCEPT
+    reason: Pyruvate kinase requires a divalent metal cofactor (Mg2+, or Mn2+ in vitro)
+      for catalysis; UniProt lists Mg(2+) and Mn(2+) as cofactors and the human RPK
+      crystal structure resolves the catalytic divalent-metal site. The InterPro mapping
+      is structurally supported.
+    supported_by:
+    - reference_id: file:human/PKLR/PKLR-uniprot.txt
+      supporting_text: Name=Mg(2+); Xref=ChEBI:CHEBI:18420;
+- term:
+    id: GO:0004743
+    label: pyruvate kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Automated multi-method assignment of pyruvate kinase activity (EC 2.7.1.40,
+      RHEA:18157), the core catalytic function.
+    action: ACCEPT
+    reason: Redundant electronic support (mapping via EC 2.7.1.40, RHEA:18157 and PK
+      InterPro domains) for the experimentally established pyruvate kinase activity;
+      correct and consistent with the EXP/TAS/IBA evidence.
+    supported_by:
+    - reference_id: file:human/PKLR/PKLR-uniprot.txt
+      supporting_text: EC=2.7.1.40 {ECO:0000269|PubMed:11960989}
+- term:
+    id: GO:0006096
+    label: glycolytic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Automated multi-method assignment (via UniPathway glycolysis) of participation
+      in the glycolytic process.
+    action: ACCEPT
+    reason: Redundant electronic support for PKLR&#39;s role in glycolysis, consistent
+      with the UniProt pathway annotation and the IBA glycolytic process annotation.
+    supported_by:
+    - reference_id: file:human/PKLR/PKLR-uniprot.txt
+      supporting_text: &#39;PATHWAY: Carbohydrate degradation; glycolysis; pyruvate from
+        D-&#39;
+- term:
+    id: GO:0030955
+    label: potassium ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro-based assignment of potassium ion binding, the required monovalent
+      cation cofactor of pyruvate kinase.
+    action: ACCEPT
+    reason: Pyruvate kinase activity requires K+; the human RPK structure resolves
+      the K+ site (binding residues 118, 120, 156, 157) and UniProt lists K(+) as
+      a cofactor. The InterPro mapping is structurally supported.
+    supported_by:
+    - reference_id: file:human/PKLR/PKLR-uniprot.txt
+      supporting_text: Name=K(+); Xref=ChEBI:CHEBI:29103;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: Single high-throughput yeast two-hybrid interaction (with CPNE7, UniProt
+      Q9UBL6-2) from the HuRI reference interactome; uninformative bare protein-binding
+      term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;GO:0005515 protein binding conveys no specific molecular function and
+      derives from a single systematic Y2H screen (HuRI) reporting a PKLR-CPNE7 interaction
+      with no functional characterization or independent orthogonal validation for
+      PKLR. Per curation guidance this bare protein-binding IPI is retained but flagged
+      as an over-annotation rather than treated as a core function.&#39;
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: With approximately 53,000 protein-protein interactions, HuRI
+        has approximately four times as many such interactions as there are high-quality
+        curated interactions from small-scale studies.
+- term:
+    id: GO:0001666
+    label: response to hypoxia
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Response to hypoxia projected electronically from the rat ortholog (P12928)
+      via Ensembl Compara orthology.
+    action: KEEP_AS_NON_CORE
+    reason: This is an orthology-transferred physiological/regulatory context (glycolytic
+      flux is modulated under hypoxia), not PKLR&#39;s own molecular function. Biologically
+      plausible for a glycolytic enzyme but peripheral to the core catalytic role,
+      so retained as non-core.
+- term:
+    id: GO:0007584
+    label: response to nutrient
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Response to nutrient projected electronically from the rat ortholog (P12928)
+      via Ensembl Compara orthology.
+    action: KEEP_AS_NON_CORE
+    reason: Reflects nutritional/dietary regulation of the hepatic pyruvate kinase
+      isoform&#39;s expression rather than PKLR&#39;s molecular function. Retained as a non-core,
+      orthology-inferred regulatory context.
+- term:
+    id: GO:0009749
+    label: response to glucose
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Response to glucose projected electronically from the rat ortholog (P12928)
+      via Ensembl Compara orthology.
+    action: KEEP_AS_NON_CORE
+    reason: Hepatic pyruvate kinase (L isoform) transcription is induced by dietary
+      glucose/carbohydrate; this is a regulatory context transferred from the rat
+      ortholog, not PKLR&#39;s molecular activity. Retained as non-core.
+- term:
+    id: GO:0010038
+    label: response to metal ion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Response to metal ion projected electronically from the rat ortholog
+      (P12928) via Ensembl Compara orthology.
+    action: KEEP_AS_NON_CORE
+    reason: Pyruvate kinase depends on Mg2+/Mn2+ and K+ as catalytic cofactors, so
+      metal-ion sensitivity is biologically plausible, but this orthology-transferred
+      biological-process term overlaps with the more precise metal-ion-binding molecular-function
+      annotations and is peripheral to the core function. Retained as non-core.
+- term:
+    id: GO:0032869
+    label: cellular response to insulin stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Cellular insulin response projected electronically from the rat ortholog
+      (P12928); reflects hormonal regulation of the liver isoform, not PKLR&#39;s molecular
+      function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Duplicates the IBA cellular-response-to-insulin annotation via orthology
+      transfer. It captures upstream insulin/glucagon regulation of hepatic pyruvate
+      kinase expression and phosphorylation rather than a process PKLR itself performs;
+      retained but flagged as an over-annotation.
+- term:
+    id: GO:0033198
+    label: response to ATP
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Response to ATP projected electronically from the rat ortholog (P12928)
+      via Ensembl Compara orthology.
+    action: KEEP_AS_NON_CORE
+    reason: ATP is both a product of the pyruvate kinase reaction and a classic allosteric
+      inhibitor of the enzyme, so ATP-sensitivity is biologically real, but this orthology-transferred
+      biological-process term is peripheral to the core catalytic function. Retained
+      as non-core.
+- term:
+    id: GO:0042866
+    label: pyruvate biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Pyruvate biosynthesis projected electronically from the rat ortholog
+      (P12928); an alternative process framing of the pyruvate kinase reaction, whose
+      product is pyruvate.
+    action: KEEP_AS_NON_CORE
+    reason: Pyruvate is the direct product of the pyruvate kinase reaction, so this
+      is a correct but redundant restatement of the glycolytic function. It duplicates
+      the Reactome TAS pyruvate-biosynthetic-process annotation and is subsumed by
+      the glycolytic-process core annotation; retained as non-core.
+- term:
+    id: GO:0048029
+    label: monosaccharide binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: Monosaccharide binding projected electronically from the rat ortholog
+      (P12928); likely a misleading generalization of fructose 1,6-bisphosphate allosteric
+      binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PKLR is allosterically activated by fructose 1,6-bisphosphate, a bisphosphorylated
+      hexose, via a dedicated allosteric site. Generalizing this to broad monosaccharide
+      binding is misleading (FBP is a phosphorylated sugar bisphosphate, not a free
+      monosaccharide) and adds no informative molecular function. Retained but flagged
+      as an over-annotation.
+- term:
+    id: GO:0051591
+    label: response to cAMP
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Response to cAMP projected electronically from the rat ortholog (P12928)
+      via Ensembl Compara orthology.
+    action: KEEP_AS_NON_CORE
+    reason: Glucagon raises hepatic cAMP, activating PKA, which phosphorylates and
+      inhibits the liver pyruvate kinase isoform; cAMP-responsiveness is therefore
+      biologically plausible but represents upstream regulation rather than PKLR&#39;s
+      molecular function. Retained as non-core.
+- term:
+    id: GO:0071872
+    label: cellular response to epinephrine stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: Cellular epinephrine response projected electronically from the rat ortholog
+      (P12928) via Ensembl Compara orthology.
+    action: KEEP_AS_NON_CORE
+    reason: Epinephrine, like glucagon, elevates cAMP/PKA signalling that regulates
+      hepatic pyruvate kinase activity by phosphorylation; this is an orthology-transferred
+      regulatory context peripheral to PKLR&#39;s core catalytic function. Retained as
+      non-core.
+- term:
+    id: GO:0042866
+    label: pyruvate biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70268
+  qualifier: involved_in
+  review:
+    summary: Reactome-asserted involvement in pyruvate biosynthesis, reflecting that
+      pyruvate is the product of the pyruvate kinase reaction.
+    action: KEEP_AS_NON_CORE
+    reason: Correct product-oriented framing of the same PEP -&gt; pyruvate reaction that
+      is captured more informatively by the glycolytic-process and pyruvate-kinase-activity
+      core annotations. Retained as non-core to avoid redundancy with the core function.
+- term:
+    id: GO:0061621
+    label: canonical glycolysis
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-70171
+  qualifier: involved_in
+  review:
+    summary: Reactome-asserted participation in canonical glycolysis (Embden-Meyerhof-Parnas
+      pathway), the final ATP-generating step of which PKLR catalyses.
+    action: ACCEPT
+    reason: Canonical glycolysis is a precise subtype of glycolytic process describing
+      the classic glucose-to-pyruvate EMP pathway, of which pyruvate kinase catalyses
+      the terminal committed step. This accurately captures PKLR&#39;s biological process
+      role.
+- term:
+    id: GO:0004743
+    label: pyruvate kinase activity
+  evidence_type: EXP
+  original_reference_id: PMID:11960989
+  qualifier: enables
+  review:
+    summary: Experimentally demonstrated pyruvate kinase activity of human erythrocyte
+      RPK, characterized structurally and kinetically together with disease mutants.
+    action: ACCEPT
+    reason: This study solved the crystal structure of human RPK in complex with fructose
+      1,6-bisphosphate and a substrate analogue and functionally characterized wild-type
+      and mutant enzymes, directly establishing the pyruvate kinase catalytic activity
+      that is the core molecular function of PKLR.
+    supported_by:
+    - reference_id: PMID:11960989
+      supporting_text: we have solved the 2.7 A resolution crystal structure of human
+        RPK in complex with fructose 1,6-bisphosphate, the allosteric activator, and
+        phosphoglycolate, a substrate analogue
+- term:
+    id: GO:0004743
+    label: pyruvate kinase activity
+  evidence_type: EXP
+  original_reference_id: PMID:15996096
+  qualifier: enables
+  review:
+    summary: Pyruvate kinase activity supported by a structural/mechanistic study;
+      the cited paper characterizes the human M2 isozyme (PKM gene), applied to PKLR
+      by isozyme analogy via Reactome.
+    action: ACCEPT
+    reason: &#39;The pyruvate kinase catalytic activity assignment is correct for PKLR
+      and independently established by human RPK biochemistry (PMID:11960989). This
+      particular Reactome-sourced EXP citation is the PKM2 crystallography paper (a
+      paralog); the catalytic mechanism, cofactor (Mg2+/K+) and FBP allostery are
+      conserved across the L/R/M1/M2 isozymes, so it does not conflict with the annotation.
+      Per curation policy the experimental annotation is retained rather than removed;
+      reference relevance is flagged as MEDIUM (paralog-derived).&#39;
+    supported_by:
+    - reference_id: PMID:15996096
+      supporting_text: The X-ray structure of human hPKM2 complexed with Mg(2+), K(+),
+        the inhibitor oxalate, and the allosteric activator fructose 1,6-bisphosphate
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomic detection of PKLR in urinary exosomes; a common
+      MS finding for abundant cytosolic enzymes rather than a functional location.
+    action: KEEP_AS_NON_CORE
+    reason: Detection in an exosome/extracellular-vesicle proteome is a frequent incidental
+      finding for highly abundant soluble glycolytic enzymes and does not reflect
+      where PKLR performs its catalytic function (the cytosol). Retained as a non-core
+      localization observation.
+    supported_by:
+    - reference_id: PMID:19056867
+      supporting_text: we used LC-MS/MS to profile the proteome of human urinary exosomes
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-71670
+  qualifier: located_in
+  review:
+    summary: Reactome-asserted cytosolic localization, the compartment where PKLR
+      catalyses the glycolytic pyruvate kinase reaction.
+    action: ACCEPT
+    reason: PKLR is a soluble cytosolic enzyme; glycolysis occurs in the cytosol and
+      the pyruvate kinase step is cytosolic. This is the informative subcellular location
+      and represents the core cellular component for the gene product.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9727857
+  qualifier: located_in
+  review:
+    summary: Reactome-asserted cytosolic localization (from a SARS-CoV-1 host-interaction
+      model), consistent with PKLR being a soluble cytosolic enzyme.
+    action: ACCEPT
+    reason: Duplicate cytosol localization from a different Reactome reaction; correct
+      and consistent with the primary glycolysis-based cytosol annotation. Cytosol
+      is the core cellular component for PKLR.
+- term:
+    id: GO:0004743
+    label: pyruvate kinase activity
+  evidence_type: TAS
+  original_reference_id: PMID:3126495
+  qualifier: enables
+  review:
+    summary: Author-stated pyruvate kinase activity from the study that cloned and
+      expressed human liver (L)-type PK, detecting enzymatic activity in transfected
+      cells.
+    action: ACCEPT
+    reason: This paper determined the full-length human L-type PK cDNA and expressed
+      it in COS cells, where L-type PK activity was detected, corroborating the core
+      pyruvate kinase molecular function of PKLR.
+    supported_by:
+    - reference_id: PMID:3126495
+      supporting_text: Human L-type PK activity was detected in the extract of COS
+        cells by the classical PK electrophoresis method.
+- term:
+    id: GO:0004743
+    label: pyruvate kinase activity
+  evidence_type: NAS
+  original_reference_id: PMID:1445295
+  qualifier: enables
+  review:
+    summary: Non-traceable author statement of pyruvate kinase identity from a study
+      of the human PK L-gene structure and its erythroid promoter.
+    action: ACCEPT
+    reason: This paper characterizes the human pyruvate kinase L-gene (12 exons, R-
+      and L-type transcripts from alternative first exons) and its promoter; the pyruvate
+      kinase activity assignment is correct for the gene, though the evidence here
+      is genomic/promoter rather than a direct activity assay. Consistent with the
+      stronger EXP/TAS evidence, so accepted.
+    supported_by:
+    - reference_id: PMID:1445295
+      supporting_text: The human pyruvate kinase (PK) L-gene is organized in 12 exons
+        over 9.5
+core_functions:
+- description: Catalyses the final, committed, essentially irreversible ATP-generating
+    step of glycolysis, transferring phosphate from phosphoenolpyruvate to ADP to
+    form pyruvate and ATP (EC 2.7.1.40), requiring Mg2+/Mn2+ and K+ as cofactors and
+    allosterically activated by fructose 1,6-bisphosphate.
+  molecular_function:
+    id: GO:0004743
+    label: pyruvate kinase activity
+  directly_involved_in:
+  - id: GO:0006096
+    label: glycolytic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:11960989
+    supporting_text: we have solved the 2.7 A resolution crystal structure of human
+      RPK in complex with fructose 1,6-bisphosphate, the allosteric activator, and
+      phosphoglycolate, a substrate analogue
+  - reference_id: file:human/PKLR/PKLR-uniprot.txt
+    supporting_text: Pyruvate kinase that catalyzes the conversion of
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: file:human/PKLR/PKLR-uniprot.txt
+  title: UniProtKB P30613 (KPYR_HUMAN) Pyruvate kinase PKLR
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Primary source record for PKLR function, catalytic activity (EC
+      2.7.1.40), Mg2+/Mn2+/K+ cofactors, FBP allosteric activation, homotetramer,
+      glycolysis pathway, and CNSHA2/PKHYP disease associations.
+- id: PMID:11960989
+  title: Structure and function of human erythrocyte pyruvate kinase. Molecular basis
+    of nonspherocytic hemolytic anemia.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Crystal structure and functional characterization of human erythrocyte
+      RPK with FBP and a substrate analogue; establishes catalytic activity, cofactors,
+      allostery, and links CNSHA2 mutations to enzyme defects.
+- id: PMID:1445295
+  title: Structural analysis of human pyruvate kinase L-gene and identification of
+    the promoter activity in erythroid cells.
+  findings: []
+- id: PMID:15996096
+  title: Structural basis for tumor pyruvate kinase M2 allosteric regulation and catalysis.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Structure/mechanism paper on the human M2 isozyme (PKM gene), not
+      PKLR. Used by Reactome to support pyruvate kinase activity for PKLR by isozyme
+      analogy; the catalytic mechanism and Mg2+/K+/FBP dependence are conserved across
+      the L/R/M1/M2 isozymes, so it corroborates but is not a direct PKLR study.
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput urinary exosome proteomics; supports the incidental
+      extracellular-exosome localization (HDA) but not PKLR&#39;s core catalytic function.
+      PKLR is not individually discussed in the abstract.
+- id: PMID:3126495
+  title: &#39;Human liver type pyruvate kinase: complete amino acid sequence and the expression
+    in mammalian cells.&#39;
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: HuRI systematic yeast two-hybrid interactome; source of the single
+      PKLR-CPNE7 (Q9UBL6-2) protein-binding IPI. High-throughput, no PKLR-specific
+      functional characterization; underlies an uninformative bare protein-binding
+      annotation flagged as over-annotated.
+- id: Reactome:R-HSA-70171
+  title: Glycolysis
+  findings: []
+- id: Reactome:R-HSA-70268
+  title: Pyruvate metabolism
+  findings: []
+- id: Reactome:R-HSA-71670
+  title: Pyruvate kinase dephosphorylates PEP to PYR
+  findings: []
+- id: Reactome:R-HSA-9727857
+  title: SARS-CoV-1 SUMO1-K62-p-S177-N dimer binds to PKL
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/modules/gluconeogenesis_human_substrates.html
+++ b/pages/modules/gluconeogenesis_human_substrates.html
@@ -584,12 +584,12 @@
                 <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
             <div class="qc-card qc-card-wide">
                 <h3>Gene-review completeness
-                    <span class="muted small">(3/13 grounded genes reviewed)</span>
+                    <span class="muted small">(5/13 grounded genes reviewed)</span>
                 </h3>                    <p class="small muted">
-                        3 complete review(s) &middot;
+                        5 complete review(s) &middot;
                         0 with deep research &middot;
-                        10 missing review &middot;
-                        3 reviewed but lacking deep research
+                        8 missing review &middot;
+                        5 reviewed but lacking deep research
                     </p>
                     <table class="qc-table small">
                         <thead>
@@ -607,20 +607,20 @@
                                     <td class="center"><span class="ok">&#10003;</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                 </tr>                                <tr>
+                                    <td>LDHA
+                                        <span class="muted term-id">P00338</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>LDHB
+                                        <span class="muted term-id">P07195</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
                                     <td>FBP2 (muscle fructose-1,6-bisphosphatase)
                                         <span class="muted term-id">O00757</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>LDHA (L-lactate dehydrogenase A)
-                                        <span class="muted term-id">P00338</span></td>
-                                    <td class="center"><span class="warn">&#10007;</span></td>
-                                    <td class="center">&mdash;</td>
-                                    <td class="center">&mdash;</td>
-                                </tr>                                <tr>
-                                    <td>LDHB (L-lactate dehydrogenase B)
-                                        <span class="muted term-id">P07195</span></td>
                                     <td class="center"><span class="warn">&#10007;</span></td>
                                     <td class="center">&mdash;</td>
                                     <td class="center">&mdash;</td>

--- a/pages/modules/glycolysis_payoff_phase.html
+++ b/pages/modules/glycolysis_payoff_phase.html
@@ -1,0 +1,972 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Glycolysis II — payoff phase (glyceraldehyde-3-phosphate → pyruvate); PGK/PGAM/enolase/PK deficiencies - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / Glycolysis II — payoff phase (glyceraldehyde-3-phosphate → pyruvate); PGK/PGAM/enolase/PK deficiencies
+    </nav>
+
+    <header class="header">
+        <h1>Glycolysis II — payoff phase (glyceraldehyde-3-phosphate → pyruvate); PGK/PGAM/enolase/PK deficiencies</h1>            <p class="description">The payoff (energy-yielding) phase of glycolysis is the second half of the cytosolic pathway, converting each glyceraldehyde-3-phosphate produced in the investment phase into pyruvate while generating ATP and NADH. Five steps: glyceraldehyde-3-phosphate dehydrogenase (GAPDH) oxidises and phosphorylates glyceraldehyde-3-phosphate to 1,3-bisphosphoglycerate, reducing NAD+ to NADH; phosphoglycerate kinase (PGK1) transfers a phosphate from 1,3-bisphosphoglycerate to ADP, forming 3-phosphoglycerate and the first ATP (substrate-level phosphorylation); phosphoglycerate mutase (muscle PGAM2) isomerises 3-phosphoglycerate to 2-phosphoglycerate; enolase (muscle ENO3) dehydrates 2-phosphoglycerate to phosphoenolpyruvate; and pyruvate kinase (liver/RBC PKLR, or muscle/other PKM) transfers the phosphate of phosphoenolpyruvate to ADP, forming pyruvate and the second ATP. Per glucose (two trioses) the payoff phase yields 4 ATP and 2 NADH, for a net glycolytic gain of 2 ATP + 2 NADH + 2 pyruvate. Because mature erythrocytes rely entirely on glycolytic ATP, defects here characteristically cause hereditary nonspherocytic hemolytic anemia, often combined with tissue-specific features: PGK1 deficiency (X-linked hemolytic anemia + myopathy + CNS disease); PGAM2 deficiency = glycogen storage disease type X (muscle); ENO3 deficiency = GSD type XIII (muscle); and PKLR deficiency = pyruvate kinase deficiency, the commonest glycolytic cause of hemolytic anemia.</p>        <div class="meta-row"><span class="pill">MODULE:glycolysis_payoff_phase</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/glycolysis_payoff_phase.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>glycolytic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006096" target="_blank" rel="noopener">GO:0006096</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006096" target="_blank" rel="noopener">GO:0006096</a><div><strong>glycolytic process</strong></div><div>The module is grounded in the GO glycolytic process (GO:0006096); it covers the payoff-phase steps from glyceraldehyde-3-phosphate to pyruvate.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-70171</span><div><strong>Glycolysis</strong></div><div>Step order and reaction stoichiometries follow the human Reactome &#34;Glycolysis&#34; reactions R-HSA-70449 (GAPDH), R-HSA-71850 (PGK1), R-HSA-71654 (PGAM), R-HSA-71660 (enolase) and R-HSA-71670 (pyruvate kinase).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/GAPDH/GAPDH-ai-review.yaml</span><div><strong>GAPDH gene review (human)</strong></div><div>The glyceraldehyde-3-phosphate dehydrogenase step (UniProtKB:P04406, GO:0004365) matches the previously completed human GAPDH review (already on main).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PGK1/PGK1-ai-review.yaml</span><div><strong>PGK1 gene review (human)</strong></div><div>The phosphoglycerate kinase step (UniProtKB:P00558, GO:0004618) matches the completed human PGK1 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PGAM2/PGAM2-ai-review.yaml</span><div><strong>PGAM2 gene review (human)</strong></div><div>The phosphoglycerate mutase step (UniProtKB:P15259, GO:0004619) matches the completed human PGAM2 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ENO3/ENO3-ai-review.yaml</span><div><strong>ENO3 gene review (human)</strong></div><div>The enolase step (UniProtKB:P13929, GO:0004634) matches the completed human ENO3 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PKLR/PKLR-ai-review.yaml</span><div><strong>PKLR gene review (human)</strong></div><div>The pyruvate kinase step (UniProtKB:P30613, GO:0004743) matches the completed human PKLR review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PKM/PKM-ai-review.yaml</span><div><strong>PKM gene review (human)</strong></div><div>The muscle/other pyruvate kinase isozyme of the final step (UniProtKB:P14618, GO:0004743) matches the previously completed human PKM review (already on main).</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">5</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">5</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">4</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:glycolysis_payoff_phase</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(6/6 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        6 complete review(s) &middot;
+                        2 with deep research &middot;
+                        0 missing review &middot;
+                        4 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>ENO3
+                                        <span class="muted term-id">P13929</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>GAPDH
+                                        <span class="muted term-id">P04406</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                                <tr>
+                                    <td>PGAM2
+                                        <span class="muted term-id">P15259</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PGK1
+                                        <span class="muted term-id">P00558</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PKLR
+                                        <span class="muted term-id">P30613</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PKM
+                                        <span class="muted term-id">P14618</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-glycolysis_payoff_phase">Glycolysis (payoff phase)</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">glycolysis_payoff_phase</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. oxidative phosphorylation of the triose (NAD+ reduction)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-gapdh_step">D-glyceraldehyde-3-phosphate + NAD+ + Pi to 1,3-bisphosphoglycerate + NADH</a><span class="pill type">Reaction</span><span class="tree-id">gapdh_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-gapdh_activity">GAPDH: glyceraldehyde-3-phosphate dehydrogenase</a>
+                                <span class="tree-id">Family: Glyceraldehyde-3-phosphate dehydrogenase family (GAPDH/GAPDHS)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. first substrate-level ATP generation</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pgk_step">1,3-bisphosphoglycerate + ADP to 3-phosphoglycerate + ATP</a><span class="pill type">Reaction</span><span class="tree-id">pgk_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pgk_activity">PGK1/PGK2: phosphoglycerate kinase</a>
+                                <span class="tree-id">Family: Phosphoglycerate kinase family (PGK1/PGK2)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. phosphoglycerate isomerisation</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pgam_step">3-phosphoglycerate to 2-phosphoglycerate</a><span class="pill type">Reaction</span><span class="tree-id">pgam_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pgam_activity">PGAM1/PGAM2: phosphoglycerate mutase</a>
+                                <span class="tree-id">Family: Cofactor-dependent phosphoglycerate mutase family (PGAM1/PGAM2/BPGM)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. dehydration to the high-energy enol phosphate</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-enolase_step">2-phosphoglycerate to phosphoenolpyruvate + H2O</a><span class="pill type">Reaction</span><span class="tree-id">enolase_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-enolase_activity">ENO1/ENO2/ENO3: enolase (phosphopyruvate hydratase)</a>
+                                <span class="tree-id">Family: Enolase family (ENO1/ENO2/ENO3)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">5. second substrate-level ATP generation (final, committed)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pk_step">phosphoenolpyruvate + ADP to pyruvate + ATP</a><span class="pill type">Reaction</span><span class="tree-id">pk_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pk_activity">PKM/PKLR: pyruvate kinase</a>
+                                <span class="tree-id">Family: Pyruvate kinase family (PKM/PKLR)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-glycolysis_payoff_phase">
+        <div class="node-heading">
+            <span class="node-title">Glycolysis (payoff phase)</span><span class="pill type">Metabolic Pathway</span><span class="pill">glycolysis_payoff_phase</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>glycolytic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006096" target="_blank" rel="noopener">GO:0006096</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
+
+            </div>
+        <p class="muted small">Five-step payoff phase of glycolysis grounded to the human enzymes GAPDH (UniProtKB:P04406, GO:0004365), phosphoglycerate kinase PGK1 (P00558, GO:0004618), phosphoglycerate mutase PGAM2 (P15259, GO:0004619), beta-enolase ENO3 (P13929, GO:0004634) and pyruvate kinase PKLR (P30613) / PKM (P14618) (GO:0004743). GO molecular-function terms were taken from the human GOA records; Reactome reaction ids and titles were verified against the local reactome cache. Each step uses a PANTHER family selector generic over the tissue isozymes and orthologs (PGAM node covers PGAM1/PGAM2/BPGM; enolase node ENO1/ENO2/ENO3; pyruvate-kinase node PKLR + PKM). GAPDH and PKM were reviewed previously (already on main) and are cross-linked via file: evidence; PGK1/PGAM2/ENO3/PKLR are the reviews new in this batch. Upstream, the two glyceraldehyde-3-phosphate molecules come from the glycolysis investment phase (hexokinase -&gt; GPI -&gt; PFK -&gt; aldolase -&gt; TPI); downstream, pyruvate feeds the pyruvate-metabolism module (PDC/PC) and lactate fermentation (LDHA/LDHB, a separate module), while the reverse reactions (except the PFK/PK/hexokinase committed steps) serve gluconeogenesis. Moonlighting roles (GAPDH; PGK1 extracellular reductase; PKM2 nuclear/protein-kinase) are captured non-core in the individual gene reviews. Disorders: PGK1 (X-linked hemolytic anemia + myopathy + CNS); PGAM2 (GSD X); ENO3 (GSD XIII); PKLR (pyruvate kinase deficiency, hemolytic anemia).</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-gapdh_step">gapdh_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pgk_step">pgk_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">1,3-bisphosphoglycerate from GAPDH is the substrate for PGK1.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pgk_step">pgk_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pgam_step">pgam_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">3-phosphoglycerate from PGK1 is isomerised by PGAM.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pgam_step">pgam_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-enolase_step">enolase_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">2-phosphoglycerate from PGAM is dehydrated by enolase.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-enolase_step">enolase_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pk_step">pk_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Phosphoenolpyruvate from enolase is converted to pyruvate by pyruvate kinase.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: oxidative phosphorylation of the triose (NAD+ reduction)</div>
+                <section class="node-detail depth-1" id="node-gapdh_step">
+        <div class="node-heading">
+            <span class="node-title">D-glyceraldehyde-3-phosphate + NAD+ + Pi to 1,3-bisphosphoglycerate + NADH</span><span class="pill type">Reaction</span><span class="pill">gapdh_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-gapdh_activity">
+        <div class="annoton-title">GAPDH: glyceraldehyde-3-phosphate dehydrogenase</div>
+        <div class="small muted">gapdh_activity</div>            <div class="small"><strong>Participant:</strong> Family: Glyceraldehyde-3-phosphate dehydrogenase family (GAPDH/GAPDHS)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Glyceraldehyde-3-phosphate dehydrogenase family (GAPDH/GAPDHS)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10836" target="_blank" rel="noopener">PANTHER:PTHR10836</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>GAPDH (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P04406/entry" target="_blank" rel="noopener">UniProtKB:P04406</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>glyceraldehyde-3-phosphate dehydrogenase (NAD+) (phosphorylating) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004365" target="_blank" rel="noopener">GO:0004365</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>D-glyceraldehyde 3-phosphate</span></span>                            <span class="descriptor">
+            <span>NAD+</span></span>                            <span class="descriptor">
+            <span>phosphate</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>1,3-bisphospho-D-glycerate</span></span>                            <span class="descriptor">
+            <span>NADH</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Couples oxidation of glyceraldehyde-3-phosphate to formation of the high-energy acyl-phosphate 1,3-bisphosphoglycerate and reduction of NAD+ to NADH (reviewed previously; also a well-known moonlighting protein).</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: first substrate-level ATP generation</div>
+                <section class="node-detail depth-1" id="node-pgk_step">
+        <div class="node-heading">
+            <span class="node-title">1,3-bisphosphoglycerate + ADP to 3-phosphoglycerate + ATP</span><span class="pill type">Reaction</span><span class="pill">pgk_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pgk_activity">
+        <div class="annoton-title">PGK1/PGK2: phosphoglycerate kinase</div>
+        <div class="small muted">pgk_activity</div>            <div class="small"><strong>Participant:</strong> Family: Phosphoglycerate kinase family (PGK1/PGK2)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Phosphoglycerate kinase family (PGK1/PGK2)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11406" target="_blank" rel="noopener">PANTHER:PTHR11406</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PGK1 (human, somatic)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P00558/entry" target="_blank" rel="noopener">UniProtKB:P00558</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>phosphoglycerate kinase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004618" target="_blank" rel="noopener">GO:0004618</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>1,3-bisphospho-D-glycerate</span></span>                            <span class="descriptor">
+            <span>ADP</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>3-phospho-D-glycerate</span></span>                            <span class="descriptor">
+            <span>ATP</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Generates the first ATP of glycolysis by substrate-level phosphorylation (reverse direction in gluconeogenesis). X-linked PGK1 deficiency causes hemolytic anemia with myopathy and CNS disease; PGK2 is testis-specific.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: phosphoglycerate isomerisation</div>
+                <section class="node-detail depth-1" id="node-pgam_step">
+        <div class="node-heading">
+            <span class="node-title">3-phosphoglycerate to 2-phosphoglycerate</span><span class="pill type">Reaction</span><span class="pill">pgam_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pgam_activity">
+        <div class="annoton-title">PGAM1/PGAM2: phosphoglycerate mutase</div>
+        <div class="small muted">pgam_activity</div>            <div class="small"><strong>Participant:</strong> Family: Cofactor-dependent phosphoglycerate mutase family (PGAM1/PGAM2/BPGM)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Cofactor-dependent phosphoglycerate mutase family (PGAM1/PGAM2/BPGM)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11931" target="_blank" rel="noopener">PANTHER:PTHR11931</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PGAM2 (human, muscle isozyme)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P15259/entry" target="_blank" rel="noopener">UniProtKB:P15259</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>phosphoglycerate mutase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004619" target="_blank" rel="noopener">GO:0004619</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>3-phospho-D-glycerate</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>2-phospho-D-glycerate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Interconverts 3- and 2-phosphoglycerate (dimer of the muscle PGAM2/M and brain PGAM1/B subunits; muscle = PGAM2 homodimer). PGAM2 deficiency = GSD type X (exercise intolerance, myoglobinuria).</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 4: dehydration to the high-energy enol phosphate</div>
+                <section class="node-detail depth-1" id="node-enolase_step">
+        <div class="node-heading">
+            <span class="node-title">2-phosphoglycerate to phosphoenolpyruvate + H2O</span><span class="pill type">Reaction</span><span class="pill">enolase_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-enolase_activity">
+        <div class="annoton-title">ENO1/ENO2/ENO3: enolase (phosphopyruvate hydratase)</div>
+        <div class="small muted">enolase_activity</div>            <div class="small"><strong>Participant:</strong> Family: Enolase family (ENO1/ENO2/ENO3)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Enolase family (ENO1/ENO2/ENO3)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11902" target="_blank" rel="noopener">PANTHER:PTHR11902</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ENO3 (human, muscle beta-enolase)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P13929/entry" target="_blank" rel="noopener">UniProtKB:P13929</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>phosphopyruvate hydratase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004634" target="_blank" rel="noopener">GO:0004634</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>2-phospho-D-glycerate</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>phosphoenolpyruvate</span></span>                            <span class="descriptor">
+            <span>water</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Mg2+-dependent dehydration of 2-phosphoglycerate to phosphoenolpyruvate. Tissue isozymes ENO1 (alpha, ubiquitous), ENO2 (gamma, neuronal), ENO3 (beta, muscle); ENO3 deficiency = GSD type XIII.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 5: second substrate-level ATP generation (final, committed)</div>
+                <section class="node-detail depth-1" id="node-pk_step">
+        <div class="node-heading">
+            <span class="node-title">phosphoenolpyruvate + ADP to pyruvate + ATP</span><span class="pill type">Reaction</span><span class="pill">pk_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pk_activity">
+        <div class="annoton-title">PKM/PKLR: pyruvate kinase</div>
+        <div class="small muted">pk_activity</div>            <div class="small"><strong>Participant:</strong> Family: Pyruvate kinase family (PKM/PKLR)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Pyruvate kinase family (PKM/PKLR)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11817" target="_blank" rel="noopener">PANTHER:PTHR11817</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PKLR (human, liver/red-cell isozyme)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P30613/entry" target="_blank" rel="noopener">UniProtKB:P30613</a></span>                            <span class="descriptor">
+            <span>PKM (human, muscle/M1-M2 isozyme)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P14618/entry" target="_blank" rel="noopener">UniProtKB:P14618</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>pyruvate kinase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004743" target="_blank" rel="noopener">GO:0004743</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>phosphoenolpyruvate</span></span>                            <span class="descriptor">
+            <span>ADP</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>pyruvate</span></span>                            <span class="descriptor">
+            <span>ATP</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Final, essentially irreversible glycolytic step generating the second ATP; homotetramer, Mg2+/K+-dependent, allosterically activated by fructose-1,6-bisphosphate. PKLR (liver/RBC) deficiency = pyruvate kinase deficiency (commonest glycolytic hemolytic anemia); PKM = muscle/other.</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -285,7 +285,7 @@
 
     <section class="toolbar">
         <input class="search" type="search" placeholder="Filter modules" data-module-search>
-        <div class="count"><span data-visible-count>113</span> / 113 modules</div>
+        <div class="count"><span data-visible-count>115</span> / 115 modules</div>
     </section>
 
     <div class="table-wrap">
@@ -1571,8 +1571,8 @@ Unlike molecular-function-tiered motifs (e.g. the MAPK relay, where every realiz
                     <td class="num">10</td>
                     <td class="num">6</td>
                     <td class="num">12</td>
-                    <td class="num">0</td>                    <td class="num" data-sort-value="3">
-                        3/13
+                    <td class="num">0</td>                    <td class="num" data-sort-value="5">
+                        5/13
                     </td>
                     <td class="num" data-sort-value="0">
                         0
@@ -1693,6 +1693,29 @@ Unlike molecular-function-tiered motifs (e.g. the MAPK relay, where every realiz
                         0
                     </td>
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/glycolysis_investment_phase.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="Glycolysis II — payoff phase (glyceraldehyde-3-phosphate → pyruvate); PGK/PGAM/enolase/PK deficiencies">
+                        <a class="module-name" href="glycolysis_payoff_phase.html">Glycolysis II — payoff phase (glyceraldehyde-3-phosphate → pyruvate); PGK/PGAM/enolase/PK deficiencies</a><span class="module-id">MODULE:glycolysis_payoff_phase</span>                        <span class="module-desc">The payoff (energy-yielding) phase of glycolysis is the second half of the cytosolic pathway, converting each glyceraldehyde-3-phosphate produced...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">The payoff (energy-yielding) phase of glycolysis is the second half of the cytosolic pathway, converting each glyceraldehyde-3-phosphate produced in the investment phase into pyruvate while generating ATP and NADH. Five steps: glyceraldehyde-3-phosphate dehydrogenase (GAPDH) oxidises and phosphorylates glyceraldehyde-3-phosphate to 1,3-bisphosphoglycerate, reducing NAD+ to NADH; phosphoglycerate kinase (PGK1) transfers a phosphate from 1,3-bisphosphoglycerate to ADP, forming 3-phosphoglycerate and the first ATP (substrate-level phosphorylation); phosphoglycerate mutase (muscle PGAM2) isomerises 3-phosphoglycerate to 2-phosphoglycerate; enolase (muscle ENO3) dehydrates 2-phosphoglycerate to phosphoenolpyruvate; and pyruvate kinase (liver/RBC PKLR, or muscle/other PKM) transfers the phosphate of phosphoenolpyruvate to ADP, forming pyruvate and the second ATP. Per glucose (two trioses) the payoff phase yields 4 ATP and 2 NADH, for a net glycolytic gain of 2 ATP + 2 NADH + 2 pyruvate. Because mature erythrocytes rely entirely on glycolytic ATP, defects here characteristically cause hereditary nonspherocytic hemolytic anemia, often combined with tissue-specific features: PGK1 deficiency (X-linked hemolytic anemia + myopathy + CNS disease); PGAM2 deficiency = glycogen storage disease type X (muscle); ENO3 deficiency = GSD type XIII (muscle); and PKLR deficiency = pyruvate kinase deficiency, the commonest glycolytic cause of hemolytic anemia.</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">glycolytic process</span>                        </div>                    </td>
+                    <td class="num">6</td>
+                    <td class="num">5</td>
+                    <td class="num">5</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">4</td>                    <td class="num" data-sort-value="6">
+                        6/6
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/glycolysis_payoff_phase.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="HGF-MET signaling pathway module">
                         <a class="module-name" href="hgf_met_signaling.html">HGF-MET signaling pathway module</a><span class="module-id">MODULE:hgf_met_signaling</span>                        <span class="module-desc">Hepatocyte growth factor activates the MET receptor tyrosine kinase, recruiting multisite docking adaptors that coordinate motility, invasive...</span>                        <details class="module-desc-more">
@@ -2130,6 +2153,29 @@ Unlike molecular-function-tiered motifs (e.g. the MAPK relay, where every realiz
                         0
                     </td>
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/tyrosine_catabolism.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="Lactate fermentation and the Rapoport-Luebering (2,3-BPG) shunt — GSD XI, BPGM deficiency">
+                        <a class="module-name" href="lactate_fermentation_and_bpg_shunt.html">Lactate fermentation and the Rapoport-Luebering (2,3-BPG) shunt — GSD XI, BPGM deficiency</a><span class="module-id">MODULE:lactate_fermentation_and_bpg_shunt</span>                        <span class="module-desc">Two branch reactions of glycolysis, prominent in anaerobic tissue and in erythrocytes (which depend entirely on glycolysis and lack mitochondria)....</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">Two branch reactions of glycolysis, prominent in anaerobic tissue and in erythrocytes (which depend entirely on glycolysis and lack mitochondria). (1) Lactate fermentation: lactate dehydrogenase (a tetramer of the LDHA/M and LDHB/H subunits) reduces the glycolytic end-product pyruvate to L-lactate using NADH, regenerating the NAD+ that glyceraldehyde-3-phosphate dehydrogenase needs to sustain glycolytic flux when oxidative phosphorylation is unavailable or saturated; the LDHA-rich isoenzymes favour pyruvate to lactate (anaerobic/glycolytic tissue) while LDHB-rich isoenzymes favour the reverse oxidation of lactate to pyruvate (oxidative tissue). (2) The Rapoport-Luebering shunt: bisphosphoglycerate mutase (BPGM) diverts 1,3-bisphosphoglycerate to 2,3-bisphosphoglycerate (and hydrolyses it onward to 3-phosphoglycerate), bypassing the ATP-generating phosphoglycerate-kinase step; 2,3-bisphosphoglycerate is the principal allosteric effector that binds deoxyhemoglobin and lowers its oxygen affinity, tuning O2 delivery to tissues. Both branches feed off glycolytic intermediates (pyruvate and 1,3-bisphosphoglycerate respectively). Inherited defects: LDHA deficiency causes glycogen storage disease type XI (exertional myopathy, myoglobinuria, skin lesions); LDHB deficiency is usually clinically silent; and BPGM deficiency lowers 2,3-BPG, raising hemoglobin oxygen affinity and causing secondary erythrocytosis.</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">glycolytic process</span>                        </div>                    </td>
+                    <td class="num">3</td>
+                    <td class="num">2</td>
+                    <td class="num">2</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>                    <td class="num" data-sort-value="3">
+                        3/3
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/lactate_fermentation_and_bpg_shunt.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="Lysosomal glycogen degradation (acid alpha-glucosidase) — Pompe disease (GSD II)">
                         <a class="module-name" href="lysosomal_glycogen_degradation.html">Lysosomal glycogen degradation (acid alpha-glucosidase) — Pompe disease (GSD II)</a><span class="module-id">MODULE:lysosomal_glycogen_degradation</span>                        <span class="module-desc">Lysosomal glycogen degradation is the acid-hydrolase route for breaking down the glycogen that is delivered to lysosomes by autophagy (glycophagy),...</span>                        <details class="module-desc-more">

--- a/pages/modules/lactate_fermentation_and_bpg_shunt.html
+++ b/pages/modules/lactate_fermentation_and_bpg_shunt.html
@@ -1,0 +1,800 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Lactate fermentation and the Rapoport-Luebering (2,3-BPG) shunt — GSD XI, BPGM deficiency - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / Lactate fermentation and the Rapoport-Luebering (2,3-BPG) shunt — GSD XI, BPGM deficiency
+    </nav>
+
+    <header class="header">
+        <h1>Lactate fermentation and the Rapoport-Luebering (2,3-BPG) shunt — GSD XI, BPGM deficiency</h1>            <p class="description">Two branch reactions of glycolysis, prominent in anaerobic tissue and in erythrocytes (which depend entirely on glycolysis and lack mitochondria). (1) Lactate fermentation: lactate dehydrogenase (a tetramer of the LDHA/M and LDHB/H subunits) reduces the glycolytic end-product pyruvate to L-lactate using NADH, regenerating the NAD+ that glyceraldehyde-3-phosphate dehydrogenase needs to sustain glycolytic flux when oxidative phosphorylation is unavailable or saturated; the LDHA-rich isoenzymes favour pyruvate to lactate (anaerobic/glycolytic tissue) while LDHB-rich isoenzymes favour the reverse oxidation of lactate to pyruvate (oxidative tissue). (2) The Rapoport-Luebering shunt: bisphosphoglycerate mutase (BPGM) diverts 1,3-bisphosphoglycerate to 2,3-bisphosphoglycerate (and hydrolyses it onward to 3-phosphoglycerate), bypassing the ATP-generating phosphoglycerate-kinase step; 2,3-bisphosphoglycerate is the principal allosteric effector that binds deoxyhemoglobin and lowers its oxygen affinity, tuning O2 delivery to tissues. Both branches feed off glycolytic intermediates (pyruvate and 1,3-bisphosphoglycerate respectively). Inherited defects: LDHA deficiency causes glycogen storage disease type XI (exertional myopathy, myoglobinuria, skin lesions); LDHB deficiency is usually clinically silent; and BPGM deficiency lowers 2,3-BPG, raising hemoglobin oxygen affinity and causing secondary erythrocytosis.</p>        <div class="meta-row"><span class="pill">MODULE:lactate_fermentation_and_bpg_shunt</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/lactate_fermentation_and_bpg_shunt.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>glycolytic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006096" target="_blank" rel="noopener">GO:0006096</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006096" target="_blank" rel="noopener">GO:0006096</a><div><strong>glycolytic process</strong></div><div>Both branches act on glycolytic intermediates (GO:0006096): LDH on pyruvate (NAD+ regeneration / lactate fermentation) and BPGM on 1,3-bisphosphoglycerate (2,3-BPG shunt).</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-71849</span><div><strong>LDH tetramer reduces PYR to LACT</strong></div><div>Reactions follow the human Reactome reactions R-HSA-71849 (LDH pyruvate -&gt; lactate) and R-HSA-6798335 (BPGM 1,3-BPG -&gt; 2,3-BPG).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/LDHA/LDHA-ai-review.yaml</span><div><strong>LDHA gene review (human)</strong></div><div>The lactate-fermentation step (UniProtKB:P00338, GO:0004459) matches the completed human LDHA review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/LDHB/LDHB-ai-review.yaml</span><div><strong>LDHB gene review (human)</strong></div><div>The lactate-oxidising isozyme of the same step (UniProtKB:P07195, GO:0004459) matches the completed human LDHB review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/BPGM/BPGM-ai-review.yaml</span><div><strong>BPGM gene review (human)</strong></div><div>The 2,3-bisphosphoglycerate shunt step (UniProtKB:P07738, GO:0004082) matches the completed human BPGM review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:lactate_fermentation_and_bpg_shunt</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(3/3 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        3 complete review(s) &middot;
+                        0 with deep research &middot;
+                        0 missing review &middot;
+                        3 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>BPGM
+                                        <span class="muted term-id">P07738</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>LDHA
+                                        <span class="muted term-id">P00338</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>LDHB
+                                        <span class="muted term-id">P07195</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-lactate_fermentation_and_bpg_shunt">Lactate fermentation and 2,3-BPG shunt</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">lactate_fermentation_and_bpg_shunt</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. lactate fermentation (NAD+ regeneration)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-ldh_step">pyruvate + NADH to L-lactate + NAD+</a><span class="pill type">Reaction</span><span class="tree-id">ldh_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-ldh_activity">LDHA/LDHB: L-lactate dehydrogenase</a>
+                                <span class="tree-id">Family: L-lactate dehydrogenase family (LDHA/LDHB/LDHC)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. Rapoport-Luebering shunt (2,3-BPG synthesis, Hb O2-affinity control)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-bpgm_step">1,3-bisphosphoglycerate to 2,3-bisphosphoglycerate</a><span class="pill type">Reaction</span><span class="tree-id">bpgm_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-bpgm_activity">BPGM: bisphosphoglycerate mutase</a>
+                                <span class="tree-id">Family: Cofactor-dependent phosphoglycerate mutase family (BPGM/PGAM)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-lactate_fermentation_and_bpg_shunt">
+        <div class="node-heading">
+            <span class="node-title">Lactate fermentation and 2,3-BPG shunt</span><span class="pill type">Metabolic Pathway</span><span class="pill">lactate_fermentation_and_bpg_shunt</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>glycolytic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006096" target="_blank" rel="noopener">GO:0006096</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
+
+            </div>
+        <p class="muted small">Two erythrocyte/anaerobic glycolysis branch reactions grounded to the human enzymes lactate dehydrogenase LDHA (UniProtKB:P00338) / LDHB (P07195) (GO:0004459, EC 1.1.1.27) and bisphosphoglycerate mutase BPGM (P07738, GO:0004082, EC 5.4.2.4). GO molecular-function terms were taken from the human GOA records; Reactome reaction ids and titles were verified against the local reactome cache. The LDH node uses PANTHER PTHR43128 (LDHA/LDHB/LDHC) with LDHA and LDHB as representatives; BPGM shares PANTHER PTHR11931 with the phosphoglycerate mutases (PGAM1/PGAM2; glycolysis payoff module). The two branches are independent (no direct connection): LDH draws pyruvate from the end of the glycolysis payoff phase (pyruvate kinase) and its lactate feeds the Cori cycle / gluconeogenesis, while BPGM diverts 1,3-bisphosphoglycerate produced by GAPDH, bypassing the PGK1 ATP-generating step (so the shunt trades ATP yield for 2,3-BPG-based control of hemoglobin oxygen affinity). LDH pyruvate&lt;-&gt;lactate also connects to the pyruvate-metabolism module (PDC/PC oxidative fate). Disorders: LDHA -&gt; GSD XI (exertional myopathy); LDHB -&gt; usually asymptomatic; BPGM -&gt; bisphosphoglycerate mutase deficiency (low 2,3-BPG, high Hb-O2 affinity, erythrocytosis).</p>                <div class="part-marker">
+                    Part 1: lactate fermentation (NAD+ regeneration)</div>
+                <section class="node-detail depth-1" id="node-ldh_step">
+        <div class="node-heading">
+            <span class="node-title">pyruvate + NADH to L-lactate + NAD+</span><span class="pill type">Reaction</span><span class="pill">ldh_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-ldh_activity">
+        <div class="annoton-title">LDHA/LDHB: L-lactate dehydrogenase</div>
+        <div class="small muted">ldh_activity</div>            <div class="small"><strong>Participant:</strong> Family: L-lactate dehydrogenase family (LDHA/LDHB/LDHC)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>L-lactate dehydrogenase family (LDHA/LDHB/LDHC)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR43128" target="_blank" rel="noopener">PANTHER:PTHR43128</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>LDHA (human, M/muscle subunit)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P00338/entry" target="_blank" rel="noopener">UniProtKB:P00338</a></span>                            <span class="descriptor">
+            <span>LDHB (human, H/heart subunit)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P07195/entry" target="_blank" rel="noopener">UniProtKB:P07195</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>L-lactate dehydrogenase (NAD+) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004459" target="_blank" rel="noopener">GO:0004459</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>pyruvate</span></span>                            <span class="descriptor">
+            <span>NADH</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>L-lactate</span></span>                            <span class="descriptor">
+            <span>NAD+</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Reduces pyruvate to lactate, regenerating NAD+ so glycolysis can continue anaerobically (LDHA/M4 favours this direction); the reverse oxidation of lactate to pyruvate (LDHB/H4, oxidative tissue) feeds gluconeogenesis/the Cori cycle. LDHA deficiency = GSD XI.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: Rapoport-Luebering shunt (2,3-BPG synthesis, Hb O2-affinity control)</div>
+                <section class="node-detail depth-1" id="node-bpgm_step">
+        <div class="node-heading">
+            <span class="node-title">1,3-bisphosphoglycerate to 2,3-bisphosphoglycerate</span><span class="pill type">Reaction</span><span class="pill">bpgm_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-bpgm_activity">
+        <div class="annoton-title">BPGM: bisphosphoglycerate mutase</div>
+        <div class="small muted">bpgm_activity</div>            <div class="small"><strong>Participant:</strong> Family: Cofactor-dependent phosphoglycerate mutase family (BPGM/PGAM)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Cofactor-dependent phosphoglycerate mutase family (BPGM/PGAM)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11931" target="_blank" rel="noopener">PANTHER:PTHR11931</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>BPGM (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P07738/entry" target="_blank" rel="noopener">UniProtKB:P07738</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>bisphosphoglycerate mutase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004082" target="_blank" rel="noopener">GO:0004082</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>1,3-bisphospho-D-glycerate</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>2,3-bisphospho-D-glycerate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Trifunctional erythrocyte enzyme of the Rapoport-Luebering shunt: makes 2,3-bisphosphoglycerate from 1,3-bisphosphoglycerate (bypassing the ATP-generating PGK1 step) and degrades it to 3-phosphoglycerate. 2,3-BPG lowers hemoglobin O2 affinity; BPGM deficiency causes erythrocytosis.</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3113 |
| Gene review HTML pages | 3113 |
| Project pages | 1109 |
| Module pages | 116 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
