### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/ALG10/ALG10-ai-review.html
+++ b/genes/human/ALG10/ALG10-ai-review.html
@@ -1,0 +1,3026 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ALG10 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ALG10</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q5BKT4" target="_blank" class="term-link">
+                        Q5BKT4
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ALG10";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q5BKT4" data-a="DESCRIPTION: ALG10 (ALG10A) is an endoplasmic reticulum membran..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ALG10 (ALG10A) is an endoplasmic reticulum membrane, multi-pass alpha-1,2-glucosyltransferase (EC 2.4.1.256) that catalyzes the final, glucose-capping step of dolichol-linked oligosaccharide (LLO) assembly. Acting on the lumenal face of the ER, it transfers glucose from dolichyl-phosphate-glucose (Dol-P-Glc, not UDP-Glc) onto the Glc2Man9GlcNAc2-PP-dolichol intermediate, adding the third and terminal alpha-1,2-linked glucose to produce the mature, fully assembled Glc3Man9GlcNAc2-PP-dolichol precursor. This mature glycan is the substrate transferred en bloc by the oligosaccharyltransferase (OST) complex onto asparagine residues of nascent polypeptides during protein N-linked glycosylation; the terminal glucose added by ALG10 is the key recognition signal for efficient OST transfer, and its subsequent glucosidase trimming feeds the calnexin/calreticulin glycoprotein quality-control cycle. ALG10 belongs to the ALG10 glucosyltransferase family (CAZy GT59).</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0005783" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred ER localization. ALG10 is a multi-pass ER membrane enzyme whose catalytic (LLO glucosylation) activity occurs at the ER; this is consistent with UniProt. Correct but less specific than the ER membrane term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records ALG10 as an endoplasmic reticulum membrane protein, and LLO assembly is an ER-localized process. IBA localization to the ER is well supported by the family and by the multi-pass membrane topology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG10/ALG10-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">operates in the biosynthetic pathway of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0006487" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. ALG10 completes assembly of the LLO precursor that OST transfers to asparagine residues of nascent proteins, so it is directly required for protein N-linked glycosylation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IBA inference (drawn from broadly conserved ALG10 orthologs) matches UniProt&#39;s description of ALG10&#39;s role in producing the glycan precursor used in protein asparagine (N)-glycosylation. This is a core function of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG10/ALG10-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the third and last glucose residue from dolichyl phosphate glucose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106073" target="_blank" class="term-link">
+                                    GO:0106073
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Glc2Man9GlcNAc2 alpha-1,2-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0106073" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function. This is the Dol-P-Glc-dependent alpha-1,2-glucosyltransferase activity (EC 2.4.1.256, RHEA:29543) that adds the third/terminal glucose to Glc2Man9GlcNAc2-PP-dolichol, yielding Glc3Man9GlcNAc2-PP-dolichol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the defining catalytic activity of ALG10, supported by UniProt (EC 2.4.1.256, RHEA:29543) and the phylogenetic inference across ALG10 orthologs. It is the correct, specific molecular function term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG10/ALG10-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Glc(2)Man(9)GlcNAc(2)-PP-Dol to produce Glc(3)Man(9)GlcNAc(2)-PP-Dol.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ER membrane localization from UniProt subcellular-location mapping. ALG10 is a multi-pass ER membrane protein (10 predicted transmembrane helices).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt SUBCELLULAR LOCATION records ALG10 as an endoplasmic reticulum membrane, multi-pass membrane protein, consistent with its role as an integral ER membrane glucosyltransferase. This is the appropriate, specific cellular component.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG10/ALG10-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0006488" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. ALG10 performs the terminal glucosylation step of dolichol-linked oligosaccharide biosynthesis, producing the mature Glc3Man9GlcNAc2-PP-dolichol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> InterPro2GO mapping (IPR016900, Alg10) to LLO biosynthesis is accurate and, in fact, is the most specific pathway term for ALG10&#39;s role; supported by UniProt&#39;s description of the dolichol-linked oligosaccharide assembly pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG10/ALG10-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">operates in the biosynthetic pathway of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106073" target="_blank" class="term-link">
+                                    GO:0106073
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Glc2Man9GlcNAc2 alpha-1,2-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0106073" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Same core molecular function as the IBA annotation, here derived electronically from EC 2.4.1.256 / RHEA:29543 / InterPro IPR016900.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and consistent with the IBA and ISS annotations of the same term; the EC/RHEA/InterPro basis matches UniProt&#39;s catalytic-activity record.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG10/ALG10-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Glc(2)Man(9)GlcNAc(2)-PP-Dol to produce Glc(3)Man(9)GlcNAc(2)-PP-Dol.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from the HuRI high-throughput binary (yeast two-hybrid) interactome screen (interaction with CD79A, UniProtKB:P11912). This is an uninformative molecular function term that does not describe ALG10&#39;s actual activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;protein binding&#34; (GO:0005515) conveys no specific functional information and this interaction comes from a systematic proteome-wide screen rather than a targeted study of ALG10 function. Per curation policy the experimental annotation is not removed, but it is flagged as an over-annotation relative to ALG10&#39;s core glucosyltransferase function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a reference map of the human protein interactome, generated systematically and comprehensively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from the HuRI binary interactome screen (interaction with FBLN1, UniProtKB:P23142-4). Uninformative MF term from a systematic screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As above: high-throughput binary interaction, not a specific function; retained as experimental but flagged over-annotated. Does not inform ALG10&#39;s core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a reference map of the human protein interactome, generated systematically and comprehensively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from the HuRI binary interactome screen (interaction with SHISAL1, UniProtKB:Q3SXP7). Uninformative MF term from a systematic screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput binary interaction; uninformative &#34;protein binding&#34; not describing ALG10&#39;s actual activity. Retained as experimental but flagged over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a reference map of the human protein interactome, generated systematically and comprehensively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from the HuRI binary interactome screen (interaction with SERP2, UniProtKB:Q8N6R1). Uninformative MF term from a systematic screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput binary interaction; uninformative &#34;protein binding&#34;. Retained as experimental but flagged over-annotated relative to the core glucosyltransferase function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a reference map of the human protein interactome, generated systematically and comprehensively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from the HuRI binary interactome screen (interaction with HERPUD2, UniProtKB:Q9BSE4). Uninformative MF term from a systematic screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput binary interaction; uninformative &#34;protein binding&#34;. Retained as experimental but flagged over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a reference map of the human protein interactome, generated systematically and comprehensively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; from the HuRI binary interactome screen (interaction with ERGIC3, UniProtKB:Q9Y282). Uninformative MF term from a systematic screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput binary interaction; uninformative &#34;protein binding&#34;. Retained as experimental but flagged over-annotated relative to ALG10&#39;s core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a reference map of the human protein interactome, generated systematically and comprehensively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0005789" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ER membrane localization transferred by sequence similarity from the ortholog (UniProtKB:Q5I7T1). Consistent with UniProt and with the multi-pass membrane topology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Agrees with the IEA SubCell ER membrane annotation and UniProt subcellular location; the appropriate, specific cellular component for this integral ER membrane enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG10/ALG10-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106073" target="_blank" class="term-link">
+                                    GO:0106073
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Glc2Man9GlcNAc2 alpha-1,2-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5BKT4" data-a="GO:0106073" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function transferred by sequence similarity from the ortholog (UniProtKB:Q5I7T1); same activity as the IBA/IEA annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the IBA and IEA annotations of GO:0106073 and with UniProt&#39;s catalytic-activity record (EC 2.4.1.256, RHEA:29543). Correct and specific.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG10/ALG10-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Glc(2)Man(9)GlcNAc(2)-PP-Dol to produce Glc(3)Man(9)GlcNAc(2)-PP-Dol.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ALG10 is the ER-lumenal, Dol-P-Glc-dependent alpha-1,2-glucosyltransferase (EC 2.4.1.256) that catalyzes the terminal glucose-capping step of dolichol-linked oligosaccharide assembly, transferring glucose from dolichyl-phosphate-glucose onto Glc2Man9GlcNAc2-PP-dolichol to produce the mature Glc3Man9GlcNAc2-PP-dolichol precursor. The terminal glucose it adds is the recognition signal for efficient oligosaccharyltransferase-mediated transfer of the glycan to nascent proteins, making ALG10 directly required for protein N-linked glycosylation. It acts as an integral, multi-pass endoplasmic reticulum membrane enzyme.</h3>
+                <span class="vote-buttons" data-g="Q5BKT4" data-a="FUNCTION: ALG10 is the ER-lumenal, Dol-P-Glc-dependent alpha..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106073" target="_blank" class="term-link">
+                            dolichyl pyrophosphate Glc2Man9GlcNAc2 alpha-1,2-glucosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                dolichol-linked oligosaccharide biosynthetic process
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                protein N-linked glycosylation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ALG10/ALG10-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">adds the third and last glucose residue from dolichyl phosphate glucose</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ALG10/ALG10-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Glc(2)Man(9)GlcNAc(2)-PP-Dol to produce Glc(3)Man(9)GlcNAc(2)-PP-Dol.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ALG10/ALG10-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Endoplasmic reticulum membrane</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ALG10 protein-binding annotations derive from the HuRI proteome-wide, systematic binary (yeast two-hybrid) interactome screen, not from a targeted study of ALG10 function.</div>
+
+                        <div class="finding-text">"a reference map of the human protein interactome, generated systematically and comprehensively"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ALG10/ALG10-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB Q5BKT4 ALG10 (AG10A_HUMAN) record</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt describes ALG10 as an ER membrane Dol-P-Glc-dependent alpha-1,2-glucosyltransferase (EC 2.4.1.256) that adds the third and terminal glucose to Glc2Man9GlcNAc2-PP-dolichol, producing mature Glc3Man9GlcNAc2-PP-dolichol for protein N-glycosylation.</div>
+
+                        <div class="finding-text">"adds the third and last glucose residue from dolichyl phosphate glucose"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ALG10 is an endoplasmic reticulum membrane, multi-pass membrane protein belonging to the ALG10 glucosyltransferase family.</div>
+
+                        <div class="finding-text">"Belongs to the ALG10 glucosyltransferase family."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does human ALG10A functionally differ from its paralog ALG10B in the terminal glucosylation step, and are they redundant in vivo?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q5BKT4" data-a="Q: Does human ALG10A functionally differ from its par..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the reported modulation of the Kv1.1 (KCNA1) potassium channel a moonlighting function of ALG10, or an indirect consequence of altered N-glycosylation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q5BKT4" data-a="Q: Is the reported modulation of the Kv1.1 (KCNA1) po..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> In vitro glucosyltransferase assay using purified ALG10, Dol-P-Glc donor and Glc2Man9GlcNAc2-PP-dolichol acceptor to confirm formation of Glc3Man9GlcNAc2-PP-dolichol and measure kinetics.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q5BKT4" data-a="EXPERIMENT: In vitro glucosyltransferase assay using purified ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> CRISPR knockout of ALG10 in human cells followed by LLO profiling (fluorophore-assisted carbohydrate electrophoresis / mass spectrometry) to confirm accumulation of the Glc2Man9GlcNAc2 intermediate and hypoglycosylation of reporter glycoproteins.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q5BKT4" data-a="EXPERIMENT: CRISPR knockout of ALG10 in human cells followed b..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ALG10-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q5BKT4" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="alg10-alg10a-curation-notes">ALG10 (ALG10A) — curation notes</h1>
+<p>UniProtKB: Q5BKT4 (AG10A_HUMAN). HGNC:23162. Gene symbol ALG10 (synonym ALG10A).<br />
+473 aa multi-pass ER membrane protein. CAZy GT59; PANTHER PTHR12989; Pfam PF04922<br />
+(DIE2_ALG10); InterPro IPR016900 (Alg10); PIRSF028810.</p>
+<p>Note: deep research (falcon) was unavailable at review time (provider out of credits,<br />
+HTTP 402). This review is grounded in the UniProt record, the seeded GOA, and the one<br />
+cached publication (PMID:32296183). No <code>-deep-research-*.md</code> file was fabricated.</p>
+<h2 id="function">Function</h2>
+<p>ALG10 is the ER-lumenal alpha-1,2-glucosyltransferase (EC 2.4.1.256) that catalyzes the<br />
+<strong>third and final glucose addition</strong> in dolichol-linked oligosaccharide (LLO) assembly.<br />
+It transfers glucose from dolichyl-phosphate-glucose (Dol-P-Glc; NOT UDP-Glc) onto the<br />
+Glc2Man9GlcNAc2-PP-dolichol intermediate to give the mature, fully assembled<br />
+Glc3Man9GlcNAc2-PP-dolichol precursor.</p>
+<p>[file:human/ALG10/ALG10-uniprot.txt "adds the third and last glucose residue from<br />
+dolichyl phosphate glucose"] ... "Glc(2)Man(9)GlcNAc(2)-PP-Dol to produce<br />
+Glc(3)Man(9)GlcNAc(2)-PP-Dol."</p>
+<p>The mature Glc3Man9GlcNAc2 glycan is transferred en bloc by the oligosaccharyltransferase<br />
+(OST) complex onto asparagine residues (N-X-S/T sequons) of nascent proteins. The<br />
+terminal alpha-1,2-linked glucose that ALG10 adds is the key recognition determinant for<br />
+efficient OST transfer, and after transfer the glucoses are trimmed by glucosidases I/II,<br />
+feeding the calnexin/calreticulin glycoprotein quality-control cycle.</p>
+<p>UniProt FUNCTION: [file:human/ALG10/ALG10-uniprot.txt "operates in the biosynthetic<br />
+pathway of"] dolichol-linked oligosaccharides ... "Once assembled, the oligosaccharide is<br />
+transferred from the lipid to nascent proteins by oligosaccharyltransferases."</p>
+<p>Catalytic activity Rhea:RHEA:29543; PhysiologicalDirection left-to-right (RHEA:29544).<br />
+Pathway: Protein modification; protein glycosylation (UniPathway UPA00378).</p>
+<h2 id="localization">Localization</h2>
+<p>ER membrane, multi-pass. UniProt SUBCELLULAR LOCATION: "Endoplasmic reticulum membrane<br />
+... Multi-pass membrane protein". 10 predicted TM helices (FT TRANSMEM). Catalysis occurs<br />
+on the lumenal face of the ER (LLO glucosylation is a lumenal step). GO:0005789<br />
+(ER membrane) and GO:0005783 (ER) both apply.</p>
+<h2 id="family-paralog">Family / paralog</h2>
+<p>Belongs to the ALG10 glucosyltransferase family<br />
+[file:human/ALG10/ALG10-uniprot.txt "Belongs to the ALG10 glucosyltransferase family."].<br />
+Human has a paralog ALG10B (ALG10-B). ALG10 has additionally been reported to modulate the<br />
+Kv1.1 (KCNA1) voltage-gated potassium channel (not part of the LLO/N-glycosylation core<br />
+function; not annotated in this GOA snapshot).</p>
+<h2 id="annotation-review-summary">Annotation review summary</h2>
+<p>GOA (Q5BKT4) carries 15 lines:<br />
+- MF GO:0106073 dolichyl pyrophosphate Glc2Man9GlcNAc2 alpha-1,2-glucosyltransferase<br />
+  activity (EC 2.4.1.256, RHEA:29543) x3 (IBA GO_REF:0000033, IEA GO_REF:0000120,<br />
+  ISS GO_REF:0000024) — core MF; ACCEPT the IBA (best supported), ACCEPT IEA/ISS.<br />
+- BP GO:0006487 protein N-linked glycosylation (IBA) — ACCEPT (core BP).<br />
+- BP GO:0006488 dolichol-linked oligosaccharide biosynthetic process (IEA InterPro) —<br />
+  ACCEPT (core BP; the specific pathway ALG10 acts in).<br />
+- CC GO:0005783 endoplasmic reticulum (IBA) — ACCEPT.<br />
+- CC GO:0005789 ER membrane (IEA SubCell + ISS) — ACCEPT (more specific, matches<br />
+  multi-pass TM topology).<br />
+- MF GO:0005515 protein binding (IPI PMID:32296183) x6 — HuRI high-throughput Y2H binary<br />
+  interactome; uninformative bare "protein binding". Per project policy on IPI protein<br />
+  binding: MARK_AS_OVER_ANNOTATED (do not REMOVE experimental).</p>
+<p>Core functions: MF GO:0106073; directly_involved_in GO:0006488 (LLO biosynthesis) and<br />
+GO:0006487 (protein N-linked glycosylation); located_in GO:0005789 (ER membrane).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q5BKT4
+gene_symbol: ALG10
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  ALG10 (ALG10A) is an endoplasmic reticulum membrane, multi-pass
+  alpha-1,2-glucosyltransferase (EC 2.4.1.256) that catalyzes the final,
+  glucose-capping step of dolichol-linked oligosaccharide (LLO) assembly. Acting on
+  the lumenal face of the ER, it transfers glucose from dolichyl-phosphate-glucose
+  (Dol-P-Glc, not UDP-Glc) onto the Glc2Man9GlcNAc2-PP-dolichol intermediate, adding
+  the third and terminal alpha-1,2-linked glucose to produce the mature, fully
+  assembled Glc3Man9GlcNAc2-PP-dolichol precursor. This mature glycan is the substrate
+  transferred en bloc by the oligosaccharyltransferase (OST) complex onto asparagine
+  residues of nascent polypeptides during protein N-linked glycosylation; the terminal
+  glucose added by ALG10 is the key recognition signal for efficient OST transfer, and
+  its subsequent glucosidase trimming feeds the calnexin/calreticulin glycoprotein
+  quality-control cycle. ALG10 belongs to the ALG10 glucosyltransferase family
+  (CAZy GT59).
+existing_annotations:
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically-inferred ER localization. ALG10 is a multi-pass ER membrane
+      enzyme whose catalytic (LLO glucosylation) activity occurs at the ER; this is
+      consistent with UniProt. Correct but less specific than the ER membrane term.
+    action: ACCEPT
+    reason: &gt;-
+      UniProt records ALG10 as an endoplasmic reticulum membrane protein, and LLO
+      assembly is an ER-localized process. IBA localization to the ER is well supported
+      by the family and by the multi-pass membrane topology.
+    supported_by:
+    - reference_id: file:human/ALG10/ALG10-uniprot.txt
+      supporting_text: &#34;operates in the biosynthetic pathway of&#34;
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process. ALG10 completes assembly of the LLO precursor that OST
+      transfers to asparagine residues of nascent proteins, so it is directly required
+      for protein N-linked glycosylation.
+    action: ACCEPT
+    reason: &gt;-
+      The IBA inference (drawn from broadly conserved ALG10 orthologs) matches UniProt&#39;s
+      description of ALG10&#39;s role in producing the glycan precursor used in protein
+      asparagine (N)-glycosylation. This is a core function of the gene.
+    supported_by:
+    - reference_id: file:human/ALG10/ALG10-uniprot.txt
+      supporting_text: &#34;adds the third and last glucose residue from dolichyl phosphate glucose&#34;
+- term:
+    id: GO:0106073
+    label: dolichyl pyrophosphate Glc2Man9GlcNAc2 alpha-1,2-glucosyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core molecular function. This is the Dol-P-Glc-dependent alpha-1,2-glucosyltransferase
+      activity (EC 2.4.1.256, RHEA:29543) that adds the third/terminal glucose to
+      Glc2Man9GlcNAc2-PP-dolichol, yielding Glc3Man9GlcNAc2-PP-dolichol.
+    action: ACCEPT
+    reason: &gt;-
+      This is the defining catalytic activity of ALG10, supported by UniProt (EC
+      2.4.1.256, RHEA:29543) and the phylogenetic inference across ALG10 orthologs. It
+      is the correct, specific molecular function term.
+    supported_by:
+    - reference_id: file:human/ALG10/ALG10-uniprot.txt
+      supporting_text: &#34;Glc(2)Man(9)GlcNAc(2)-PP-Dol to produce Glc(3)Man(9)GlcNAc(2)-PP-Dol.&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ER membrane localization from UniProt subcellular-location mapping. ALG10 is a
+      multi-pass ER membrane protein (10 predicted transmembrane helices).
+    action: ACCEPT
+    reason: &gt;-
+      UniProt SUBCELLULAR LOCATION records ALG10 as an endoplasmic reticulum membrane,
+      multi-pass membrane protein, consistent with its role as an integral ER membrane
+      glucosyltransferase. This is the appropriate, specific cellular component.
+    supported_by:
+    - reference_id: file:human/ALG10/ALG10-uniprot.txt
+      supporting_text: &#34;Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process. ALG10 performs the terminal glucosylation step of
+      dolichol-linked oligosaccharide biosynthesis, producing the mature
+      Glc3Man9GlcNAc2-PP-dolichol.
+    action: ACCEPT
+    reason: &gt;-
+      InterPro2GO mapping (IPR016900, Alg10) to LLO biosynthesis is accurate and, in
+      fact, is the most specific pathway term for ALG10&#39;s role; supported by UniProt&#39;s
+      description of the dolichol-linked oligosaccharide assembly pathway.
+    supported_by:
+    - reference_id: file:human/ALG10/ALG10-uniprot.txt
+      supporting_text: &#34;operates in the biosynthetic pathway of&#34;
+- term:
+    id: GO:0106073
+    label: dolichyl pyrophosphate Glc2Man9GlcNAc2 alpha-1,2-glucosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Same core molecular function as the IBA annotation, here derived electronically
+      from EC 2.4.1.256 / RHEA:29543 / InterPro IPR016900.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and consistent with the IBA and ISS annotations of the same term; the
+      EC/RHEA/InterPro basis matches UniProt&#39;s catalytic-activity record.
+    supported_by:
+    - reference_id: file:human/ALG10/ALG10-uniprot.txt
+      supporting_text: &#34;Glc(2)Man(9)GlcNAc(2)-PP-Dol to produce Glc(3)Man(9)GlcNAc(2)-PP-Dol.&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from the HuRI high-throughput binary (yeast two-hybrid)
+      interactome screen (interaction with CD79A, UniProtKB:P11912). This is an
+      uninformative molecular function term that does not describe ALG10&#39;s actual
+      activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;protein binding&#34; (GO:0005515) conveys no specific functional information and this
+      interaction comes from a systematic proteome-wide screen rather than a targeted
+      study of ALG10 function. Per curation policy the experimental annotation is not
+      removed, but it is flagged as an over-annotation relative to ALG10&#39;s core
+      glucosyltransferase function.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &#34;a reference map of the human protein interactome, generated systematically and comprehensively&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from the HuRI binary interactome screen (interaction with
+      FBLN1, UniProtKB:P23142-4). Uninformative MF term from a systematic screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      As above: high-throughput binary interaction, not a specific function; retained as
+      experimental but flagged over-annotated. Does not inform ALG10&#39;s core molecular
+      function.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &#34;a reference map of the human protein interactome, generated systematically and comprehensively&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from the HuRI binary interactome screen (interaction with
+      SHISAL1, UniProtKB:Q3SXP7). Uninformative MF term from a systematic screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput binary interaction; uninformative &#34;protein binding&#34; not describing
+      ALG10&#39;s actual activity. Retained as experimental but flagged over-annotated.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &#34;a reference map of the human protein interactome, generated systematically and comprehensively&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from the HuRI binary interactome screen (interaction with
+      SERP2, UniProtKB:Q8N6R1). Uninformative MF term from a systematic screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput binary interaction; uninformative &#34;protein binding&#34;. Retained as
+      experimental but flagged over-annotated relative to the core glucosyltransferase
+      function.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &#34;a reference map of the human protein interactome, generated systematically and comprehensively&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from the HuRI binary interactome screen (interaction with
+      HERPUD2, UniProtKB:Q9BSE4). Uninformative MF term from a systematic screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput binary interaction; uninformative &#34;protein binding&#34;. Retained as
+      experimental but flagged over-annotated.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &#34;a reference map of the human protein interactome, generated systematically and comprehensively&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; from the HuRI binary interactome screen (interaction with
+      ERGIC3, UniProtKB:Q9Y282). Uninformative MF term from a systematic screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput binary interaction; uninformative &#34;protein binding&#34;. Retained as
+      experimental but flagged over-annotated relative to ALG10&#39;s core function.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &#34;a reference map of the human protein interactome, generated systematically and comprehensively&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ER membrane localization transferred by sequence similarity from the ortholog
+      (UniProtKB:Q5I7T1). Consistent with UniProt and with the multi-pass membrane
+      topology.
+    action: ACCEPT
+    reason: &gt;-
+      Agrees with the IEA SubCell ER membrane annotation and UniProt subcellular
+      location; the appropriate, specific cellular component for this integral ER
+      membrane enzyme.
+    supported_by:
+    - reference_id: file:human/ALG10/ALG10-uniprot.txt
+      supporting_text: &#34;Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0106073
+    label: dolichyl pyrophosphate Glc2Man9GlcNAc2 alpha-1,2-glucosyltransferase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core molecular function transferred by sequence similarity from the ortholog
+      (UniProtKB:Q5I7T1); same activity as the IBA/IEA annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the IBA and IEA annotations of GO:0106073 and with UniProt&#39;s
+      catalytic-activity record (EC 2.4.1.256, RHEA:29543). Correct and specific.
+    supported_by:
+    - reference_id: file:human/ALG10/ALG10-uniprot.txt
+      supporting_text: &#34;Glc(2)Man(9)GlcNAc(2)-PP-Dol to produce Glc(3)Man(9)GlcNAc(2)-PP-Dol.&#34;
+core_functions:
+- description: &gt;-
+    ALG10 is the ER-lumenal, Dol-P-Glc-dependent alpha-1,2-glucosyltransferase
+    (EC 2.4.1.256) that catalyzes the terminal glucose-capping step of dolichol-linked
+    oligosaccharide assembly, transferring glucose from dolichyl-phosphate-glucose onto
+    Glc2Man9GlcNAc2-PP-dolichol to produce the mature Glc3Man9GlcNAc2-PP-dolichol
+    precursor. The terminal glucose it adds is the recognition signal for efficient
+    oligosaccharyltransferase-mediated transfer of the glycan to nascent proteins,
+    making ALG10 directly required for protein N-linked glycosylation. It acts as an
+    integral, multi-pass endoplasmic reticulum membrane enzyme.
+  molecular_function:
+    id: GO:0106073
+    label: dolichyl pyrophosphate Glc2Man9GlcNAc2 alpha-1,2-glucosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  - id: GO:0006487
+    label: protein N-linked glycosylation
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: file:human/ALG10/ALG10-uniprot.txt
+    supporting_text: &#34;adds the third and last glucose residue from dolichyl phosphate glucose&#34;
+  - reference_id: file:human/ALG10/ALG10-uniprot.txt
+    supporting_text: &#34;Glc(2)Man(9)GlcNAc(2)-PP-Dol to produce Glc(3)Man(9)GlcNAc(2)-PP-Dol.&#34;
+  - reference_id: file:human/ALG10/ALG10-uniprot.txt
+    supporting_text: &#34;Endoplasmic reticulum membrane&#34;
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Does human ALG10A functionally differ from its paralog ALG10B in the terminal
+    glucosylation step, and are they redundant in vivo?
+- question: &gt;-
+    Is the reported modulation of the Kv1.1 (KCNA1) potassium channel a moonlighting
+    function of ALG10, or an indirect consequence of altered N-glycosylation?
+suggested_experiments:
+- description: &gt;-
+    In vitro glucosyltransferase assay using purified ALG10, Dol-P-Glc donor and
+    Glc2Man9GlcNAc2-PP-dolichol acceptor to confirm formation of
+    Glc3Man9GlcNAc2-PP-dolichol and measure kinetics.
+- description: &gt;-
+    CRISPR knockout of ALG10 in human cells followed by LLO profiling
+    (fluorophore-assisted carbohydrate electrophoresis / mass spectrometry) to confirm
+    accumulation of the Glc2Man9GlcNAc2 intermediate and hypoglycosylation of reporter
+    glycoproteins.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings:
+  - statement: &gt;-
+      ALG10 protein-binding annotations derive from the HuRI proteome-wide, systematic
+      binary (yeast two-hybrid) interactome screen, not from a targeted study of ALG10
+      function.
+    supporting_text: &#34;a reference map of the human protein interactome, generated systematically and comprehensively&#34;
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified HuRI interactome paper. Correctly cited for the six IPI protein
+      binding annotations, but as a high-throughput binary screen it does not establish
+      a specific molecular function for ALG10; these annotations are flagged as
+      over-annotated.
+- id: file:human/ALG10/ALG10-uniprot.txt
+  title: UniProtKB Q5BKT4 ALG10 (AG10A_HUMAN) record
+  findings:
+  - statement: &gt;-
+      UniProt describes ALG10 as an ER membrane Dol-P-Glc-dependent
+      alpha-1,2-glucosyltransferase (EC 2.4.1.256) that adds the third and terminal
+      glucose to Glc2Man9GlcNAc2-PP-dolichol, producing mature Glc3Man9GlcNAc2-PP-dolichol
+      for protein N-glycosylation.
+    supporting_text: &#34;adds the third and last glucose residue from dolichyl phosphate glucose&#34;
+  - statement: &gt;-
+      ALG10 is an endoplasmic reticulum membrane, multi-pass membrane protein belonging
+      to the ALG10 glucosyltransferase family.
+    supporting_text: &#34;Belongs to the ALG10 glucosyltransferase family.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary source for ALG10 function, catalytic activity, pathway and localization
+      used throughout this review.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/ALG12/ALG12-ai-review.html
+++ b/genes/human/ALG12/ALG12-ai-review.html
@@ -1,0 +1,4178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ALG12 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ALG12</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9BV10" target="_blank" class="term-link">
+                        Q9BV10
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ALG12";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9BV10" data-a="DESCRIPTION: ALG12 is an endoplasmic reticulum membrane, ER-lum..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ALG12 is an endoplasmic reticulum membrane, ER-lumen-facing dolichyl-phosphate-mannose (Dol-P-Man)-dependent alpha-1,6-mannosyltransferase (glycosyltransferase family GT22; EC 2.4.1.260) that acts in the biosynthesis of the dolichol-linked oligosaccharide (LLO) precursor used for protein asparagine (N)-linked glycosylation. In the ER lumen it adds the eighth mannose residue in an alpha-1,6 linkage from Dol-P-Man onto Man7GlcNAc2-PP-dolichol to produce Man8GlcNAc2-PP-dolichol. It is a multi-pass ER membrane protein. Loss of its mannosyltransferase activity causes ALG12-CDG (congenital disorder of glycosylation type Ig), a multisystem disease with under-glycosylated serum glycoproteins.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000009" target="_blank" class="term-link">
+                                    GO:0000009
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,6-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0000009" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) call of alpha-1,6-mannosyltransferase activity. This is correct for ALG12, which forms the alpha-1,6 linkage when adding the eighth mannose of LLO assembly, though it is a general parent of the specific Dol-P-Man-dependent term GO:0052917.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct molecular activity, consistent with the experimentally verified alpha-1,6-mannosyltransferase function. Retained as an accurate parent of the more specific core MF term GO:0052917.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link">
+                                        PMID:12217961
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we describe a deficiency in the ALG12 ER</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG12/ALG12-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the eighth mannose residue in an alpha-1,6 linkage onto</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) localization of active ALG12 to the ER membrane. ALG12 is a multi-pass ER membrane protein whose catalytic site faces the ER lumen, consistent with the lumenal LLO mannose additions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct subcellular location; the enzyme is an integral ER membrane protein acting on the lumenal LLO intermediate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG12/ALG12-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0006487" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) involvement in protein N-linked glycosylation. ALG12 builds the LLO precursor that is transferred en bloc to asparagine residues of nascent proteins, so it is genuinely part of the N-glycosylation process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process. ALG12 contributes the eighth mannose of the dolichol-linked precursor used for protein N-glycosylation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                        PMID:11983712
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">used for protein N-glycosylation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link">
+                                        PMID:12217961
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">N-linked glycans are first</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt SubCell mapping) location in the ER membrane. Agrees with the curated SUBCELLULAR LOCATION and the IBA/TAS ER-membrane calls.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location, consistent with all other evidence for ER membrane localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG12/ALG12-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016757" target="_blank" class="term-link">
+                                    GO:0016757
+                                </a>
+                            </span>
+                            <span class="term-label">glycosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0016757" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO (IEA) mapping from the GT22/Glyco_transf_22 domain to the broad parent term glycosyltransferase activity. Correct but uninformative relative to the specific mannosyltransferase terms.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct high-level activity inferred from the glycosyltransferase family 22 domain; acceptable as a broad IEA parent of the specific core MF term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG12/ALG12-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the glycosyltransferase 22 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052917" target="_blank" class="term-link">
+                                    GO:0052917
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0052917" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (RHEA/EC 2.4.1.260) mapping to the exact Dol-P-Man-dependent alpha-1,6-mannosyltransferase reaction. This is the precise catalytic activity of ALG12 and matches the experimentally supported EC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Exactly correct molecular function; corroborated by the EXP and IMP annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                        PMID:11983712
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dolichyl-P-Man:Man(7)GlcNAc(2)-PP-dolichyl alpha6-mannosyltransferase that is</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG12/ALG12-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.4.1.260</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446193
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0006488" data-r="Reactome:R-HSA-446193" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) involvement in dolichol-linked oligosaccharide biosynthesis. ALG12 catalyzes one step (eighth mannose addition) of LLO assembly, so this is a correct and core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, corroborated by the IMP and IDA annotations to the same term from CDG-Ig studies.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                        PMID:11983712
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">deficient in their capacity to add the eighth mannose residue onto the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052917" target="_blank" class="term-link">
+                                    GO:0052917
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12217961
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    ALG12 mannosyltransferase defect in congenital disorder of g...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0052917" data-r="PMID:12217961" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation of the specific Dol-P-Man-dependent alpha-1,6-mannosyltransferase activity. Patient fibroblasts show a defect in the ALG12 alpha-1,6-mannosyltransferase, with yeast alg12 complementation confirming the enzymatic identity of the human protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly experimentally supported core molecular function; the exact current GOA MF term for ALG12 (EC 2.4.1.260).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link">
+                                        PMID:12217961
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we describe a deficiency in the ALG12 ER</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link">
+                                        PMID:12217961
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the dolichyl pyrophosphate-GlcNAc(2)Man(7)-dependent ALG12 alpha1,6</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098553" target="_blank" class="term-link">
+                                    GO:0098553
+                                </a>
+                            </span>
+                            <span class="term-label">lumenal side of endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12217961
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    ALG12 mannosyltransferase defect in congenital disorder of g...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0098553" data-r="PMID:12217961" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator-inferred (IC) localization of active ALG12 to the lumenal side of the ER membrane. The lumenal mannose additions of LLO assembly (using Dol-P-Man) occur on the ER lumenal face, consistent with the ER alpha-1,6-mannosyltransferase described for ALG12.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and more specific than the generic ER membrane term; reflects the lumenal topology of the catalytic activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link">
+                                        PMID:12217961
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we describe a deficiency in the ALG12 ER</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG12/ALG12-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">In the lumen of the endoplasmic reticulum</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11983712
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Congenital disorders of glycosylation type Ig is defined by ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0006487" data-r="PMID:11983712" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype (IMP) evidence for involvement in protein N-linked glycosylation. CDG-Ig patient fibroblasts with defective ALG12 show under-glycosylated glycoproteins, and the phenotype is rescued by wild-type ALG12, tying ALG12 function to N-glycosylation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core biological process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                        PMID:11983712
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">under-glycosylated serum glycoproteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12093361" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12093361
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Deficiency of dolichyl-P-Man:Man7GlcNAc2-PP-dolichyl mannosy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0006487" data-r="PMID:12093361" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Independent mutant-phenotype (IMP) evidence for involvement in protein N-linked glycosylation. A second CDG-Ig patient with reduced ALG12 mannosyltransferase activity shows partial loss of N-glycan side chains on serum transferrin, rescued by wild-type ALG12.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core biological process, independently corroborating PMID:11983712.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12093361" target="_blank" class="term-link">
+                                        PMID:12093361
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the partial loss of complete N-glycan</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11983712
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Congenital disorders of glycosylation type Ig is defined by ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0006488" data-r="PMID:11983712" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype (IMP) evidence for involvement in dolichol-linked oligosaccharide biosynthesis. Loss of ALG12 blocks addition of the eighth mannose onto the LLO precursor; wild-type gene transduction normalizes the phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core biological process (the direct step ALG12 catalyzes in LLO assembly).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                        PMID:11983712
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">deficient in their capacity to add the eighth mannose residue onto the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12093361" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12093361
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Deficiency of dolichyl-P-Man:Man7GlcNAc2-PP-dolichyl mannosy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0006488" data-r="PMID:12093361" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Independent mutant-phenotype (IMP) evidence for involvement in dolichol-linked oligosaccharide biosynthesis. Reduced ALG12 activity causes accumulation of the Man7GlcNAc2-PP-Dol intermediate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core biological process, corroborating the other IMP/IDA annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12093361" target="_blank" class="term-link">
+                                        PMID:12093361
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">leading to the accumulation of Man(7)GlcNAc(2)-PP-Dol, which was transferred to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052917" target="_blank" class="term-link">
+                                    GO:0052917
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11983712
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Congenital disorders of glycosylation type Ig is defined by ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0052917" data-r="PMID:11983712" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype (IMP) evidence for the specific Dol-P-Man-dependent alpha-1,6-mannosyltransferase activity. The CDG-Ig patient&#39;s fibroblasts cannot add the eighth mannose, and the human ALG12 cDNA rescues the defect, identifying ALG12 as this enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core molecular function; the exact current GOA MF term for ALG12.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                        PMID:11983712
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dolichyl-P-Man:Man(7)GlcNAc(2)-PP-dolichyl alpha6-mannosyltransferase that is</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052917" target="_blank" class="term-link">
+                                    GO:0052917
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12093361" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12093361
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Deficiency of dolichyl-P-Man:Man7GlcNAc2-PP-dolichyl mannosy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0052917" data-r="PMID:12093361" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Independent mutant-phenotype (IMP) evidence for the Dol-P-Man-dependent mannosyltransferase activity. Patient fibroblasts show severely reduced Dol-P-Man:Man7GlcNAc2-PP-Dol mannosyltransferase activity, normalized by wild-type ALG12 expression.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core molecular function, independently corroborating PMID:11983712.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12093361" target="_blank" class="term-link">
+                                        PMID:12093361
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Retroviral expression of the wild-type</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000030" target="_blank" class="term-link">
+                                    GO:0000030
+                                </a>
+                            </span>
+                            <span class="term-label">mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446198
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0000030" data-r="Reactome:R-HSA-446198" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) mannosyltransferase activity. Correct but overly general: the specific and experimentally supported activity is the Dol-P-Man-dependent alpha-1,6-mannosyltransferase GO:0052917.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Too general. ALG12&#39;s activity is captured precisely by GO:0052917; replace the generic mannosyltransferase term with the specific one.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052917" target="_blank" class="term-link">
+                                    dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                        PMID:11983712
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dolichyl-P-Man:Man(7)GlcNAc(2)-PP-dolichyl alpha6-mannosyltransferase that is</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000030" target="_blank" class="term-link">
+                                    GO:0000030
+                                </a>
+                            </span>
+                            <span class="term-label">mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-4720497
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0000030" data-r="Reactome:R-HSA-4720497" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) mannosyltransferase activity (from the defective-ALG12 disease reaction). Same over-general term as R-HSA-446198.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Too general; the specific activity term GO:0052917 should be used.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052917" target="_blank" class="term-link">
+                                    dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                        PMID:11983712
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dolichyl-P-Man:Man(7)GlcNAc(2)-PP-dolichyl alpha6-mannosyltransferase that is</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-4720497
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0005789" data-r="Reactome:R-HSA-4720497" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) location in the ER membrane. Consistent with all other ER-membrane evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct subcellular location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG12/ALG12-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomics (HDA) detection of ALG12 in a membrane fraction from an NK-like cell line. The generic &#34;membrane&#34; term adds no information beyond the specific ER membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic membrane term from a large-scale membrane-proteome survey (1843 proteins); the specific, well-supported location is ER membrane. Not incorrect, but over-broad and non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">identified 1843 proteins with high confidence scores</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11983712
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Congenital disorders of glycosylation type Ig is defined by ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0006488" data-r="PMID:11983712" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (IDA) evidence that ALG12 acts within dolichol-linked oligosaccharide biosynthesis, with the acts_upstream_of_or_within qualifier. The eighth mannose addition step ALG12 catalyzes is directly demonstrated by the biochemical defect and its rescue.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core biological process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                        PMID:11983712
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">deficient in their capacity to add the eighth mannose residue onto the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446198
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0005789" data-r="Reactome:R-HSA-446198" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) location in the ER membrane. Consistent with all other ER-membrane evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct subcellular location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG12/ALG12-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12217961
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    ALG12 mannosyltransferase defect in congenital disorder of g...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0005783" data-r="PMID:12217961" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable author statement (NAS) placing ALG12 in the endoplasmic reticulum. Broader than the ER membrane term but correct; ALG12 is an ER alpha-1,6-mannosyltransferase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but less specific than the ER membrane annotations; retained as an accurate broader location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link">
+                                        PMID:12217961
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we describe a deficiency in the ALG12 ER</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12217961
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    ALG12 mannosyltransferase defect in congenital disorder of g...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BV10" data-a="GO:0006457" data-r="PMID:12217961" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable author statement (NAS) associating ALG12 with protein folding. ALG12 is a mannosyltransferase that builds the N-glycan precursor; N-glycosylation supports downstream glycoprotein folding/quality control, but ALG12 does not itself carry out protein folding. This mislabels the molecular role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-annotation via a downstream/indirect consequence. ALG12&#39;s direct role is dolichol-linked oligosaccharide biosynthesis for N-glycosylation (GO:0006488, GO:0006487); &#34;protein folding&#34; is an indirect effect and does not describe ALG12&#39;s function. Non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link">
+                                        PMID:12217961
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">N-linked glycans are first</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Dol-P-Man-dependent alpha-1,6-mannosyltransferase that adds the eighth mannose from dolichyl-phosphate-mannose in an alpha-1,6 linkage onto Man7GlcNAc2-PP-dolichol to produce Man8GlcNAc2-PP-dolichol in the ER lumen (EC 2.4.1.260).</h3>
+                <span class="vote-buttons" data-g="Q9BV10" data-a="FUNCTION: Dol-P-Man-dependent alpha-1,6-mannosyltransferase ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052917" target="_blank" class="term-link">
+                            dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                dolichol-linked oligosaccharide biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                PMID:11983712
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">dolichyl-P-Man:Man(7)GlcNAc(2)-PP-dolichyl alpha6-mannosyltransferase that is</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                                PMID:11983712
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">deficient in their capacity to add the eighth mannose residue onto the</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ER membrane mannosyltransferase that contributes the eighth mannose of the dolichol-linked oligosaccharide precursor transferred en bloc to asparagine residues during protein N-linked glycosylation.</h3>
+                <span class="vote-buttons" data-g="Q9BV10" data-a="FUNCTION: ER membrane mannosyltransferase that contributes t..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052917" target="_blank" class="term-link">
+                            dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                protein N-linked glycosylation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12093361" target="_blank" class="term-link">
+                                PMID:12093361
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Deficiency of the endoplasmic reticulum enzyme dolichyl-phosphate mannose</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12093361" target="_blank" class="term-link">
+                                PMID:12093361
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the partial loss of complete N-glycan</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11983712" target="_blank" class="term-link">
+                            PMID:11983712
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Congenital disorders of glycosylation type Ig is defined by a deficiency in dolichyl-P-mannose:Man7GlcNAc2-PP-dolichyl mannosyltransferase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human ALG12, the ortholog of yeast ALG12, encodes the dolichyl-P-Man:Man7GlcNAc2-PP-dolichyl alpha6-mannosyltransferase; CDG-Ig patient fibroblasts are deficient in adding the eighth mannose onto the LLO precursor, and the defect (F142V) is rescued by wild-type ALG12.</div>
+
+                        <div class="finding-text">"deficient in their capacity to add the eighth mannose residue onto the"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12093361" target="_blank" class="term-link">
+                            PMID:12093361
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deficiency of dolichyl-P-Man:Man7GlcNAc2-PP-dolichyl mannosyltransferase causes congenital disorder of glycosylation type Ig.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A second CDG-Ig patient shows severely reduced ER Dol-P-Man:Man7GlcNAc2-PP-Dol mannosyltransferase activity with accumulation of Man7GlcNAc2-PP-Dol and partial loss of N-glycan side chains; wild-type ALG12 normalizes activity.</div>
+
+                        <div class="finding-text">"leading to the accumulation of Man(7)GlcNAc(2)-PP-Dol, which was transferred to"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12217961" target="_blank" class="term-link">
+                            PMID:12217961
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ALG12 mannosyltransferase defect in congenital disorder of glycosylation type lg.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Describes deficiency in the ALG12 ER alpha-1,6-mannosyltransferase; ER lumenal LLO context; yeast alg12 complementation confirms enzyme identity; defines CDG-Ig.</div>
+
+                        <div class="finding-text">"we describe a deficiency in the ALG12 ER"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Large-scale membrane-proteome survey of an NK-like cell line detecting ALG12 among 1843 proteins; basis of the generic membrane annotation only.</div>
+
+                        <div class="finding-text">"identified 1843 proteins with high confidence scores"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446193
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide, LLO) and transfer to a nascent protein</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446198
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ALG12 transfers Man to N-glycan precursor (GlcNAc)2 (Man)7 (PP-Dol)1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-4720497
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective ALG12 does not add mannose to the N-glycan precursor</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ALG12/ALG12-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB Q9BV10 (ALG12_HUMAN) curated entry</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ALG12 is an ER membrane, multi-pass Dol-P-Man-dependent alpha-1,6-mannosyltransferase (EC 2.4.1.260) of the glycosyltransferase 22 family that adds the eighth mannose onto Man7GlcNAc2-PP-dolichol in the ER lumen; defects cause CDG type Ig.</div>
+
+                        <div class="finding-text">"adds the eighth mannose residue in an alpha-1,6 linkage onto"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ALG12-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9BV10" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="alg12-human-q9bv10-review-notes">ALG12 (human, Q9BV10) review notes</h1>
+<h2 id="summary-of-function">Summary of function</h2>
+<p>ALG12 is an ER membrane, ER-lumenal-facing alpha-1,6-mannosyltransferase (glycosyltransferase<br />
+family GT22; CAZy GT22, Pfam PF03901 Glyco_transf_22) of the dolichol-linked oligosaccharide<br />
+(LLO) assembly pathway for protein N-glycosylation. It transfers the <strong>eighth mannose</strong> from<br />
+<strong>dolichyl-phosphate-mannose (Dol-P-Man)</strong> in an alpha-1,6 linkage onto Man7GlcNAc2-PP-dolichol<br />
+to give Man8GlcNAc2-PP-dolichol (EC 2.4.1.260; RHEA:29535). The lumenal mannose additions of LLO<br />
+assembly use Dol-P-Man as donor, not GDP-Man.</p>
+<ul>
+<li>[UniProt Q9BV10 FUNCTION, "In the lumen of the endoplasmic reticulum, adds the eighth mannose residue in an alpha-1,6 linkage onto Man(7)GlcNAc(2)-PP-dolichol to produce Man(8)GlcNAc(2)-PP-dolichol."]</li>
+<li>[UniProt Q9BV10 SUBCELLULAR LOCATION "Endoplasmic reticulum membrane"; "Multi-pass membrane protein" — 12 predicted TM helices]</li>
+<li>[UniProt Q9BV10 SIMILARITY "Belongs to the glycosyltransferase 22 family."]</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<p>Loss of ALG12 mannosyltransferase activity causes <strong>ALG12-CDG / congenital disorder of<br />
+glycosylation type Ig (CDG-Ig, MIM:607143)</strong>, a multisystem disorder with under-glycosylated<br />
+serum glycoproteins, psychomotor/developmental retardation, hypotonia, dysmorphism,<br />
+immunodeficiency.</p>
+<h2 id="key-references-all-abstract-only-in-cache-quotes-verbatim-from-abstracts">Key references (all abstract-only in cache; quotes verbatim from abstracts)</h2>
+<ul>
+<li><strong>PMID:11983712</strong> (Chantret et al 2002, J Biol Chem) — identified human ALG12 as ortholog of<br />
+  yeast ALG12 encoding the dolichyl-P-Man:Man7GlcNAc2-PP-dolichyl alpha6-mannosyltransferase;<br />
+  CDG-Ig patient fibroblasts "deficient in their capacity to add the eighth mannose residue onto<br />
+  the lipid-linked oligosaccharide precursor"; homozygous F142V; WT rescue. Establishes MF, BP,<br />
+  and disease. Basis of the EXP/IMP/IDA annotations.</li>
+<li><strong>PMID:12093361</strong> (Thiel et al 2002, Biochem J) — "Deficiency of the endoplasmic reticulum<br />
+  enzyme dolichyl-phosphate mannose (Dol-P-Man):Man(7)GlcNAc(2)-PP-dolichyl mannosyltransferase";<br />
+  reduced activity, Man7GlcNAc2-PP-Dol accumulation; L158P + C-terminal truncation; WT rescue.</li>
+<li><strong>PMID:12217961</strong> (Grubenmann et al 2002, Hum Mol Genet) — "a deficiency in the ALG12 ER<br />
+  alpha1,6-mannosyltransferase"; ER/lumenal localization inference; yeast alg12 complementation;<br />
+  T67M and R146Q. Basis of the IC (lumenal side of ER membrane) and NAS (ER; protein folding)<br />
+  annotations.</li>
+<li><strong>PMID:19946888</strong> (Ghosh et al 2010, J Mass Spectrom) — NK-cell membrane proteome MS study<br />
+  (1843 proteins); basis of HDA "membrane" annotation. Generic membrane localization only.</li>
+</ul>
+<h2 id="annotation-decisions-high-level">Annotation decisions (high level)</h2>
+<ul>
+<li>Core MF: GO:0052917 (dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity) —<br />
+  EXP/IMP ACCEPT (core). Exact GOA current term (EC 2.4.1.260).</li>
+<li>GO:0000009 (alpha-1,6-mannosyltransferase activity, IBA) ACCEPT — correct but less specific<br />
+  than GO:0052917.</li>
+<li>GO:0000030 (mannosyltransferase activity, TAS Reactome x2) MODIFY -&gt; GO:0052917 (too general).</li>
+<li>GO:0016757 (glycosyltransferase activity, IEA InterPro) ACCEPT as correct-but-broad parent.</li>
+<li>Core BP: GO:0006488 (dolichol-linked oligosaccharide biosynthetic process) IMP/IDA/TAS and<br />
+  GO:0006487 (protein N-linked glycosylation) IBA/IMP — ACCEPT (core).</li>
+<li>Core CC: GO:0005789 (ER membrane) IBA/IEA/TAS — ACCEPT. GO:0098553 (lumenal side of ER<br />
+  membrane, IC) ACCEPT (more specific, correct topology). GO:0005783 (ER, NAS) ACCEPT as broader.</li>
+<li>GO:0016020 (membrane, HDA PMID:19946888) MARK_AS_OVER_ANNOTATED — uninformative generic<br />
+  membrane from a proteome survey; ER membrane is the specific term.</li>
+<li>GO:0006457 (protein folding, NAS PMID:12217961) — MARK_AS_OVER_ANNOTATED. ALG12 does not fold<br />
+  proteins; N-glycosylation is upstream of/supports folding but "protein folding" mis-describes<br />
+  the molecular role. Downstream/indirect.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9BV10
+gene_symbol: ALG12
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  ALG12 is an endoplasmic reticulum membrane, ER-lumen-facing
+  dolichyl-phosphate-mannose (Dol-P-Man)-dependent alpha-1,6-mannosyltransferase
+  (glycosyltransferase family GT22; EC 2.4.1.260) that acts in the biosynthesis
+  of the dolichol-linked oligosaccharide (LLO) precursor used for protein
+  asparagine (N)-linked glycosylation. In the ER lumen it adds the eighth
+  mannose residue in an alpha-1,6 linkage from Dol-P-Man onto
+  Man7GlcNAc2-PP-dolichol to produce Man8GlcNAc2-PP-dolichol. It is a
+  multi-pass ER membrane protein. Loss of its mannosyltransferase activity
+  causes ALG12-CDG (congenital disorder of glycosylation type Ig), a
+  multisystem disease with under-glycosylated serum glycoproteins.
+existing_annotations:
+- term:
+    id: GO:0000009
+    label: alpha-1,6-mannosyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) call of alpha-1,6-mannosyltransferase activity. This is
+      correct for ALG12, which forms the alpha-1,6 linkage when adding the eighth
+      mannose of LLO assembly, though it is a general parent of the specific
+      Dol-P-Man-dependent term GO:0052917.
+    action: ACCEPT
+    reason: &gt;-
+      Correct molecular activity, consistent with the experimentally verified
+      alpha-1,6-mannosyltransferase function. Retained as an accurate parent of
+      the more specific core MF term GO:0052917.
+    supported_by:
+    - reference_id: PMID:12217961
+      supporting_text: &gt;-
+        we describe a deficiency in the ALG12 ER
+    - reference_id: file:human/ALG12/ALG12-uniprot.txt
+      supporting_text: &gt;-
+        adds the eighth mannose residue in an alpha-1,6 linkage onto
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) localization of active ALG12 to the ER membrane. ALG12
+      is a multi-pass ER membrane protein whose catalytic site faces the ER
+      lumen, consistent with the lumenal LLO mannose additions.
+    action: ACCEPT
+    reason: &gt;-
+      Correct subcellular location; the enzyme is an integral ER membrane protein
+      acting on the lumenal LLO intermediate.
+    supported_by:
+    - reference_id: file:human/ALG12/ALG12-uniprot.txt
+      supporting_text: &gt;-
+        SUBCELLULAR LOCATION: Endoplasmic reticulum membrane
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) involvement in protein N-linked glycosylation. ALG12
+      builds the LLO precursor that is transferred en bloc to asparagine
+      residues of nascent proteins, so it is genuinely part of the
+      N-glycosylation process.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process. ALG12 contributes the eighth mannose of the
+      dolichol-linked precursor used for protein N-glycosylation.
+    supported_by:
+    - reference_id: PMID:11983712
+      supporting_text: &gt;-
+        used for protein N-glycosylation
+    - reference_id: PMID:12217961
+      supporting_text: &gt;-
+        N-linked glycans are first
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (UniProt SubCell mapping) location in the ER membrane. Agrees
+      with the curated SUBCELLULAR LOCATION and the IBA/TAS ER-membrane calls.
+    action: ACCEPT
+    reason: &gt;-
+      Correct location, consistent with all other evidence for ER membrane
+      localization.
+    supported_by:
+    - reference_id: file:human/ALG12/ALG12-uniprot.txt
+      supporting_text: &gt;-
+        SUBCELLULAR LOCATION: Endoplasmic reticulum membrane
+- term:
+    id: GO:0016757
+    label: glycosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO (IEA) mapping from the GT22/Glyco_transf_22 domain to the broad
+      parent term glycosyltransferase activity. Correct but uninformative
+      relative to the specific mannosyltransferase terms.
+    action: ACCEPT
+    reason: &gt;-
+      Correct high-level activity inferred from the glycosyltransferase family 22
+      domain; acceptable as a broad IEA parent of the specific core MF term.
+    supported_by:
+    - reference_id: file:human/ALG12/ALG12-uniprot.txt
+      supporting_text: &gt;-
+        Belongs to the glycosyltransferase 22 family
+- term:
+    id: GO:0052917
+    label: dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (RHEA/EC 2.4.1.260) mapping to the exact Dol-P-Man-dependent
+      alpha-1,6-mannosyltransferase reaction. This is the precise catalytic
+      activity of ALG12 and matches the experimentally supported EC.
+    action: ACCEPT
+    reason: &gt;-
+      Exactly correct molecular function; corroborated by the EXP and IMP
+      annotations to the same term.
+    supported_by:
+    - reference_id: PMID:11983712
+      supporting_text: &gt;-
+        dolichyl-P-Man:Man(7)GlcNAc(2)-PP-dolichyl alpha6-mannosyltransferase that is
+    - reference_id: file:human/ALG12/ALG12-uniprot.txt
+      supporting_text: &gt;-
+        EC=2.4.1.260
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446193
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome (TAS) involvement in dolichol-linked oligosaccharide biosynthesis.
+      ALG12 catalyzes one step (eighth mannose addition) of LLO assembly, so this
+      is a correct and core biological process.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, corroborated by the IMP and IDA annotations to the
+      same term from CDG-Ig studies.
+    supported_by:
+    - reference_id: PMID:11983712
+      supporting_text: &gt;-
+        deficient in their capacity to add the eighth mannose residue onto the
+- term:
+    id: GO:0052917
+    label: dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+  evidence_type: EXP
+  original_reference_id: PMID:12217961
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental annotation of the specific Dol-P-Man-dependent
+      alpha-1,6-mannosyltransferase activity. Patient fibroblasts show a defect in
+      the ALG12 alpha-1,6-mannosyltransferase, with yeast alg12 complementation
+      confirming the enzymatic identity of the human protein.
+    action: ACCEPT
+    reason: &gt;-
+      Directly experimentally supported core molecular function; the exact current
+      GOA MF term for ALG12 (EC 2.4.1.260).
+    supported_by:
+    - reference_id: PMID:12217961
+      supporting_text: &gt;-
+        we describe a deficiency in the ALG12 ER
+    - reference_id: PMID:12217961
+      supporting_text: &gt;-
+        the dolichyl pyrophosphate-GlcNAc(2)Man(7)-dependent ALG12 alpha1,6
+- term:
+    id: GO:0098553
+    label: lumenal side of endoplasmic reticulum membrane
+  evidence_type: IC
+  original_reference_id: PMID:12217961
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Curator-inferred (IC) localization of active ALG12 to the lumenal side of
+      the ER membrane. The lumenal mannose additions of LLO assembly (using
+      Dol-P-Man) occur on the ER lumenal face, consistent with the ER
+      alpha-1,6-mannosyltransferase described for ALG12.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and more specific than the generic ER membrane term; reflects the
+      lumenal topology of the catalytic activity.
+    supported_by:
+    - reference_id: PMID:12217961
+      supporting_text: &gt;-
+        we describe a deficiency in the ALG12 ER
+    - reference_id: file:human/ALG12/ALG12-uniprot.txt
+      supporting_text: &gt;-
+        In the lumen of the endoplasmic reticulum
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IMP
+  original_reference_id: PMID:11983712
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mutant-phenotype (IMP) evidence for involvement in protein N-linked
+      glycosylation. CDG-Ig patient fibroblasts with defective ALG12 show
+      under-glycosylated glycoproteins, and the phenotype is rescued by wild-type
+      ALG12, tying ALG12 function to N-glycosylation.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported core biological process.
+    supported_by:
+    - reference_id: PMID:11983712
+      supporting_text: &gt;-
+        under-glycosylated serum glycoproteins
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IMP
+  original_reference_id: PMID:12093361
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Independent mutant-phenotype (IMP) evidence for involvement in protein
+      N-linked glycosylation. A second CDG-Ig patient with reduced ALG12
+      mannosyltransferase activity shows partial loss of N-glycan side chains on
+      serum transferrin, rescued by wild-type ALG12.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported core biological process, independently
+      corroborating PMID:11983712.
+    supported_by:
+    - reference_id: PMID:12093361
+      supporting_text: &gt;-
+        the partial loss of complete N-glycan
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:11983712
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mutant-phenotype (IMP) evidence for involvement in dolichol-linked
+      oligosaccharide biosynthesis. Loss of ALG12 blocks addition of the eighth
+      mannose onto the LLO precursor; wild-type gene transduction normalizes the
+      phenotype.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported core biological process (the direct step ALG12
+      catalyzes in LLO assembly).
+    supported_by:
+    - reference_id: PMID:11983712
+      supporting_text: &gt;-
+        deficient in their capacity to add the eighth mannose residue onto the
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:12093361
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Independent mutant-phenotype (IMP) evidence for involvement in
+      dolichol-linked oligosaccharide biosynthesis. Reduced ALG12 activity causes
+      accumulation of the Man7GlcNAc2-PP-Dol intermediate.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported core biological process, corroborating the other
+      IMP/IDA annotations.
+    supported_by:
+    - reference_id: PMID:12093361
+      supporting_text: &gt;-
+        leading to the accumulation of Man(7)GlcNAc(2)-PP-Dol, which was transferred to
+- term:
+    id: GO:0052917
+    label: dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+  evidence_type: IMP
+  original_reference_id: PMID:11983712
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Mutant-phenotype (IMP) evidence for the specific Dol-P-Man-dependent
+      alpha-1,6-mannosyltransferase activity. The CDG-Ig patient&#39;s fibroblasts
+      cannot add the eighth mannose, and the human ALG12 cDNA rescues the defect,
+      identifying ALG12 as this enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported core molecular function; the exact current GOA MF
+      term for ALG12.
+    supported_by:
+    - reference_id: PMID:11983712
+      supporting_text: &gt;-
+        dolichyl-P-Man:Man(7)GlcNAc(2)-PP-dolichyl alpha6-mannosyltransferase that is
+- term:
+    id: GO:0052917
+    label: dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+  evidence_type: IMP
+  original_reference_id: PMID:12093361
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Independent mutant-phenotype (IMP) evidence for the Dol-P-Man-dependent
+      mannosyltransferase activity. Patient fibroblasts show severely reduced
+      Dol-P-Man:Man7GlcNAc2-PP-Dol mannosyltransferase activity, normalized by
+      wild-type ALG12 expression.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported core molecular function, independently
+      corroborating PMID:11983712.
+    supported_by:
+    - reference_id: PMID:12093361
+      supporting_text: &gt;-
+        Retroviral expression of the wild-type
+- term:
+    id: GO:0000030
+    label: mannosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446198
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome (TAS) mannosyltransferase activity. Correct but overly general:
+      the specific and experimentally supported activity is the Dol-P-Man-dependent
+      alpha-1,6-mannosyltransferase GO:0052917.
+    action: MODIFY
+    reason: &gt;-
+      Too general. ALG12&#39;s activity is captured precisely by GO:0052917; replace
+      the generic mannosyltransferase term with the specific one.
+    proposed_replacement_terms:
+    - id: GO:0052917
+      label: dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+    supported_by:
+    - reference_id: PMID:11983712
+      supporting_text: &gt;-
+        dolichyl-P-Man:Man(7)GlcNAc(2)-PP-dolichyl alpha6-mannosyltransferase that is
+- term:
+    id: GO:0000030
+    label: mannosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-4720497
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome (TAS) mannosyltransferase activity (from the defective-ALG12
+      disease reaction). Same over-general term as R-HSA-446198.
+    action: MODIFY
+    reason: &gt;-
+      Too general; the specific activity term GO:0052917 should be used.
+    proposed_replacement_terms:
+    - id: GO:0052917
+      label: dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+    supported_by:
+    - reference_id: PMID:11983712
+      supporting_text: &gt;-
+        dolichyl-P-Man:Man(7)GlcNAc(2)-PP-dolichyl alpha6-mannosyltransferase that is
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-4720497
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome (TAS) location in the ER membrane. Consistent with all other
+      ER-membrane evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Correct subcellular location.
+    supported_by:
+    - reference_id: file:human/ALG12/ALG12-uniprot.txt
+      supporting_text: &gt;-
+        SUBCELLULAR LOCATION: Endoplasmic reticulum membrane
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomics (HDA) detection of ALG12 in a membrane fraction
+      from an NK-like cell line. The generic &#34;membrane&#34; term adds no information
+      beyond the specific ER membrane localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Uninformative generic membrane term from a large-scale membrane-proteome
+      survey (1843 proteins); the specific, well-supported location is ER
+      membrane. Not incorrect, but over-broad and non-core.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: &gt;-
+        identified 1843 proteins with high confidence scores
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:11983712
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: &gt;-
+      Direct-assay (IDA) evidence that ALG12 acts within dolichol-linked
+      oligosaccharide biosynthesis, with the acts_upstream_of_or_within
+      qualifier. The eighth mannose addition step ALG12 catalyzes is directly
+      demonstrated by the biochemical defect and its rescue.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported core biological process.
+    supported_by:
+    - reference_id: PMID:11983712
+      supporting_text: &gt;-
+        deficient in their capacity to add the eighth mannose residue onto the
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446198
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome (TAS) location in the ER membrane. Consistent with all other
+      ER-membrane evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Correct subcellular location.
+    supported_by:
+    - reference_id: file:human/ALG12/ALG12-uniprot.txt
+      supporting_text: &gt;-
+        SUBCELLULAR LOCATION: Endoplasmic reticulum membrane
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: NAS
+  original_reference_id: PMID:12217961
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Non-traceable author statement (NAS) placing ALG12 in the endoplasmic
+      reticulum. Broader than the ER membrane term but correct; ALG12 is an ER
+      alpha-1,6-mannosyltransferase.
+    action: ACCEPT
+    reason: &gt;-
+      Correct but less specific than the ER membrane annotations; retained as an
+      accurate broader location.
+    supported_by:
+    - reference_id: PMID:12217961
+      supporting_text: &gt;-
+        we describe a deficiency in the ALG12 ER
+- term:
+    id: GO:0006457
+    label: protein folding
+  evidence_type: NAS
+  original_reference_id: PMID:12217961
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Non-traceable author statement (NAS) associating ALG12 with protein
+      folding. ALG12 is a mannosyltransferase that builds the N-glycan precursor;
+      N-glycosylation supports downstream glycoprotein folding/quality control,
+      but ALG12 does not itself carry out protein folding. This mislabels the
+      molecular role.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Over-annotation via a downstream/indirect consequence. ALG12&#39;s direct role
+      is dolichol-linked oligosaccharide biosynthesis for N-glycosylation
+      (GO:0006488, GO:0006487); &#34;protein folding&#34; is an indirect effect and does
+      not describe ALG12&#39;s function. Non-core.
+    supported_by:
+    - reference_id: PMID:12217961
+      supporting_text: &gt;-
+        N-linked glycans are first
+core_functions:
+- description: &gt;-
+    Dol-P-Man-dependent alpha-1,6-mannosyltransferase that adds the eighth
+    mannose from dolichyl-phosphate-mannose in an alpha-1,6 linkage onto
+    Man7GlcNAc2-PP-dolichol to produce Man8GlcNAc2-PP-dolichol in the ER lumen
+    (EC 2.4.1.260).
+  molecular_function:
+    id: GO:0052917
+    label: dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:11983712
+    supporting_text: &gt;-
+      dolichyl-P-Man:Man(7)GlcNAc(2)-PP-dolichyl alpha6-mannosyltransferase that is
+  - reference_id: PMID:11983712
+    supporting_text: &gt;-
+      deficient in their capacity to add the eighth mannose residue onto the
+- description: &gt;-
+    ER membrane mannosyltransferase that contributes the eighth mannose of the
+    dolichol-linked oligosaccharide precursor transferred en bloc to asparagine
+    residues during protein N-linked glycosylation.
+  molecular_function:
+    id: GO:0052917
+    label: dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006487
+    label: protein N-linked glycosylation
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:12093361
+    supporting_text: &gt;-
+      Deficiency of the endoplasmic reticulum enzyme dolichyl-phosphate mannose
+  - reference_id: PMID:12093361
+    supporting_text: &gt;-
+      the partial loss of complete N-glycan
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:11983712
+  title: Congenital disorders of glycosylation type Ig is defined by a deficiency
+    in dolichyl-P-mannose:Man7GlcNAc2-PP-dolichyl mannosyltransferase.
+  findings:
+  - statement: &gt;-
+      Human ALG12, the ortholog of yeast ALG12, encodes the
+      dolichyl-P-Man:Man7GlcNAc2-PP-dolichyl alpha6-mannosyltransferase; CDG-Ig
+      patient fibroblasts are deficient in adding the eighth mannose onto the LLO
+      precursor, and the defect (F142V) is rescued by wild-type ALG12.
+    supporting_text: &gt;-
+      deficient in their capacity to add the eighth mannose residue onto the
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; primary paper establishing human ALG12 identity, the
+      Dol-P-Man-dependent alpha-1,6-mannosyltransferase activity, LLO
+      biosynthesis role, and CDG-Ig disease. Abstract-only in cache.
+- id: PMID:12093361
+  title: Deficiency of dolichyl-P-Man:Man7GlcNAc2-PP-dolichyl mannosyltransferase
+    causes congenital disorder of glycosylation type Ig.
+  findings:
+  - statement: &gt;-
+      A second CDG-Ig patient shows severely reduced ER Dol-P-Man:Man7GlcNAc2-PP-Dol
+      mannosyltransferase activity with accumulation of Man7GlcNAc2-PP-Dol and
+      partial loss of N-glycan side chains; wild-type ALG12 normalizes activity.
+    supporting_text: &gt;-
+      leading to the accumulation of Man(7)GlcNAc(2)-PP-Dol, which was transferred to
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; independent confirmation of ALG12 mannosyltransferase
+      activity, LLO role, and CDG-Ig. Abstract-only in cache.
+- id: PMID:12217961
+  title: ALG12 mannosyltransferase defect in congenital disorder of glycosylation
+    type lg.
+  findings:
+  - statement: &gt;-
+      Describes deficiency in the ALG12 ER alpha-1,6-mannosyltransferase; ER
+      lumenal LLO context; yeast alg12 complementation confirms enzyme identity;
+      defines CDG-Ig.
+    supporting_text: &gt;-
+      we describe a deficiency in the ALG12 ER
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; supports ER localization, lumenal topology, and the
+      alpha-1,6-mannosyltransferase activity. Abstract-only in cache.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings:
+  - statement: &gt;-
+      Large-scale membrane-proteome survey of an NK-like cell line detecting
+      ALG12 among 1843 proteins; basis of the generic membrane annotation only.
+    supporting_text: &gt;-
+      identified 1843 proteins with high confidence scores
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified; high-throughput proteomics providing only generic membrane
+      localization, not gene-specific function.
+- id: Reactome:R-HSA-446193
+  title: Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide,
+    LLO) and transfer to a nascent protein
+  findings: []
+- id: Reactome:R-HSA-446198
+  title: ALG12 transfers Man to N-glycan precursor (GlcNAc)2 (Man)7 (PP-Dol)1
+  findings: []
+- id: Reactome:R-HSA-4720497
+  title: Defective ALG12 does not add mannose to the N-glycan precursor
+  findings: []
+- id: file:human/ALG12/ALG12-uniprot.txt
+  title: UniProtKB Q9BV10 (ALG12_HUMAN) curated entry
+  findings:
+  - statement: &gt;-
+      ALG12 is an ER membrane, multi-pass Dol-P-Man-dependent
+      alpha-1,6-mannosyltransferase (EC 2.4.1.260) of the glycosyltransferase 22
+      family that adds the eighth mannose onto Man7GlcNAc2-PP-dolichol in the ER
+      lumen; defects cause CDG type Ig.
+    supporting_text: &gt;-
+      adds the eighth mannose residue in an alpha-1,6 linkage onto
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/ALG3/ALG3-ai-review.html
+++ b/genes/human/ALG3/ALG3-ai-review.html
@@ -1,0 +1,3947 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ALG3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ALG3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q92685" target="_blank" class="term-link">
+                        Q92685
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ALG3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q92685" data-a="DESCRIPTION: Dol-P-Man:Man(5)GlcNAc(2)-PP-dolichol alpha-1,3-ma..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Dol-P-Man:Man(5)GlcNAc(2)-PP-dolichol alpha-1,3-mannosyltransferase (EC 2.4.1.258) that catalyzes the first endoplasmic reticulum (ER) lumenal step of dolichol-linked oligosaccharide (LLO) assembly for protein N-linked glycosylation. LLO assembly begins on the cytosolic face of the ER membrane and completes in the lumen; after Man5GlcNAc2-PP-dolichol is flipped to the lumenal face, ALG3 transfers the sixth mannose - the first mannose donated by dolichyl-phosphate-mannose (Dol-P-Man) rather than GDP-mannose - in an alpha-1,3 linkage to yield Man6GlcNAc2-PP-dolichol, the substrate for the next enzyme ALG9. It is a multi-pass ER membrane protein of the glycosyltransferase ALG3 family (CAZy GT58) acting on the lumenal side of the ER membrane. Deficiency causes ALG3-CDG (congenital disorder of glycosylation type Id, CDG1D).</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0005783" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) localization of ALG3 to the endoplasmic reticulum. This is correct but is a broad parent of the more precise endoplasmic reticulum membrane (GO:0005789) where the enzyme actually resides as a multi-pass membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment but less specific than the experimentally supported ER membrane localization; retained as a broader, non-core supporting annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG3/ALG3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009101" target="_blank" class="term-link">
+                                    GO:0009101
+                                </a>
+                            </span>
+                            <span class="term-label">glycoprotein biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0009101" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) involvement in glycoprotein biosynthesis. Correct in essence - ALG3 builds the LLO precursor used for N-glycosylation - but this is a broad parent of the more specific protein N-linked glycosylation (GO:0006487) and dolichol-linked oligosaccharide biosynthetic process (GO:0006488).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> True but general; the specific BP terms (GO:0006487, GO:0006488) better capture the function and are separately annotated. Kept as non-core broader context.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                                        PMID:10581255
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the molecular defect in the index patient is a missense mutation in the gene encoding the mannosyltransferase that transfers mannose from dolichyl-phosphate mannose on to the lipid-linked oligosaccharide (LLO) intermediate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052925" target="_blank" class="term-link">
+                                    GO:0052925
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0052925" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of the specific catalytic activity - the Dol-P-Man-dependent alpha-1,3-mannosyltransferase (EC 2.4.1.258) that adds the sixth mannose to Man5GlcNAc2-PP-dolichol. This is the precise, correct molecular function and is directly supported experimentally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Specific, experimentally validated core molecular function, concordant across IBA, EC/RHEA IEA, and human IDA evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                                        PMID:10581255
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the mannosyltransferase that transfers mannose from dolichyl-phosphate mannose on to the lipid-linked oligosaccharide (LLO) intermediate Man(5)GlcNAc(2)-PP-dolichol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000030" target="_blank" class="term-link">
+                                    GO:0000030
+                                </a>
+                            </span>
+                            <span class="term-label">mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0000030" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based (IEA) generic mannosyltransferase activity. Correct at a broad level but far less specific than the experimentally established GO:0052925 (dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic parent term under-annotates a well-characterized enzyme; replace with the specific EC 2.4.1.258 activity term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052925" target="_blank" class="term-link">
+                                    dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG3/ALG3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.4.1.258</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt subcellular-location (IEA) mapping to the ER membrane, consistent with the experimental IDA localization and with the protein being a multi-pass ER membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization; agrees with experimental evidence and UniProt annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG3/ALG3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0006487" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA machine-learning (IEA) involvement in protein N-linked glycosylation. Correct - ALG3 builds the LLO precursor employed in N-glycosylation - and duplicated by an experimental IDA annotation on the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate core biological process; concordant with the human IDA annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG3/ALG3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the glycan precursors employed in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052925" target="_blank" class="term-link">
+                                    GO:0052925
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0052925" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> RHEA/EC-based (IEA, EC 2.4.1.258, RHEA:29527) assignment of the specific Dol-P-Man-dependent alpha-1,3-mannosyltransferase activity. Matches the reaction described in UniProt and the experimental IDA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct specific catalytic activity, supported by the curated EC/RHEA reaction and human experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG3/ALG3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.4.1.258</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21516116
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Next-generation sequencing to generate interactome datasets.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0005515" data-r="PMID:21516116" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein-binding IPI from a high-throughput next-generation-sequencing interactome dataset (CREB3, O43889). The bare &#34;protein binding&#34; term is uninformative about molecular function and derives from a large-scale screen rather than a mechanistic study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding from a high-throughput interactome screen conveys no specific molecular function; over-annotated per curation guidelines (not removed, as the interaction datum itself is real).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link">
+                                        PMID:21516116
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Next-generation sequencing to generate interactome datasets.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25910212
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Widespread macromolecular interaction perturbations in human...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0005515" data-r="PMID:25910212" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein-binding IPI from a systematic study of interaction perturbations in human genetic disorders (CREB3 isoform, O43889-2). &#34;Protein binding&#34; is uninformative and derived from a high-throughput map.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative bare protein-binding term from a large-scale interactome perturbation study; over-annotated per guidelines.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
+                                        PMID:25910212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29547901" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29547901
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular partners of hNOT/ALG3, the human counterpart of th...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0005515" data-r="PMID:29547901" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein-binding IPIs (multiple partners including CREB3, OSBP, OSBPL9, LRP1, SYPL1) from a dedicated yeast two-hybrid study of hNOT/ALG3. Although this is an ALG3-focused study, the GO term captured is the uninformative generic &#34;protein binding&#34;; the interactions are suggestive of roles beyond glycosylation but do not define a specific molecular function for ALG3.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Even from a targeted interactome study, bare protein binding is uninformative as a molecular function; the interactions (e.g. CREB3, OSBPs) are retained context but not a core function. Not removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29547901" target="_blank" class="term-link">
+                                        PMID:29547901
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identify 17 molecular partners of hNOT-1/ALG3-1</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29547901" target="_blank" class="term-link">
+                                        PMID:29547901
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">its in vivo interaction with the functionally linked proteins OSBP, OSBPL9 and LRP1, the SYPL1 protein and the transcription factor CREB3</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31515488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive disruption of protein interactions by genetic vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0005515" data-r="PMID:31515488" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein-binding IPI from a large-scale study of interaction disruption by genetic variants across the allele-frequency spectrum (CREB3, O43889). Bare protein binding from a high-throughput assay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding term from a high-throughput variant-interaction screen; over-annotated per guidelines.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                                        PMID:31515488
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein-binding IPIs from a systematic human binary interactome map (HuRI; partners ARL13B, CD79A, TMEM52B, SERP1, etc.). Bare &#34;protein binding&#34; from a genome-scale Y2H reference map.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic protein-binding term from a genome-scale binary interactome map; over-annotated per guidelines.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A reference map of the human binary protein interactome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446193
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0006488" data-r="Reactome:R-HSA-446193" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing ALG3 in dolichol-linked oligosaccharide (LLO) biosynthesis, the core pathway in which ALG3 adds the sixth mannose. Matches the experimental IDA on the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process; concordant with human IDA evidence and the UniProt pathway annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                                        PMID:10581255
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the lipid-linked oligosaccharide (LLO) intermediate Man(5)GlcNAc(2)-PP-dolichol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098553" target="_blank" class="term-link">
+                                    GO:0098553
+                                </a>
+                            </span>
+                            <span class="term-label">lumenal side of endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10581255
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Carbohydrate deficient glycoprotein syndrome type IV: defici...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0098553" data-r="PMID:10581255" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator inference (IC) that ALG3 acts on the lumenal side of the ER membrane, consistent with the established topology of LLO assembly in which the reaction ALG3 catalyzes occurs after the Man5GlcNAc2-PP-dolichol intermediate is flipped into the ER lumen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and precise topological localization matching the known lumenal step of LLO assembly catalyzed by ALG3.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG3/ALG3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">The assembly of dolichol-linked</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG3/ALG3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">In the lumen of the endoplasmic reticulum,</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10581255
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Carbohydrate deficient glycoprotein syndrome type IV: defici...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0005789" data-r="PMID:10581255" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) localization of ALG3 to the ER membrane, where the multi-pass membrane enzyme catalyzes the lumenal mannosyltransfer step of LLO assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported core localization; consistent with UniProt (multi-pass ER membrane protein) and the enzyme&#39;s role in ER LLO biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG3/ALG3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10581255
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Carbohydrate deficient glycoprotein syndrome type IV: defici...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0006487" data-r="PMID:10581255" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) involvement in protein N-linked glycosylation - ALG3 deficiency causes abnormal N-glycosylation due to transfer of truncated oligosaccharides, establishing its role in the pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported core biological process; ALG3 defect impairs N-glycosylation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                                        PMID:10581255
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">N-glycosylation is abnormal because of the transfer of truncated oligosaccharides</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10581255
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Carbohydrate deficient glycoprotein syndrome type IV: defici...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0006488" data-r="PMID:10581255" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) involvement in dolichol-linked oligosaccharide biosynthesis; ALG3 deficiency causes accumulation of the Man5GlcNAc2-PP-dolichol LLO intermediate, directly demonstrating its role in the pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported core biological process; the enzyme adds the sixth mannose of the LLO and its loss stalls the pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                                        PMID:10581255
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The defect results in the accumulation of the LLO intermediate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052925" target="_blank" class="term-link">
+                                    GO:0052925
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10581255
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Carbohydrate deficient glycoprotein syndrome type IV: defici...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0052925" data-r="PMID:10581255" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) demonstration of the specific Dol-P-Man-dependent alpha-1,3-mannosyltransferase activity (EC 2.4.1.258) transferring mannose from dolichyl-phosphate-mannose onto Man5GlcNAc2-PP-dolichol. This is the defining, experimentally validated core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Primary experimental evidence for the core catalytic function; the CDG1D G118D variant abolishes this activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                                        PMID:10581255
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the mannosyltransferase that transfers mannose from dolichyl-phosphate mannose on to the lipid-linked oligosaccharide (LLO) intermediate Man(5)GlcNAc(2)-PP-dolichol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000033" target="_blank" class="term-link">
+                                    GO:0000033
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,3-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446188
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0000033" data-r="Reactome:R-HSA-446188" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS assigning alpha-1,3-mannosyltransferase activity. Correct linkage specificity but a broad parent of the precise, substrate-defined GO:0052925 (dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity, EC 2.4.1.258).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but under-specified for a well-characterized enzyme; replace with the specific EC 2.4.1.258 activity term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052925" target="_blank" class="term-link">
+                                    dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                                        PMID:10581255
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the mannosyltransferase that transfers mannose from dolichyl-phosphate mannose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000033" target="_blank" class="term-link">
+                                    GO:0000033
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,3-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-4720473
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0000033" data-r="Reactome:R-HSA-4720473" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS (from the defective-ALG3 CDG1D reaction) assigning alpha-1,3-mannosyltransferase activity. As above, correct but a broad parent of the substrate-specific GO:0052925.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but under-specified; replace with the specific EC 2.4.1.258 activity term to match the well-characterized function.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052925" target="_blank" class="term-link">
+                                    dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                                        PMID:10581255
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the mannosyltransferase that transfers mannose from dolichyl-phosphate mannose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-4720473
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0005789" data-r="Reactome:R-HSA-4720473" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localizing ALG3 to the ER membrane, concordant with the experimental IDA and UniProt subcellular-location annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization; agrees with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG3/ALG3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446188
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92685" data-a="GO:0005789" data-r="Reactome:R-HSA-446188" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localizing ALG3 to the ER membrane (from the mannose-transfer reaction), concordant with the experimental IDA and UniProt annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core localization; agrees with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG3/ALG3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Dol-P-Man-dependent alpha-1,3-mannosyltransferase (EC 2.4.1.258) that catalyzes the first ER-lumenal step of dolichol-linked oligosaccharide assembly, transferring the sixth mannose from dolichyl-phosphate-mannose in an alpha-1,3 linkage onto Man5GlcNAc2-PP-dolichol to produce Man6GlcNAc2-PP-dolichol for protein N-linked glycosylation.</h3>
+                <span class="vote-buttons" data-g="Q92685" data-a="FUNCTION: Dol-P-Man-dependent alpha-1,3-mannosyltransferase ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052925" target="_blank" class="term-link">
+                            dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                dolichol-linked oligosaccharide biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                                PMID:10581255
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the mannosyltransferase that transfers mannose from dolichyl-phosphate mannose on to the lipid-linked oligosaccharide (LLO) intermediate Man(5)GlcNAc(2)-PP-dolichol</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Participates in protein N-linked glycosylation by generating the lipid-linked oligosaccharide precursor; loss of activity (as in ALG3-CDG) causes accumulation of the Man5GlcNAc2-PP-dolichol intermediate and transfer of truncated oligosaccharides.</h3>
+                <span class="vote-buttons" data-g="Q92685" data-a="FUNCTION: Participates in protein N-linked glycosylation by ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052925" target="_blank" class="term-link">
+                            dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                protein N-linked glycosylation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                                PMID:10581255
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">N-glycosylation is abnormal because of the transfer of truncated oligosaccharides</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10581255" target="_blank" class="term-link">
+                            PMID:10581255
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Carbohydrate deficient glycoprotein syndrome type IV: deficiency of dolichyl-P-Man:Man(5)GlcNAc(2)-PP-dolichyl mannosyltransferase.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Identified ALG3 as the deficient enzyme in CDGS type IV (now ALG3-CDG/CDG1D); the mannosyltransferase transfers mannose from dolichyl-phosphate-mannose onto the Man5GlcNAc2-PP-dolichol LLO intermediate, and is the structural/functional orthologue of yeast ALG3.</div>
+
+                        <div class="finding-text">"the mannosyltransferase that transfers mannose from dolichyl-phosphate mannose on to the lipid-linked oligosaccharide (LLO) intermediate Man(5)GlcNAc(2)-PP-dolichol"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link">
+                            PMID:21516116
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Next-generation sequencing to generate interactome datasets.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
+                            PMID:25910212
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29547901" target="_blank" class="term-link">
+                            PMID:29547901
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular partners of hNOT/ALG3, the human counterpart of the Drosophila NOT and yeast ALG3 gene, suggest its involvement in distinct cellular processes relevant to congenital disorders of glycosylation, cancer, neurodegeneration and a variety of further pathologies.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Yeast two-hybrid study identifying 17 molecular partners of hNOT/ALG3 including homodimers and in vivo interactions with OSBP, OSBPL9, LRP1, SYPL1 and the transcription factor CREB3.</div>
+
+                        <div class="finding-text">"we identify 17 molecular partners of hNOT-1/ALG3-1"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
+                            PMID:31515488
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446188
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ALG3 transfers Man to N-glycan precursor (GlcNAc)2 (Man)5 (PP-Dol)1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446193
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide, LLO) and transfer to a nascent protein</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-4720473
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective ALG3 does not add mannose to the N-glycan precursor</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ALG3/ALG3-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt entry Q92685 (ALG3_HUMAN)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ALG3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q92685" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="alg3-q92685-review-notes">ALG3 (Q92685) review notes</h1>
+<h2 id="summary-of-function">Summary of function</h2>
+<p>ALG3 is the human Dol-P-Man:Man(5)GlcNAc(2)-PP-dolichol alpha-1,3-mannosyltransferase<br />
+(EC 2.4.1.258), the enzyme catalysing the <strong>first ER-lumenal step</strong> of dolichol-linked<br />
+oligosaccharide (LLO) assembly for protein N-glycosylation.</p>
+<ul>
+<li>Assembly of the LLO begins on the <strong>cytosolic face</strong> of the ER membrane and finishes<br />
+  in the <strong>lumen</strong>. After Man5GlcNAc2-PP-dolichol is flipped to the lumenal face, ALG3<br />
+  transfers the <strong>sixth mannose</strong> (the first mannose derived from <strong>dolichyl-phosphate-mannose,<br />
+  Dol-P-Man</strong>, rather than GDP-Man) in an <strong>alpha-1,3 linkage</strong> onto Man5GlcNAc2-PP-Dol to<br />
+  give <strong>Man6GlcNAc2-PP-dolichol</strong>. The product is the substrate for ALG9, the next enzyme<br />
+  in the pathway [UniProt Q92685 FUNCTION; PMID:10581255].</li>
+<li>ALG3 is a <strong>polytopic ER membrane protein</strong> (11 predicted TM helices; UniProt features),<br />
+  member of the glycosyltransferase ALG3 family / CAZy GT58, active on the lumenal side of<br />
+  the ER membrane.</li>
+<li>It is the structural and functional orthologue of <em>S. cerevisiae</em> ALG3<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10581255" title="The mannosyltransferase is the structural and functional orthologue of the   Saccharomyces cerevisiae ALG3 gene.">PMID:10581255</a>.</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<p>Deficiency causes <strong>ALG3-CDG (congenital disorder of glycosylation type Id / CDG1D;<br />
+MIM:601110)</strong>, originally described as CDGS type IV. Characterised by microcephaly,<br />
+severe epilepsy, minimal psychomotor development, dysmorphism, and partial deficiency of<br />
+sialic acids in serum glycoproteins; the defect causes accumulation of the<br />
+Man5GlcNAc2-PP-Dol intermediate and transfer of truncated oligosaccharides<br />
+[PMID:10581255; PMID:15840742]. Pathogenic variants include G118D and R171Q.</p>
+<h2 id="key-references">Key references</h2>
+<ul>
+<li>PMID:10581255 (Körner et al. 1999, EMBO J): identified ALG3 as the deficient<br />
+  mannosyltransferase in CDGS type IV; defines catalytic activity, pathway, subcellular<br />
+  location, and disease. Abstract-only in cache (full_text_available: false) but abstract<br />
+  is rich. This is the primary experimental reference for MF/BP/CC IDA/IC annotations.</li>
+<li>PMID:15840742 (Sun et al. 2005): CDG1D variant R171Q; clinical presentation.</li>
+<li>PMID:29547901 (Hacker et al. 2018, Hum Mol Genet): Y2H interactome of hNOT/ALG3;<br />
+  homodimers, and interactions with OSBP, OSBPL9, LRP1, SYPL1, CREB3. Abstract-only.<br />
+  Provides functional context for the IntAct protein-binding annotations. 33% identity<br />
+  with yeast ALG3.</li>
+</ul>
+<h2 id="annotation-review-decisions">Annotation review decisions</h2>
+<p>GOA MF term = <strong>GO:0052925</strong> (dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase<br />
+activity) — this is the specific, correct current MF; used in IBA, IEA(EC/RHEA), and IDA.</p>
+<ul>
+<li>Core MF: GO:0052925 (IDA PMID:10581255, plus IBA and EC/RHEA IEA) — ACCEPT.</li>
+<li>GO:0000030 mannosyltransferase activity (IEA InterPro) and GO:0000033<br />
+  alpha-1,3-mannosyltransferase activity (TAS Reactome): correct but <strong>less specific</strong><br />
+  parents of GO:0052925 -&gt; MODIFY to GO:0052925 (over-general MF).</li>
+<li>Core BP: GO:0006488 dolichol-linked oligosaccharide biosynthetic process (IDA + TAS) and<br />
+  GO:0006487 protein N-linked glycosylation (IDA + IEA) — ACCEPT.</li>
+<li>GO:0009101 glycoprotein biosynthetic process (IBA): correct but broad parent of<br />
+  GO:0006487 -&gt; KEEP_AS_NON_CORE (acceptable broader IBA).</li>
+<li>Core CC: GO:0005789 endoplasmic reticulum membrane (IDA + IEA + TAS) — ACCEPT;<br />
+  GO:0098553 lumenal side of ER membrane (IC) — ACCEPT (precise topology).<br />
+  GO:0005783 endoplasmic reticulum (IBA) — KEEP_AS_NON_CORE (broader parent of ER membrane).</li>
+<li>GO:0005515 protein binding (IPI x11 across 5 interactome papers): bare, uninformative<br />
+  MF from high-throughput screens -&gt; MARK_AS_OVER_ANNOTATED (per policy, not REMOVE).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q92685
+gene_symbol: ALG3
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: Dol-P-Man:Man(5)GlcNAc(2)-PP-dolichol alpha-1,3-mannosyltransferase (EC
+  2.4.1.258) that catalyzes the first endoplasmic reticulum (ER) lumenal step of dolichol-linked
+  oligosaccharide (LLO) assembly for protein N-linked glycosylation. LLO assembly begins
+  on the cytosolic face of the ER membrane and completes in the lumen; after Man5GlcNAc2-PP-dolichol
+  is flipped to the lumenal face, ALG3 transfers the sixth mannose - the first mannose
+  donated by dolichyl-phosphate-mannose (Dol-P-Man) rather than GDP-mannose - in an alpha-1,3
+  linkage to yield Man6GlcNAc2-PP-dolichol, the substrate for the next enzyme ALG9. It
+  is a multi-pass ER membrane protein of the glycosyltransferase ALG3 family (CAZy GT58)
+  acting on the lumenal side of the ER membrane. Deficiency causes ALG3-CDG (congenital
+  disorder of glycosylation type Id, CDG1D).
+alternative_products:
+- name: &#39;1&#39;
+  id: Q92685-1
+- name: &#39;2&#39;
+  id: Q92685-2
+  sequence_note: VSP_042738
+existing_annotations:
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) localization of ALG3 to the endoplasmic reticulum. This
+      is correct but is a broad parent of the more precise endoplasmic reticulum membrane
+      (GO:0005789) where the enzyme actually resides as a multi-pass membrane protein.
+    action: KEEP_AS_NON_CORE
+    reason: Correct compartment but less specific than the experimentally supported ER
+      membrane localization; retained as a broader, non-core supporting annotation.
+    supported_by:
+    - reference_id: file:human/ALG3/ALG3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0009101
+    label: glycoprotein biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic (IBA) involvement in glycoprotein biosynthesis. Correct in
+      essence - ALG3 builds the LLO precursor used for N-glycosylation - but this is a
+      broad parent of the more specific protein N-linked glycosylation (GO:0006487) and
+      dolichol-linked oligosaccharide biosynthetic process (GO:0006488).
+    action: KEEP_AS_NON_CORE
+    reason: True but general; the specific BP terms (GO:0006487, GO:0006488) better capture
+      the function and are separately annotated. Kept as non-core broader context.
+    supported_by:
+    - reference_id: PMID:10581255
+      supporting_text: the molecular defect in the index patient is a missense mutation
+        in the gene encoding the mannosyltransferase that transfers mannose from dolichyl-phosphate
+        mannose on to the lipid-linked oligosaccharide (LLO) intermediate
+- term:
+    id: GO:0052925
+    label: dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) assignment of the specific catalytic activity - the Dol-P-Man-dependent
+      alpha-1,3-mannosyltransferase (EC 2.4.1.258) that adds the sixth mannose to Man5GlcNAc2-PP-dolichol.
+      This is the precise, correct molecular function and is directly supported experimentally.
+    action: ACCEPT
+    reason: Specific, experimentally validated core molecular function, concordant across
+      IBA, EC/RHEA IEA, and human IDA evidence.
+    supported_by:
+    - reference_id: PMID:10581255
+      supporting_text: the mannosyltransferase that transfers mannose from dolichyl-phosphate
+        mannose on to the lipid-linked oligosaccharide (LLO) intermediate Man(5)GlcNAc(2)-PP-dolichol
+- term:
+    id: GO:0000030
+    label: mannosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro-based (IEA) generic mannosyltransferase activity. Correct at a broad
+      level but far less specific than the experimentally established GO:0052925 (dol-P-Man:Man(5)GlcNAc(2)-PP-Dol
+      alpha-1,3-mannosyltransferase activity).
+    action: MODIFY
+    reason: The generic parent term under-annotates a well-characterized enzyme; replace
+      with the specific EC 2.4.1.258 activity term.
+    proposed_replacement_terms:
+    - id: GO:0052925
+      label: dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+    supported_by:
+    - reference_id: file:human/ALG3/ALG3-uniprot.txt
+      supporting_text: EC=2.4.1.258
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt subcellular-location (IEA) mapping to the ER membrane, consistent
+      with the experimental IDA localization and with the protein being a multi-pass ER
+      membrane protein.
+    action: ACCEPT
+    reason: Correct core localization; agrees with experimental evidence and UniProt annotation.
+    supported_by:
+    - reference_id: file:human/ALG3/ALG3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: ARBA machine-learning (IEA) involvement in protein N-linked glycosylation.
+      Correct - ALG3 builds the LLO precursor employed in N-glycosylation - and duplicated
+      by an experimental IDA annotation on the same term.
+    action: ACCEPT
+    reason: Accurate core biological process; concordant with the human IDA annotation.
+    supported_by:
+    - reference_id: file:human/ALG3/ALG3-uniprot.txt
+      supporting_text: the glycan precursors employed in
+- term:
+    id: GO:0052925
+    label: dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: RHEA/EC-based (IEA, EC 2.4.1.258, RHEA:29527) assignment of the specific
+      Dol-P-Man-dependent alpha-1,3-mannosyltransferase activity. Matches the reaction
+      described in UniProt and the experimental IDA.
+    action: ACCEPT
+    reason: Correct specific catalytic activity, supported by the curated EC/RHEA reaction
+      and human experimental evidence.
+    supported_by:
+    - reference_id: file:human/ALG3/ALG3-uniprot.txt
+      supporting_text: EC=2.4.1.258
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21516116
+  qualifier: enables
+  review:
+    summary: Protein-binding IPI from a high-throughput next-generation-sequencing interactome
+      dataset (CREB3, O43889). The bare &#34;protein binding&#34; term is uninformative about
+      molecular function and derives from a large-scale screen rather than a mechanistic
+      study.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding from a high-throughput interactome screen conveys no specific
+      molecular function; over-annotated per curation guidelines (not removed, as the
+      interaction datum itself is real).
+    supported_by:
+    - reference_id: PMID:21516116
+      supporting_text: Next-generation sequencing to generate interactome datasets.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25910212
+  qualifier: enables
+  review:
+    summary: Protein-binding IPI from a systematic study of interaction perturbations in
+      human genetic disorders (CREB3 isoform, O43889-2). &#34;Protein binding&#34; is uninformative
+      and derived from a high-throughput map.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative bare protein-binding term from a large-scale interactome perturbation
+      study; over-annotated per guidelines.
+    supported_by:
+    - reference_id: PMID:25910212
+      supporting_text: Widespread macromolecular interaction perturbations in human genetic
+        disorders.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:29547901
+  qualifier: enables
+  review:
+    summary: Protein-binding IPIs (multiple partners including CREB3, OSBP, OSBPL9, LRP1,
+      SYPL1) from a dedicated yeast two-hybrid study of hNOT/ALG3. Although this is an
+      ALG3-focused study, the GO term captured is the uninformative generic &#34;protein binding&#34;;
+      the interactions are suggestive of roles beyond glycosylation but do not define a
+      specific molecular function for ALG3.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Even from a targeted interactome study, bare protein binding is uninformative
+      as a molecular function; the interactions (e.g. CREB3, OSBPs) are retained context
+      but not a core function. Not removed.
+    supported_by:
+    - reference_id: PMID:29547901
+      supporting_text: we identify 17 molecular partners of hNOT-1/ALG3-1
+    - reference_id: PMID:29547901
+      supporting_text: its in vivo interaction with the functionally linked proteins OSBP,
+        OSBPL9 and LRP1, the SYPL1 protein and the transcription factor CREB3
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  qualifier: enables
+  review:
+    summary: Protein-binding IPI from a large-scale study of interaction disruption by
+      genetic variants across the allele-frequency spectrum (CREB3, O43889). Bare protein
+      binding from a high-throughput assay.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding term from a high-throughput variant-interaction
+      screen; over-annotated per guidelines.
+    supported_by:
+    - reference_id: PMID:31515488
+      supporting_text: Extensive disruption of protein interactions by genetic variants
+        across the allele frequency spectrum in human populations.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: Protein-binding IPIs from a systematic human binary interactome map (HuRI;
+      partners ARL13B, CD79A, TMEM52B, SERP1, etc.). Bare &#34;protein binding&#34; from a genome-scale
+      Y2H reference map.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic protein-binding term from a genome-scale binary interactome
+      map; over-annotated per guidelines.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: A reference map of the human binary protein interactome.
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446193
+  qualifier: involved_in
+  review:
+    summary: Reactome TAS placing ALG3 in dolichol-linked oligosaccharide (LLO) biosynthesis,
+      the core pathway in which ALG3 adds the sixth mannose. Matches the experimental IDA
+      on the same term.
+    action: ACCEPT
+    reason: Correct core biological process; concordant with human IDA evidence and the
+      UniProt pathway annotation.
+    supported_by:
+    - reference_id: PMID:10581255
+      supporting_text: the lipid-linked oligosaccharide (LLO) intermediate Man(5)GlcNAc(2)-PP-dolichol
+- term:
+    id: GO:0098553
+    label: lumenal side of endoplasmic reticulum membrane
+  evidence_type: IC
+  original_reference_id: PMID:10581255
+  qualifier: is_active_in
+  review:
+    summary: Curator inference (IC) that ALG3 acts on the lumenal side of the ER membrane,
+      consistent with the established topology of LLO assembly in which the reaction ALG3
+      catalyzes occurs after the Man5GlcNAc2-PP-dolichol intermediate is flipped into the
+      ER lumen.
+    action: ACCEPT
+    reason: Correct and precise topological localization matching the known lumenal step
+      of LLO assembly catalyzed by ALG3.
+    supported_by:
+    - reference_id: file:human/ALG3/ALG3-uniprot.txt
+      supporting_text: The assembly of dolichol-linked
+    - reference_id: file:human/ALG3/ALG3-uniprot.txt
+      supporting_text: In the lumen of the endoplasmic reticulum,
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:10581255
+  qualifier: is_active_in
+  review:
+    summary: Experimental (IDA) localization of ALG3 to the ER membrane, where the multi-pass
+      membrane enzyme catalyzes the lumenal mannosyltransfer step of LLO assembly.
+    action: ACCEPT
+    reason: Experimentally supported core localization; consistent with UniProt (multi-pass
+      ER membrane protein) and the enzyme&#39;s role in ER LLO biosynthesis.
+    supported_by:
+    - reference_id: file:human/ALG3/ALG3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IDA
+  original_reference_id: PMID:10581255
+  qualifier: involved_in
+  review:
+    summary: Experimental (IDA) involvement in protein N-linked glycosylation - ALG3 deficiency
+      causes abnormal N-glycosylation due to transfer of truncated oligosaccharides, establishing
+      its role in the pathway.
+    action: ACCEPT
+    reason: Directly supported core biological process; ALG3 defect impairs N-glycosylation.
+    supported_by:
+    - reference_id: PMID:10581255
+      supporting_text: N-glycosylation is abnormal because of the transfer of truncated
+        oligosaccharides
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:10581255
+  qualifier: involved_in
+  review:
+    summary: Experimental (IDA) involvement in dolichol-linked oligosaccharide biosynthesis;
+      ALG3 deficiency causes accumulation of the Man5GlcNAc2-PP-dolichol LLO intermediate,
+      directly demonstrating its role in the pathway.
+    action: ACCEPT
+    reason: Directly supported core biological process; the enzyme adds the sixth mannose
+      of the LLO and its loss stalls the pathway.
+    supported_by:
+    - reference_id: PMID:10581255
+      supporting_text: The defect results in the accumulation of the LLO intermediate
+- term:
+    id: GO:0052925
+    label: dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:10581255
+  qualifier: enables
+  review:
+    summary: Experimental (IDA) demonstration of the specific Dol-P-Man-dependent alpha-1,3-mannosyltransferase
+      activity (EC 2.4.1.258) transferring mannose from dolichyl-phosphate-mannose onto
+      Man5GlcNAc2-PP-dolichol. This is the defining, experimentally validated core molecular
+      function.
+    action: ACCEPT
+    reason: Primary experimental evidence for the core catalytic function; the CDG1D G118D
+      variant abolishes this activity.
+    supported_by:
+    - reference_id: PMID:10581255
+      supporting_text: the mannosyltransferase that transfers mannose from dolichyl-phosphate
+        mannose on to the lipid-linked oligosaccharide (LLO) intermediate Man(5)GlcNAc(2)-PP-dolichol
+- term:
+    id: GO:0000033
+    label: alpha-1,3-mannosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446188
+  qualifier: enables
+  review:
+    summary: Reactome TAS assigning alpha-1,3-mannosyltransferase activity. Correct linkage
+      specificity but a broad parent of the precise, substrate-defined GO:0052925 (dol-P-Man:Man(5)GlcNAc(2)-PP-Dol
+      alpha-1,3-mannosyltransferase activity, EC 2.4.1.258).
+    action: MODIFY
+    reason: Correct but under-specified for a well-characterized enzyme; replace with the
+      specific EC 2.4.1.258 activity term.
+    proposed_replacement_terms:
+    - id: GO:0052925
+      label: dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+    supported_by:
+    - reference_id: PMID:10581255
+      supporting_text: the mannosyltransferase that transfers mannose from dolichyl-phosphate
+        mannose
+- term:
+    id: GO:0000033
+    label: alpha-1,3-mannosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-4720473
+  qualifier: enables
+  review:
+    summary: Reactome TAS (from the defective-ALG3 CDG1D reaction) assigning alpha-1,3-mannosyltransferase
+      activity. As above, correct but a broad parent of the substrate-specific GO:0052925.
+    action: MODIFY
+    reason: Correct but under-specified; replace with the specific EC 2.4.1.258 activity
+      term to match the well-characterized function.
+    proposed_replacement_terms:
+    - id: GO:0052925
+      label: dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+    supported_by:
+    - reference_id: PMID:10581255
+      supporting_text: the mannosyltransferase that transfers mannose from dolichyl-phosphate
+        mannose
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-4720473
+  qualifier: located_in
+  review:
+    summary: Reactome TAS localizing ALG3 to the ER membrane, concordant with the experimental
+      IDA and UniProt subcellular-location annotations.
+    action: ACCEPT
+    reason: Correct core localization; agrees with experimental evidence.
+    supported_by:
+    - reference_id: file:human/ALG3/ALG3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446188
+  qualifier: located_in
+  review:
+    summary: Reactome TAS localizing ALG3 to the ER membrane (from the mannose-transfer
+      reaction), concordant with the experimental IDA and UniProt annotations.
+    action: ACCEPT
+    reason: Correct core localization; agrees with experimental evidence.
+    supported_by:
+    - reference_id: file:human/ALG3/ALG3-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+core_functions:
+- description: Dol-P-Man-dependent alpha-1,3-mannosyltransferase (EC 2.4.1.258) that catalyzes
+    the first ER-lumenal step of dolichol-linked oligosaccharide assembly, transferring
+    the sixth mannose from dolichyl-phosphate-mannose in an alpha-1,3 linkage onto Man5GlcNAc2-PP-dolichol
+    to produce Man6GlcNAc2-PP-dolichol for protein N-linked glycosylation.
+  molecular_function:
+    id: GO:0052925
+    label: dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:10581255
+    supporting_text: the mannosyltransferase that transfers mannose from dolichyl-phosphate
+      mannose on to the lipid-linked oligosaccharide (LLO) intermediate Man(5)GlcNAc(2)-PP-dolichol
+- description: Participates in protein N-linked glycosylation by generating the lipid-linked
+    oligosaccharide precursor; loss of activity (as in ALG3-CDG) causes accumulation of
+    the Man5GlcNAc2-PP-dolichol intermediate and transfer of truncated oligosaccharides.
+  molecular_function:
+    id: GO:0052925
+    label: dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006487
+    label: protein N-linked glycosylation
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:10581255
+    supporting_text: N-glycosylation is abnormal because of the transfer of truncated
+      oligosaccharides
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10581255
+  title: &#39;Carbohydrate deficient glycoprotein syndrome type IV: deficiency of dolichyl-P-Man:Man(5)GlcNAc(2)-PP-dolichyl
+    mannosyltransferase.&#39;
+  findings:
+  - statement: Identified ALG3 as the deficient enzyme in CDGS type IV (now ALG3-CDG/CDG1D);
+      the mannosyltransferase transfers mannose from dolichyl-phosphate-mannose onto the
+      Man5GlcNAc2-PP-dolichol LLO intermediate, and is the structural/functional orthologue
+      of yeast ALG3.
+    supporting_text: the mannosyltransferase that transfers mannose from dolichyl-phosphate
+      mannose on to the lipid-linked oligosaccharide (LLO) intermediate Man(5)GlcNAc(2)-PP-dolichol
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified primary reference (Korner et al. 1999, EMBO J); establishes
+      catalytic activity, pathway, ER localization and CDG1D. Cached entry is abstract-only
+      (full_text_available false) but the abstract directly supports the MF/BP/CC annotations.
+- id: PMID:21516116
+  title: Next-generation sequencing to generate interactome datasets.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput interactome methods paper; source of a bare protein-binding
+      IPI (CREB3). Real interaction datum but uninformative as molecular function.
+- id: PMID:25910212
+  title: Widespread macromolecular interaction perturbations in human genetic disorders.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Large-scale interaction-perturbation study; source of a bare protein-binding
+      IPI (CREB3 isoform). Not informative for ALG3 molecular function.
+- id: PMID:29547901
+  title: Molecular partners of hNOT/ALG3, the human counterpart of the Drosophila
+    NOT and yeast ALG3 gene, suggest its involvement in distinct cellular processes
+    relevant to congenital disorders of glycosylation, cancer, neurodegeneration and
+    a variety of further pathologies.
+  findings:
+  - statement: Yeast two-hybrid study identifying 17 molecular partners of hNOT/ALG3
+      including homodimers and in vivo interactions with OSBP, OSBPL9, LRP1, SYPL1 and
+      the transcription factor CREB3.
+    supporting_text: we identify 17 molecular partners of hNOT-1/ALG3-1
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: ALG3-focused Y2H interactome study; provides functional context for the
+      IntAct protein-binding annotations. Abstract-only in cache. Interactions are suggestive
+      but do not define a specific molecular function beyond the mannosyltransferase activity.
+- id: PMID:31515488
+  title: Extensive disruption of protein interactions by genetic variants across the
+    allele frequency spectrum in human populations.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput variant-interaction screen; source of a bare protein-binding
+      IPI (CREB3). Uninformative for ALG3 molecular function.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Genome-scale binary interactome map (HuRI); source of several bare protein-binding
+      IPIs. Uninformative for ALG3 molecular function.
+- id: Reactome:R-HSA-446188
+  title: ALG3 transfers Man to N-glycan precursor (GlcNAc)2 (Man)5 (PP-Dol)1
+  findings: []
+- id: Reactome:R-HSA-446193
+  title: Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide,
+    LLO) and transfer to a nascent protein
+  findings: []
+- id: Reactome:R-HSA-4720473
+  title: Defective ALG3 does not add mannose to the N-glycan precursor
+  findings: []
+- id: file:human/ALG3/ALG3-uniprot.txt
+  title: UniProt entry Q92685 (ALG3_HUMAN)
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/ALG6/ALG6-ai-review.html
+++ b/genes/human/ALG6/ALG6-ai-review.html
@@ -1,0 +1,4149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ALG6 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ALG6</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9Y672" target="_blank" class="term-link">
+                        Q9Y672
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ALG6";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9Y672" data-a="DESCRIPTION: ALG6 (Dol-P-Glc:Man(9)GlcNAc(2)-PP-dolichol alpha-..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ALG6 (Dol-P-Glc:Man(9)GlcNAc(2)-PP-dolichol alpha-1,3-glucosyltransferase; EC 2.4.1.267) is a multi-pass endoplasmic reticulum membrane enzyme that catalyzes the first of the three glucosylation steps in the assembly of the dolichol-linked oligosaccharide (LLO), the N-glycan precursor. Acting on the lumenal face of the ER membrane, it transfers a glucose residue from the lipid donor dolichyl-phosphate-glucose (Dol-P-Glc, not UDP-glucose) onto Man9GlcNAc2-PP-dolichol to produce Glc1Man9GlcNAc2-PP-dolichol, which is then extended by ALG8 and ALG10 to yield the mature Glc3Man9GlcNAc2-PP-dolichol. Glucosylation of the LLO is required for efficient transfer of the glycan onto nascent proteins by the oligosaccharyltransferase, so ALG6 activity supports protein N-linked glycosylation. It belongs to the ALG6/ALG8 glucosyltransferase family (CAZy GT57). Loss-of-function variants cause ALG6-congenital disorder of glycosylation (ALG6-CDG / CDG type Ic), one of the most common CDG-I subtypes, characterized by accumulation of Man9GlcNAc2-PP-dolichol and hypoglycosylation of serum glycoproteins, with a multisystem clinical presentation.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assertion that ALG6 is active in the ER membrane. This matches the experimentally supported subcellular location and the multi-pass ER membrane topology of the protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ALG6 is a multi-pass ER membrane protein whose glucosyltransferase active site faces the ER lumen; the ER membrane is its correct site of action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0006488" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assertion that ALG6 participates in dolichol-linked oligosaccharide (LLO) biosynthesis. This is the core biological process of the enzyme: it adds the first glucose to the Man9GlcNAc2-PP-Dol intermediate during LLO assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported: ALG6 catalyzes a defined step of LLO assembly, producing Glc1Man9GlcNAc2-PP-Dol from Man9GlcNAc2-PP-Dol. Loss of ALG6 causes accumulation of the Man9GlcNAc2-PP-Dol precursor. This is a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the first glucose residue from dolichyl phosphate glucose (Dol-P-</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25792706" target="_blank" class="term-link">
+                                        PMID:25792706
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A defect in the assembly of the oligosaccharide donor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042281" target="_blank" class="term-link">
+                                    GO:0042281
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0042281" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assertion of the specific molecular function of ALG6: dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity (EC 2.4.1.267). This is the exact enzymatic activity supported by experimental and biochemical evidence and is the core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the precise, correct molecular-function term for ALG6, consistent across IBA, IMP and IEA/EC evidence and the UniProt catalytic-activity record (RHEA:30635, EC 2.4.1.267).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the first glucose residue from dolichyl phosphate glucose (Dol-P-</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10924277" target="_blank" class="term-link">
+                                        PMID:10924277
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">encodes an alpha-1,3 glucosyltransferase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) subcellular-location mapping from UniProt Swiss-Prot keyword/SubCell vocabulary placing ALG6 in the ER membrane. Consistent with the experimentally curated location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization, redundant with the IBA and TAS ER-membrane annotations and with the curated UniProt subcellular location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016758" target="_blank" class="term-link">
+                                    GO:0016758
+                                </a>
+                            </span>
+                            <span class="term-label">hexosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0016758" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) InterPro2GO mapping (IPR004856, the ALG6/ALG8 glucosyltransferase domain) to the broad grouping term hexosyltransferase activity. This is correct but far less specific than the known activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Hexosyltransferase activity is a high-level parent that is chemically correct but uninformative given the well-established, specific activity of ALG6. Replace with the specific alpha-1,3-glucosyltransferase term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042281" target="_blank" class="term-link">
+                                    dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the ALG6/ALG8 glucosyltransferase family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042281" target="_blank" class="term-link">
+                                    GO:0042281
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0042281" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) annotation of the specific alpha-1,3-glucosyltransferase activity derived from the EC/RHEA mapping (RHEA:30635, EC 2.4.1.267). Fully consistent with the curated catalytic activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The EC 2.4.1.267 / RHEA:30635 mapping matches the experimentally curated reaction; this is the correct, specific molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.4.1.267</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI annotation to the generic term protein binding, from a proteome-scale AP-MS interactome study (BioPlex). The interaction partner (UniProtKB:Q9BVK2 = ALG8) is biologically meaningful: ALG8 is the next enzyme in LLO glucosylation and acts on the ALG6 product. However, the term itself is uninformative about molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding conveys no specific molecular function and is discouraged per curation guidelines. The underlying ALG6-ALG8 interaction is real and pathway-relevant (ALG8 extends the Glc1Man9GlcNAc2-PP-Dol product made by ALG6), but this should not be treated as a core function annotation. Retain as over-annotated rather than removed, since it is a valid experimental interaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Q9Y672; Q9BVK2: ALG8</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">affinity-purification mass spectrometry</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446193
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0006488" data-r="Reactome:R-HSA-446193" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author (Reactome) annotation to LLO biosynthesis, from the pathway &#34;Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide, LLO) and transfer to a nascent protein&#34;. Correct core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the IBA/IMP LLO-biosynthesis annotations; correctly captures ALG6&#39;s role in LLO assembly.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the first glucose residue from dolichyl phosphate glucose (Dol-P-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098553" target="_blank" class="term-link">
+                                    GO:0098553
+                                </a>
+                            </span>
+                            <span class="term-label">lumenal side of endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10359825
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A mutation in the human ortholog of the Saccharomyces cerevi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0098553" data-r="PMID:10359825" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator-inferred (IC) annotation that ALG6 is active on the lumenal side of the ER membrane. This reflects the enzyme mechanism: it uses the lumenal LLO intermediate Man9GlcNAc2-PP-Dol as acceptor, and the UniProt membrane topology places lumenal loops between transmembrane helices.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and more precise than the generic ER membrane term. LLO glucosylation occurs in the ER lumen (the assembly begins on the cytosolic face and finishes in the lumen), consistent with a lumenal-side active site.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the first glucose residue from dolichyl phosphate glucose (Dol-P-</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link">
+                                        PMID:10359825
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in the endoplasmic reticulum</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10359825
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A mutation in the human ortholog of the Saccharomyces cerevi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0006487" data-r="PMID:10359825" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP annotation to protein N-linked glycosylation based on mutant phenotype: patient/mutant ALG6 fails to restore glycosylation in an alg6-deficient yeast strain, and ALG6 deficiency underlies CDG type Ic (defective N-glycosylation). ALG6 acts upstream, providing the glucosylated LLO used by the oligosaccharyltransferase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ALG6 is genuinely required for normal protein N-linked glycosylation; loss-of-function produces hypoglycosylation. This is a bona fide, if upstream, involvement in N-glycosylation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link">
+                                        PMID:10359825
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the mutant ALG6 cDNA of CDGS patients failed to revert the hypoglycosylation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10924277" target="_blank" class="term-link">
+                                        PMID:10924277
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">addition of the first glucose residue to the lipid-linked oligosaccharide</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25792706" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25792706
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Reduced expression of the oligosaccharyltransferase exacerba...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0006487" data-r="PMID:25792706" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP annotation to protein N-linked glycosylation from analysis of ALG6-deficient cell lines, which assemble Man9GlcNAc2-PP-Dol as the largest donor and show hypoglycosylation of oligosaccharyl- transferase substrate sites.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly demonstrates that ALG6 loss impairs protein N-linked glycosylation; supports involvement in the N-glycosylation process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25792706" target="_blank" class="term-link">
+                                        PMID:25792706
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A defect in the assembly of the oligosaccharide donor</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25792706" target="_blank" class="term-link">
+                                        PMID:25792706
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">assemble Dol-PP-GlcNAc(2)Man(9)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10359825
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A mutation in the human ortholog of the Saccharomyces cerevi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0006488" data-r="PMID:10359825" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP annotation to LLO biosynthesis: CDG-Ic patients accumulate dolichyl pyrophosphate-linked Man9GlcNAc2, and mutant ALG6 fails to complement the yeast alg6 glycosylation defect, demonstrating ALG6&#39;s role in LLO assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process; strongly supported by the accumulation of the Man9GlcNAc2-PP-Dol intermediate on ALG6 loss and by yeast complementation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link">
+                                        PMID:10359825
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">impaired biosynthesis of dolichyl pyrophosphate-linked</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link">
+                                        PMID:10359825
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the mutant ALG6 cDNA of CDGS patients failed to revert the hypoglycosylation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25792706" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25792706
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Reduced expression of the oligosaccharyltransferase exacerba...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0006488" data-r="PMID:25792706" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP annotation to LLO biosynthesis from ALG6-deficient cells, which stall LLO assembly at Man9GlcNAc2-PP-Dol (the largest donor they can make), confirming ALG6&#39;s role in extending the LLO.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with ALG6 being the enzyme that adds the first glucose during LLO biosynthesis; loss halts assembly at Man9GlcNAc2-PP-Dol.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25792706" target="_blank" class="term-link">
+                                        PMID:25792706
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">assemble Dol-PP-GlcNAc(2)Man(9)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042281" target="_blank" class="term-link">
+                                    GO:0042281
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25792706" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25792706
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Reduced expression of the oligosaccharyltransferase exacerba...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0042281" data-r="PMID:25792706" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP annotation of the specific alpha-1,3-glucosyltransferase activity, inferred from the phenotype of ALG6-deficient cells that cannot add glucose beyond Man9GlcNAc2-PP-Dol. This is the core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The mutant phenotype (accumulation of Man9GlcNAc2-PP-Dol; hypoglycosylation) directly attributes the alpha-1,3-glucosyltransferase activity to ALG6.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25792706" target="_blank" class="term-link">
+                                        PMID:25792706
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">assemble Dol-PP-GlcNAc(2)Man(9)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.4.1.267</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042281" target="_blank" class="term-link">
+                                    GO:0042281
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10359825
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A mutation in the human ortholog of the Saccharomyces cerevi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0042281" data-r="PMID:10359825" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IGI annotation (genetic interaction with the ALG8 glucosyltransferase, UniProtKB:Q12001) supporting the alpha-1,3-glucosyltransferase activity of ALG6. Consistent with yeast complementation defining ALG6 as the first LLO glucosyltransferase acting upstream of ALG8.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The genetic relationship with the downstream glucosyltransferase (ALG8) plus yeast complementation supports ALG6 as the alpha-1,3-glucosyltransferase adding the first glucose; correct specific MF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link">
+                                        PMID:10359825
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ALG6 dolichyl pyrophosphate Man9GlcNAc2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004583" target="_blank" class="term-link">
+                                    GO:0004583
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl-phosphate-glucose-glycolipid alpha-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446202
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0004583" data-r="Reactome:R-HSA-446202" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation of a Dol-P-Glc-dependent glucosyltransferase activity for the reaction &#34;Addition of the first glucose to the N-glycan precursor by ALG6&#34;. The chemistry (Dol-P-Glc donor) is correct, but this parent term is less precise than the specific ALG6 activity term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0004583 correctly captures the Dol-P-Glc donor chemistry but is a broader grouping; the specific substrate-defined activity GO:0042281 (dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3- glucosyltransferase activity, EC 2.4.1.267) is the accurate molecular function for ALG6.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042281" target="_blank" class="term-link">
+                                    dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the first glucose residue from dolichyl phosphate glucose (Dol-P-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004583" target="_blank" class="term-link">
+                                    GO:0004583
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl-phosphate-glucose-glycolipid alpha-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-4724291
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0004583" data-r="Reactome:R-HSA-4724291" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation of Dol-P-Glc-dependent glucosyltransferase activity from the CDG variant pathway (&#34;Defective ALG6 does not add glucose to the N-glycan precursor&#34;). Same as the R-HSA-446202 annotation: correct chemistry, but a broader term than the specific ALG6 activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As above, replace the broader Dol-P-Glc glucosyltransferase grouping with the specific GO:0042281 term that matches ALG6&#39;s defined substrate and product.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042281" target="_blank" class="term-link">
+                                    dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the first glucose residue from dolichyl phosphate glucose (Dol-P-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-4724291
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0005789" data-r="Reactome:R-HSA-4724291" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation placing ALG6 in the ER membrane. Consistent with the curated subcellular location and multi-pass ER membrane topology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization, redundant with other ER-membrane annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0016020" data-r="PMID:19946888" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput (HDA) proteomics annotation to the generic term membrane, from a mass-spectrometry membrane-proteome survey of NK-like cells. This detects ALG6 in a membrane fraction but is not specific to the ER.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic membrane term is uninformative given the well-established ER membrane localization. Replace with the specific ER membrane term. The proteomics detection is consistent with (though not diagnostic of) ER membrane residence.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    endoplasmic reticulum membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">1843 proteins with high confidence scores</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446202
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0005789" data-r="Reactome:R-HSA-446202" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation placing ALG6 in the ER membrane (from the &#34;Addition of the first glucose&#34; pathway). Correct localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and redundant with the other ER-membrane annotations; consistent with the curated location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG6/ALG6-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10924277" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10924277
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of multiple mutations in the hALG6 gene in a patien...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0006487" data-r="PMID:10924277" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation (acts_upstream_of_or_within protein N-linked glycosylation) from biochemical/ molecular analysis of a CDG-Ic patient with multiple hALG6 mutations. ALG6 adds the first glucose to the LLO precursor, an event required upstream of protein N-glycosylation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly captures ALG6&#39;s upstream role in N-linked glycosylation. The acts_upstream_of_or_within qualifier is appropriate because ALG6 provides the glucosylated LLO used by the oligosaccharyltransferase rather than performing the protein-transfer step itself.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10924277" target="_blank" class="term-link">
+                                        PMID:10924277
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">addition of the first glucose residue to the lipid-linked oligosaccharide</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10924277" target="_blank" class="term-link">
+                                        PMID:10924277
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This enzyme is required for the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046527" target="_blank" class="term-link">
+                                    GO:0046527
+                                </a>
+                            </span>
+                            <span class="term-label">glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10359825
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A mutation in the human ortholog of the Saccharomyces cerevi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y672" data-a="GO:0046527" data-r="PMID:10359825" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to the grouping term glucosyltransferase activity, from the cloning/complementation study that identified human ALG6 as the alpha-1,3-glucosyltransferase adding the first glucose to the LLO. Correct chemistry but less specific than the defined ALG6 activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Glucosyltransferase activity is a correct parent but under-specifies ALG6&#39;s function; the specific GO:0042281 term (matching the EC 2.4.1.267 reaction) is the accurate molecular function.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042281" target="_blank" class="term-link">
+                                    dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link">
+                                        PMID:10359825
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ALG6 dolichyl pyrophosphate Man9GlcNAc2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ALG6 is the ER-lumenal alpha-1,3-glucosyltransferase that adds the first of the three glucoses to the dolichol-linked oligosaccharide precursor. Using dolichyl-phosphate-glucose (Dol-P-Glc) as donor, it converts Man9GlcNAc2-PP-dolichol to Glc1Man9GlcNAc2-PP-dolichol during dolichol-linked oligosaccharide biosynthesis, thereby supporting downstream protein N-linked glycosylation.</h3>
+                <span class="vote-buttons" data-g="Q9Y672" data-a="FUNCTION: ALG6 is the ER-lumenal alpha-1,3-glucosyltransfera..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042281" target="_blank" class="term-link">
+                            dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                dolichol-linked oligosaccharide biosynthetic process
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                protein N-linked glycosylation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ALG6/ALG6-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">adds the first glucose residue from dolichyl phosphate glucose (Dol-P-</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ALG6/ALG6-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">substrate for ALG8, the following</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25792706" target="_blank" class="term-link">
+                                PMID:25792706
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">A defect in the assembly of the oligosaccharide donor</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10924277" target="_blank" class="term-link">
+                                PMID:10924277
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">addition of the first glucose residue to the lipid-linked oligosaccharide</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10359825" target="_blank" class="term-link">
+                            PMID:10359825
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A mutation in the human ortholog of the Saccharomyces cerevisiae ALG6 gene causes carbohydrate-deficient glycoprotein syndrome type-Ic.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10924277" target="_blank" class="term-link">
+                            PMID:10924277
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of multiple mutations in the hALG6 gene in a patient with congenital disorder of glycosylation Ic.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25792706" target="_blank" class="term-link">
+                            PMID:25792706
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Reduced expression of the oligosaccharyltransferase exacerbates protein hypoglycosylation in cells lacking the fully assembled oligosaccharide donor.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446193
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide, LLO) and transfer to a nascent protein</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446202
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Addition of the first glucose to the N-glycan precursor by ALG6</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-4724291
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective ALG6 does not add glucose to the N-glycan precursor</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ALG6/ALG6-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB Q9Y672 (ALG6_HUMAN) record</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the structural basis for ALG6 substrate recognition of Man9GlcNAc2-PP-dolichol, and how do the common CDG-Ic variants (e.g. A333V, S478P) reduce catalytic activity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9Y672" data-a="Q: What is the structural basis for ALG6 substrate re..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does ALG6 function as part of a stable multi-enzyme LLO-glucosylation module with ALG8 and ALG10, or is the ALG6-ALG8 interaction transient/substrate-channeling?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9Y672" data-a="Q: Does ALG6 function as part of a stable multi-enzym..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute purified ALG6 with Dol-P-Glc and Man9GlcNAc2-PP-Dol in vitro to directly measure alpha-1,3-glucosyltransferase kinetics and the effect of disease variants on activity.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9Y672" data-a="EXPERIMENT: Reconstitute purified ALG6 with Dol-P-Glc and Man9..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the cryo-EM structure of ALG6 (alone and in complex with ALG8) to map the lumenal active site and the donor/acceptor binding sites.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9Y672" data-a="EXPERIMENT: Determine the cryo-EM structure of ALG6 (alone and..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ALG6-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9Y672" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="alg6-human-curation-notes">ALG6 (human) curation notes</h1>
+<p>UniProtKB:Q9Y672 — Dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase; EC 2.4.1.267.<br />
+HGNC:23157. 507 aa multi-pass ER membrane protein (UniProt lists 10 TM helices).</p>
+<blockquote>
+<p>Note: falcon deep research was unavailable (API out of credits, HTTP 402). This review is<br />
+grounded in the UniProt record (<code>ALG6-uniprot.txt</code>), the seeded GOA (<code>ALG6-goa.tsv</code>), and the<br />
+cached publications under <code>publications/</code>. No <code>-deep-research-falcon.md</code> was fabricated.</p>
+</blockquote>
+<h2 id="core-biology">Core biology</h2>
+<p>ALG6 is the ER-lumenal alpha-1,3-glucosyltransferase that adds the <strong>first of three glucoses</strong><br />
+to the dolichol-linked oligosaccharide (LLO). It transfers glucose from dolichyl-phosphate-glucose<br />
+(Dol-P-Glc; <strong>not</strong> UDP-Glc) onto Man9GlcNAc2-PP-dolichol to give Glc1Man9GlcNAc2-PP-dolichol,<br />
+the substrate for the next enzyme ALG8.</p>
+<ul>
+<li>UniProt FUNCTION: "In the lumen of the endoplasmic reticulum, adds the first glucose residue from<br />
+  dolichyl phosphate glucose (Dol-P-Glc) onto the lipid-linked oligosaccharide intermediate<br />
+  Man(9)GlcNAc(2)-PP-Dol to produce Glc(1)Man(9)GlcNAc(2)-PP-Dol. Glc(1)Man(9)GlcNAc(2)-PP-Dol is a<br />
+  substrate for ALG8, the following enzyme in the biosynthetic pathway."<br />
+  [ECO:0000269|PubMed:10359825, ECO:0000269|PubMed:25792706]</li>
+<li>CATALYTIC ACTIVITY: RHEA:30635, EC=2.4.1.267; donor = di-trans,poly-cis-dolichyl beta-D-glucosyl<br />
+  phosphate (Dol-P-Glc).</li>
+<li>SUBCELLULAR LOCATION: Endoplasmic reticulum membrane; Multi-pass membrane protein.</li>
+<li>Belongs to the ALG6/ALG8 glucosyltransferase family (CAZy GT57; Pfam PF03155 Alg6_Alg8;<br />
+  InterPro IPR004856).</li>
+</ul>
+<p>Glucosylation of the LLO is required for <strong>efficient transfer</strong> of the glycan to nascent protein by<br />
+the oligosaccharyltransferase (OST). Loss of ALG6 causes accumulation of Man9GlcNAc2-PP-Dol and<br />
+protein hypoglycosylation.</p>
+<h2 id="disease">Disease</h2>
+<p>ALG6 deficiency causes <strong>ALG6-CDG / congenital disorder of glycosylation type Ic (CDG1C; MIM:603147)</strong>,<br />
+one of the most common CDG-I subtypes. Recessive; many missense/deletion/splice variants (e.g. A333V —<br />
+the most common; S478P; delI299; exon-3 skipping). F304S is a common mild/polymorphic allele that can<br />
+exacerbate other CDGs. [UniProt DISEASE; PMID:10359825, PMID:10924277, PMID:10914684, etc.]</p>
+<h2 id="key-references-cached-all-abstract-only-except-pmid33961781">Key references (cached; all abstract-only except PMID:33961781)</h2>
+<ul>
+<li><strong>PMID:10359825</strong> (Imbach 1999, PNAS): cloned human ALG6 as ortholog of yeast ALG6 "dolichyl<br />
+  pyrophosphate Man9GlcNAc2 alpha1,3-glucosyltransferase"; mutant human ALG6 fails to complement yeast<br />
+  alg6 hypoglycosylation; defines CDGS type-Ic. Origin of MF (IDA/IGI/IC), BP, N-glycosylation, and<br />
+  lumenal-side localization annotations.</li>
+<li><strong>PMID:10924277</strong> (Westphal 2000, Mol Genet Metab): "This enzyme is required for the addition of the<br />
+  first glucose residue to the lipid-linked oligosaccharide precursor for N-linked glycosylation."<br />
+  IDA acts_upstream_of_or_within N-glycosylation.</li>
+<li><strong>PMID:25792706</strong> (Shrimal &amp; Gilmore 2015, Glycobiology): ALG6-deficient cells assemble<br />
+  Dol-PP-GlcNAc2Man9 as largest donor; hypoglycosylation of OST sites. IMP for MF/BP/N-glyc.</li>
+<li><strong>PMID:19946888</strong> (Ghosh 2010): NK-cell membrane proteome MS; supports membrane localization (HDA).</li>
+<li><strong>PMID:33961781</strong> (Huttlin 2021, BioPlex): interactome AP-MS; ALG6–ALG8 (Q9BVK2) interaction (bare<br />
+  protein-binding IPI). UniProt INTERACTION record: "Q9Y672; Q9BVK2: ALG8; NbExp=2".</li>
+</ul>
+<h2 id="annotation-decisions-summary">Annotation decisions (summary)</h2>
+<ul>
+<li>MF <strong>GO:0042281</strong> dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity — the<br />
+  exact GOA/EC 2.4.1.267 term. ACCEPT (IBA, IMP, IEA). Core MF.</li>
+<li>MF <strong>GO:0004583</strong> dolichyl-phosphate-glucose-glycolipid alpha-glucosyltransferase activity (Reactome<br />
+  TAS) — the parent/donor-focused MF; correct chemistry (Dol-P-Glc donor) but less precise than<br />
+  GO:0042281 → MODIFY to GO:0042281.</li>
+<li>MF <strong>GO:0016758</strong> hexosyltransferase activity (IEA InterPro) — correct but general grouping → MODIFY<br />
+  to GO:0042281 (or KEEP; chose MODIFY, over-general).</li>
+<li>MF <strong>GO:0046527</strong> glucosyltransferase activity (IDA) — correct but general parent → MODIFY to<br />
+  GO:0042281.</li>
+<li>MF <strong>GO:0005515</strong> protein binding (IPI, ALG8) — bare protein binding, uninformative → MARK_AS_OVER_ANNOTATED.</li>
+<li>BP <strong>GO:0006488</strong> dolichol-linked oligosaccharide biosynthetic process — core BP. ACCEPT.</li>
+<li>BP <strong>GO:0006487</strong> protein N-linked glycosylation — downstream process ALG6 is required for. ACCEPT.</li>
+<li>CC <strong>GO:0005789</strong> endoplasmic reticulum membrane — correct localization. ACCEPT.</li>
+<li>CC <strong>GO:0098553</strong> lumenal side of ER membrane (IC) — active-site topology; correct. ACCEPT.</li>
+<li>CC <strong>GO:0016020</strong> membrane (HDA proteomics) — correct but general → MODIFY to GO:0005789.<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9Y672
+gene_symbol: ALG6
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  ALG6 (Dol-P-Glc:Man(9)GlcNAc(2)-PP-dolichol alpha-1,3-glucosyltransferase;
+  EC 2.4.1.267) is a multi-pass endoplasmic reticulum membrane enzyme that catalyzes the first
+  of the three glucosylation steps in the assembly of the dolichol-linked oligosaccharide (LLO),
+  the N-glycan precursor. Acting on the lumenal face of the ER membrane, it transfers a glucose
+  residue from the lipid donor dolichyl-phosphate-glucose (Dol-P-Glc, not UDP-glucose) onto
+  Man9GlcNAc2-PP-dolichol to produce Glc1Man9GlcNAc2-PP-dolichol, which is then extended by ALG8
+  and ALG10 to yield the mature Glc3Man9GlcNAc2-PP-dolichol. Glucosylation of the LLO is required
+  for efficient transfer of the glycan onto nascent proteins by the oligosaccharyltransferase, so
+  ALG6 activity supports protein N-linked glycosylation. It belongs to the ALG6/ALG8 glucosyltransferase
+  family (CAZy GT57). Loss-of-function variants cause ALG6-congenital disorder of glycosylation
+  (ALG6-CDG / CDG type Ic), one of the most common CDG-I subtypes, characterized by accumulation of
+  Man9GlcNAc2-PP-dolichol and hypoglycosylation of serum glycoproteins, with a multisystem clinical
+  presentation.
+existing_annotations:
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assertion that ALG6 is active in the ER membrane. This matches the
+      experimentally supported subcellular location and the multi-pass ER membrane topology of the
+      protein.
+    action: ACCEPT
+    reason: &gt;-
+      ALG6 is a multi-pass ER membrane protein whose glucosyltransferase active site faces the ER
+      lumen; the ER membrane is its correct site of action.
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &#34;Multi-pass membrane protein&#34;
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assertion that ALG6 participates in dolichol-linked oligosaccharide (LLO)
+      biosynthesis. This is the core biological process of the enzyme: it adds the first glucose to the
+      Man9GlcNAc2-PP-Dol intermediate during LLO assembly.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported: ALG6 catalyzes a defined step of LLO assembly, producing
+      Glc1Man9GlcNAc2-PP-Dol from Man9GlcNAc2-PP-Dol. Loss of ALG6 causes accumulation of the
+      Man9GlcNAc2-PP-Dol precursor. This is a core function.
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &gt;-
+        adds the first glucose residue from dolichyl phosphate glucose (Dol-P-
+    - reference_id: PMID:25792706
+      supporting_text: &gt;-
+        A defect in the assembly of the oligosaccharide donor
+- term:
+    id: GO:0042281
+    label: dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assertion of the specific molecular function of ALG6: dolichyl pyrophosphate
+      Man9GlcNAc2 alpha-1,3-glucosyltransferase activity (EC 2.4.1.267). This is the exact enzymatic
+      activity supported by experimental and biochemical evidence and is the core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      This is the precise, correct molecular-function term for ALG6, consistent across IBA, IMP and
+      IEA/EC evidence and the UniProt catalytic-activity record (RHEA:30635, EC 2.4.1.267).
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &gt;-
+        adds the first glucose residue from dolichyl phosphate glucose (Dol-P-
+    - reference_id: PMID:10924277
+      supporting_text: &gt;-
+        encodes an alpha-1,3 glucosyltransferase
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (IEA) subcellular-location mapping from UniProt Swiss-Prot keyword/SubCell vocabulary
+      placing ALG6 in the ER membrane. Consistent with the experimentally curated location.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localization, redundant with the IBA and TAS ER-membrane annotations and with the
+      curated UniProt subcellular location.
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0016758
+    label: hexosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (IEA) InterPro2GO mapping (IPR004856, the ALG6/ALG8 glucosyltransferase domain) to the
+      broad grouping term hexosyltransferase activity. This is correct but far less specific than the
+      known activity.
+    action: MODIFY
+    reason: &gt;-
+      Hexosyltransferase activity is a high-level parent that is chemically correct but uninformative
+      given the well-established, specific activity of ALG6. Replace with the specific
+      alpha-1,3-glucosyltransferase term.
+    proposed_replacement_terms:
+    - id: GO:0042281
+      label: dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &#34;Belongs to the ALG6/ALG8 glucosyltransferase family&#34;
+- term:
+    id: GO:0042281
+    label: dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (IEA) annotation of the specific alpha-1,3-glucosyltransferase activity derived from the
+      EC/RHEA mapping (RHEA:30635, EC 2.4.1.267). Fully consistent with the curated catalytic activity.
+    action: ACCEPT
+    reason: &gt;-
+      The EC 2.4.1.267 / RHEA:30635 mapping matches the experimentally curated reaction; this is the
+      correct, specific molecular function.
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &#34;EC=2.4.1.267&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI annotation to the generic term protein binding, from a proteome-scale AP-MS interactome study
+      (BioPlex). The interaction partner (UniProtKB:Q9BVK2 = ALG8) is biologically meaningful: ALG8 is
+      the next enzyme in LLO glucosylation and acts on the ALG6 product. However, the term itself is
+      uninformative about molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare protein binding conveys no specific molecular function and is discouraged per curation
+      guidelines. The underlying ALG6-ALG8 interaction is real and pathway-relevant (ALG8 extends the
+      Glc1Man9GlcNAc2-PP-Dol product made by ALG6), but this should not be treated as a core function
+      annotation. Retain as over-annotated rather than removed, since it is a valid experimental
+      interaction.
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &#34;Q9Y672; Q9BVK2: ALG8&#34;
+    - reference_id: PMID:33961781
+      supporting_text: &gt;-
+        affinity-purification mass spectrometry
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446193
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Traceable-author (Reactome) annotation to LLO biosynthesis, from the pathway &#34;Biosynthesis of the
+      N-glycan precursor (dolichol lipid-linked oligosaccharide, LLO) and transfer to a nascent protein&#34;.
+      Correct core biological process.
+    action: ACCEPT
+    reason: &gt;-
+      Redundant with the IBA/IMP LLO-biosynthesis annotations; correctly captures ALG6&#39;s role in LLO
+      assembly.
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &gt;-
+        adds the first glucose residue from dolichyl phosphate glucose (Dol-P-
+- term:
+    id: GO:0098553
+    label: lumenal side of endoplasmic reticulum membrane
+  evidence_type: IC
+  original_reference_id: PMID:10359825
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Curator-inferred (IC) annotation that ALG6 is active on the lumenal side of the ER membrane. This
+      reflects the enzyme mechanism: it uses the lumenal LLO intermediate Man9GlcNAc2-PP-Dol as acceptor,
+      and the UniProt membrane topology places lumenal loops between transmembrane helices.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and more precise than the generic ER membrane term. LLO glucosylation occurs in the ER
+      lumen (the assembly begins on the cytosolic face and finishes in the lumen), consistent with a
+      lumenal-side active site.
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &gt;-
+        adds the first glucose residue from dolichyl phosphate glucose (Dol-P-
+    - reference_id: PMID:10359825
+      supporting_text: &gt;-
+        in the endoplasmic reticulum
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IMP
+  original_reference_id: PMID:10359825
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IMP annotation to protein N-linked glycosylation based on mutant phenotype: patient/mutant ALG6
+      fails to restore glycosylation in an alg6-deficient yeast strain, and ALG6 deficiency underlies
+      CDG type Ic (defective N-glycosylation). ALG6 acts upstream, providing the glucosylated LLO used by
+      the oligosaccharyltransferase.
+    action: ACCEPT
+    reason: &gt;-
+      ALG6 is genuinely required for normal protein N-linked glycosylation; loss-of-function produces
+      hypoglycosylation. This is a bona fide, if upstream, involvement in N-glycosylation.
+    supported_by:
+    - reference_id: PMID:10359825
+      supporting_text: &gt;-
+        the mutant ALG6 cDNA of CDGS patients failed to revert the hypoglycosylation
+    - reference_id: PMID:10924277
+      supporting_text: &gt;-
+        addition of the first glucose residue to the lipid-linked oligosaccharide
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IMP
+  original_reference_id: PMID:25792706
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IMP annotation to protein N-linked glycosylation from analysis of ALG6-deficient cell lines, which
+      assemble Man9GlcNAc2-PP-Dol as the largest donor and show hypoglycosylation of oligosaccharyl-
+      transferase substrate sites.
+    action: ACCEPT
+    reason: &gt;-
+      Directly demonstrates that ALG6 loss impairs protein N-linked glycosylation; supports involvement
+      in the N-glycosylation process.
+    supported_by:
+    - reference_id: PMID:25792706
+      supporting_text: &gt;-
+        A defect in the assembly of the oligosaccharide donor
+    - reference_id: PMID:25792706
+      supporting_text: &gt;-
+        assemble Dol-PP-GlcNAc(2)Man(9)
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:10359825
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IMP annotation to LLO biosynthesis: CDG-Ic patients accumulate dolichyl pyrophosphate-linked
+      Man9GlcNAc2, and mutant ALG6 fails to complement the yeast alg6 glycosylation defect, demonstrating
+      ALG6&#39;s role in LLO assembly.
+    action: ACCEPT
+    reason: &gt;-
+      Core process; strongly supported by the accumulation of the Man9GlcNAc2-PP-Dol intermediate on
+      ALG6 loss and by yeast complementation.
+    supported_by:
+    - reference_id: PMID:10359825
+      supporting_text: &gt;-
+        impaired biosynthesis of dolichyl pyrophosphate-linked
+    - reference_id: PMID:10359825
+      supporting_text: &gt;-
+        the mutant ALG6 cDNA of CDGS patients failed to revert the hypoglycosylation
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:25792706
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IMP annotation to LLO biosynthesis from ALG6-deficient cells, which stall LLO assembly at
+      Man9GlcNAc2-PP-Dol (the largest donor they can make), confirming ALG6&#39;s role in extending the LLO.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with ALG6 being the enzyme that adds the first glucose during LLO biosynthesis; loss
+      halts assembly at Man9GlcNAc2-PP-Dol.
+    supported_by:
+    - reference_id: PMID:25792706
+      supporting_text: &gt;-
+        assemble Dol-PP-GlcNAc(2)Man(9)
+- term:
+    id: GO:0042281
+    label: dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  evidence_type: IMP
+  original_reference_id: PMID:25792706
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IMP annotation of the specific alpha-1,3-glucosyltransferase activity, inferred from the phenotype
+      of ALG6-deficient cells that cannot add glucose beyond Man9GlcNAc2-PP-Dol. This is the core
+      molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      The mutant phenotype (accumulation of Man9GlcNAc2-PP-Dol; hypoglycosylation) directly attributes
+      the alpha-1,3-glucosyltransferase activity to ALG6.
+    supported_by:
+    - reference_id: PMID:25792706
+      supporting_text: &gt;-
+        assemble Dol-PP-GlcNAc(2)Man(9)
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &#34;EC=2.4.1.267&#34;
+- term:
+    id: GO:0042281
+    label: dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  evidence_type: IGI
+  original_reference_id: PMID:10359825
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IGI annotation (genetic interaction with the ALG8 glucosyltransferase, UniProtKB:Q12001) supporting
+      the alpha-1,3-glucosyltransferase activity of ALG6. Consistent with yeast complementation defining
+      ALG6 as the first LLO glucosyltransferase acting upstream of ALG8.
+    action: ACCEPT
+    reason: &gt;-
+      The genetic relationship with the downstream glucosyltransferase (ALG8) plus yeast complementation
+      supports ALG6 as the alpha-1,3-glucosyltransferase adding the first glucose; correct specific MF.
+    supported_by:
+    - reference_id: PMID:10359825
+      supporting_text: &gt;-
+        ALG6 dolichyl pyrophosphate Man9GlcNAc2
+- term:
+    id: GO:0004583
+    label: dolichyl-phosphate-glucose-glycolipid alpha-glucosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446202
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome TAS annotation of a Dol-P-Glc-dependent glucosyltransferase activity for the reaction
+      &#34;Addition of the first glucose to the N-glycan precursor by ALG6&#34;. The chemistry (Dol-P-Glc donor)
+      is correct, but this parent term is less precise than the specific ALG6 activity term.
+    action: MODIFY
+    reason: &gt;-
+      GO:0004583 correctly captures the Dol-P-Glc donor chemistry but is a broader grouping; the specific
+      substrate-defined activity GO:0042281 (dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-
+      glucosyltransferase activity, EC 2.4.1.267) is the accurate molecular function for ALG6.
+    proposed_replacement_terms:
+    - id: GO:0042281
+      label: dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &gt;-
+        adds the first glucose residue from dolichyl phosphate glucose (Dol-P-
+- term:
+    id: GO:0004583
+    label: dolichyl-phosphate-glucose-glycolipid alpha-glucosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-4724291
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome TAS annotation of Dol-P-Glc-dependent glucosyltransferase activity from the CDG variant
+      pathway (&#34;Defective ALG6 does not add glucose to the N-glycan precursor&#34;). Same as the R-HSA-446202
+      annotation: correct chemistry, but a broader term than the specific ALG6 activity.
+    action: MODIFY
+    reason: &gt;-
+      As above, replace the broader Dol-P-Glc glucosyltransferase grouping with the specific
+      GO:0042281 term that matches ALG6&#39;s defined substrate and product.
+    proposed_replacement_terms:
+    - id: GO:0042281
+      label: dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &gt;-
+        adds the first glucose residue from dolichyl phosphate glucose (Dol-P-
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-4724291
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation placing ALG6 in the ER membrane. Consistent with the curated subcellular
+      location and multi-pass ER membrane topology.
+    action: ACCEPT
+    reason: &gt;-
+      Correct localization, redundant with other ER-membrane annotations.
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput (HDA) proteomics annotation to the generic term membrane, from a mass-spectrometry
+      membrane-proteome survey of NK-like cells. This detects ALG6 in a membrane fraction but is not
+      specific to the ER.
+    action: MODIFY
+    reason: &gt;-
+      The generic membrane term is uninformative given the well-established ER membrane localization.
+      Replace with the specific ER membrane term. The proteomics detection is consistent with (though
+      not diagnostic of) ER membrane residence.
+    proposed_replacement_terms:
+    - id: GO:0005789
+      label: endoplasmic reticulum membrane
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: &gt;-
+        1843 proteins with high confidence scores
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446202
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation placing ALG6 in the ER membrane (from the &#34;Addition of the first glucose&#34;
+      pathway). Correct localization.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and redundant with the other ER-membrane annotations; consistent with the curated location.
+    supported_by:
+    - reference_id: file:human/ALG6/ALG6-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IDA
+  original_reference_id: PMID:10924277
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: &gt;-
+      IDA annotation (acts_upstream_of_or_within protein N-linked glycosylation) from biochemical/
+      molecular analysis of a CDG-Ic patient with multiple hALG6 mutations. ALG6 adds the first glucose
+      to the LLO precursor, an event required upstream of protein N-glycosylation.
+    action: ACCEPT
+    reason: &gt;-
+      Correctly captures ALG6&#39;s upstream role in N-linked glycosylation. The acts_upstream_of_or_within
+      qualifier is appropriate because ALG6 provides the glucosylated LLO used by the
+      oligosaccharyltransferase rather than performing the protein-transfer step itself.
+    supported_by:
+    - reference_id: PMID:10924277
+      supporting_text: &gt;-
+        addition of the first glucose residue to the lipid-linked oligosaccharide
+    - reference_id: PMID:10924277
+      supporting_text: &gt;-
+        This enzyme is required for the
+- term:
+    id: GO:0046527
+    label: glucosyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:10359825
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IDA annotation to the grouping term glucosyltransferase activity, from the cloning/complementation
+      study that identified human ALG6 as the alpha-1,3-glucosyltransferase adding the first glucose to
+      the LLO. Correct chemistry but less specific than the defined ALG6 activity.
+    action: MODIFY
+    reason: &gt;-
+      Glucosyltransferase activity is a correct parent but under-specifies ALG6&#39;s function; the specific
+      GO:0042281 term (matching the EC 2.4.1.267 reaction) is the accurate molecular function.
+    proposed_replacement_terms:
+    - id: GO:0042281
+      label: dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+    supported_by:
+    - reference_id: PMID:10359825
+      supporting_text: &gt;-
+        ALG6 dolichyl pyrophosphate Man9GlcNAc2
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10359825
+  title: A mutation in the human ortholog of the Saccharomyces cerevisiae ALG6 gene
+    causes carbohydrate-deficient glycoprotein syndrome type-Ic.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Foundational paper cloning human ALG6 as the ortholog of yeast ALG6 dolichyl pyrophosphate
+      Man9GlcNAc2 alpha-1,3-glucosyltransferase; defines CDG type Ic. Abstract-only in cache but
+      directly supports the MF, LLO-biosynthesis, N-glycosylation, and ER localization annotations.
+- id: PMID:10924277
+  title: Analysis of multiple mutations in the hALG6 gene in a patient with congenital
+    disorder of glycosylation Ic.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      States that hALG6 encodes an alpha-1,3 glucosyltransferase required for adding the first glucose
+      to the LLO precursor for N-glycosylation; source of the IDA N-glycosylation annotation.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput NK-cell membrane proteome MS study; detects ALG6 in a membrane fraction (generic
+      membrane annotation) but is not specific for the ER and does not address function.
+- id: PMID:25792706
+  title: Reduced expression of the oligosaccharyltransferase exacerbates protein hypoglycosylation
+    in cells lacking the fully assembled oligosaccharide donor.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Uses ALG6-deficient cell lines (assembling Man9GlcNAc2-PP-Dol as largest donor) to demonstrate
+      hypoglycosylation; supports the MF, LLO-biosynthesis, and N-glycosylation annotations.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale AP-MS interactome (BioPlex 3.0); source of the ALG6-ALG8 protein-binding IPI. The
+      ALG6-ALG8 interaction is pathway-relevant but the bare protein binding term is uninformative.
+- id: Reactome:R-HSA-446193
+  title: Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide,
+    LLO) and transfer to a nascent protein
+  findings: []
+- id: Reactome:R-HSA-446202
+  title: Addition of the first glucose to the N-glycan precursor by ALG6
+  findings: []
+- id: Reactome:R-HSA-4724291
+  title: Defective ALG6 does not add glucose to the N-glycan precursor
+  findings: []
+- id: file:human/ALG6/ALG6-uniprot.txt
+  title: UniProtKB Q9Y672 (ALG6_HUMAN) record
+  findings: []
+core_functions:
+- description: &gt;-
+    ALG6 is the ER-lumenal alpha-1,3-glucosyltransferase that adds the first of the three glucoses to
+    the dolichol-linked oligosaccharide precursor. Using dolichyl-phosphate-glucose (Dol-P-Glc) as
+    donor, it converts Man9GlcNAc2-PP-dolichol to Glc1Man9GlcNAc2-PP-dolichol during dolichol-linked
+    oligosaccharide biosynthesis, thereby supporting downstream protein N-linked glycosylation.
+  molecular_function:
+    id: GO:0042281
+    label: dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  - id: GO:0006487
+    label: protein N-linked glycosylation
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: file:human/ALG6/ALG6-uniprot.txt
+    supporting_text: &gt;-
+      adds the first glucose residue from dolichyl phosphate glucose (Dol-P-
+  - reference_id: file:human/ALG6/ALG6-uniprot.txt
+    supporting_text: &gt;-
+      substrate for ALG8, the following
+  - reference_id: PMID:25792706
+    supporting_text: &gt;-
+      A defect in the assembly of the oligosaccharide donor
+  - reference_id: PMID:10924277
+    supporting_text: &gt;-
+      addition of the first glucose residue to the lipid-linked oligosaccharide
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    What is the structural basis for ALG6 substrate recognition of Man9GlcNAc2-PP-dolichol, and how do
+    the common CDG-Ic variants (e.g. A333V, S478P) reduce catalytic activity?
+- question: &gt;-
+    Does ALG6 function as part of a stable multi-enzyme LLO-glucosylation module with ALG8 and ALG10, or
+    is the ALG6-ALG8 interaction transient/substrate-channeling?
+suggested_experiments:
+- description: &gt;-
+    Reconstitute purified ALG6 with Dol-P-Glc and Man9GlcNAc2-PP-Dol in vitro to directly measure
+    alpha-1,3-glucosyltransferase kinetics and the effect of disease variants on activity.
+- description: &gt;-
+    Determine the cryo-EM structure of ALG6 (alone and in complex with ALG8) to map the lumenal active
+    site and the donor/acceptor binding sites.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/ALG8/ALG8-ai-review.html
+++ b/genes/human/ALG8/ALG8-ai-review.html
@@ -1,0 +1,4267 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ALG8 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ALG8</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9BVK2" target="_blank" class="term-link">
+                        Q9BVK2
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ALG8";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9BVK2" data-a="DESCRIPTION: ALG8 is the endoplasmic reticulum (ER)-lumenal, Do..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ALG8 is the endoplasmic reticulum (ER)-lumenal, Dol-P-Glc-dependent alpha-1,3-glucosyltransferase (EC 2.4.1.265) that catalyzes the second of the three glucosylation steps in assembly of the dolichol-linked oligosaccharide (LLO), the Glc3Man9GlcNAc2 glycan precursor used for protein N-linked glycosylation. Acting on the lumenal face of the ER membrane, it transfers a glucose residue from dolichyl-phosphate-glucose (Dol-P-Glc, not UDP-Glc) onto the lipid-linked intermediate Glc1Man9GlcNAc2-PP-dolichol to give Glc2Man9GlcNAc2-PP-dolichol, the substrate for the following enzyme ALG10. ALG8 is a polytopic (multi-pass) ER membrane protein of the ALG6/ALG8 glucosyltransferase family (CAZy GT57). It functions in the dolichol-linked oligosaccharide biosynthetic process and, downstream, in protein N-linked glycosylation. Loss-of-function variants cause the autosomal recessive multisystem congenital disorder of glycosylation type Ih (ALG8-CDG / CDG-Ih), characterized by hypoglycosylation of serum glycoproteins; ALG8 variants are also associated with isolated polycystic liver disease.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ALG8 is an ER membrane enzyme; the phylogenetically inferred ER membrane localization is fully consistent with experimental and UniProt evidence. ALG8 is a multi-pass ER membrane protein that acts on the lumenal side of the ER membrane during LLO assembly. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA localization to the ER membrane matches the UniProt-curated subcellular location and the enzyme&#39;s role in ER-lumenal LLO assembly.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0006488" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ALG8 adds the second glucose to the growing lipid-linked oligosaccharide (LLO), a defining step of dolichol-linked oligosaccharide biosynthesis. This is the core biological process for the gene and is supported by experimental (IMP) evidence in humans as well as the phylogenetic inference. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The gene&#39;s characterized enzymatic step (adding glucose to Glc1Man9GlcNAc2-PP-Dol) is part of dolichol-linked oligosaccharide biosynthesis; the IBA agrees with experimental annotations from PubMed:12480927 and PubMed:15235028.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the second glucose residue from dolichyl phosphate glucose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042283" target="_blank" class="term-link">
+                                    GO:0042283
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0042283" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the precise, correct molecular function of ALG8: the Dol-P-Glc-dependent alpha-1,3-glucosyltransferase (EC 2.4.1.265) that adds the second glucose from Dol-P-Glc onto Glc1Man9GlcNAc2-PP-Dol to give Glc2Man9GlcNAc2-PP-Dol. The phylogenetic inference agrees with human experimental evidence and is the core enzymatic activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This IBA term is the exact characterized activity of ALG8 and matches the UniProt catalytic-activity annotation and the experimental IMP annotations. Core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the second glucose residue from dolichyl phosphate glucose</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link">
+                                        PMID:12480927
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which catalyzes this reaction</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IEA localization to the ER membrane derived from the UniProt Swiss-Prot subcellular location mapping. This agrees with the experimentally supported (PubMed:15235028) UniProt subcellular location annotation. Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The mapping reproduces the curated ER membrane location, which is experimentally grounded.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016758" target="_blank" class="term-link">
+                                    GO:0016758
+                                </a>
+                            </span>
+                            <span class="term-label">hexosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0016758" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping (IPR004856, ALG6/ALG8 glucosyltransferase family) to the generic parent term hexosyltransferase activity. This is correct but much more general than ALG8&#39;s characterized activity (GO:0042283, dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity), which is already annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong, but too general given the specific EC 2.4.1.265 activity is established. Replace with the specific glucosyltransferase term already supported by experimental and phylogenetic evidence.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042283" target="_blank" class="term-link">
+                                    dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the ALG6/ALG8 glucosyltransferase family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042283" target="_blank" class="term-link">
+                                    GO:0042283
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0042283" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (RHEA:31307 / EC:2.4.1.265) assignment of the precise enzymatic activity. This matches the UniProt catalytic activity annotation and the experimental evidence. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> RHEA/EC-based IEA reproduces the exact experimentally established activity (EC 2.4.1.265), consistent with the IBA and IMP annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the second glucose residue from dolichyl phosphate glucose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25910212
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Widespread macromolecular interaction perturbations in human...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0005515" data-r="PMID:25910212" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; IPI from a large-scale interactome/edgotyping study (Sahni et al. 2015). The recorded interactor is CREB3 (UniProtKB:O43889-2). This uninformative MF term does not describe ALG8&#39;s actual glucosyltransferase function and the interaction has no established biological role for ALG8.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;Protein binding&#34; (GO:0005515) is uninformative and comes from a high-throughput screen; it is retained but flagged as over-annotation rather than removed, per curation policy for experimental IPIs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
+                                        PMID:25910212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">two-thirds of disease-associated alleles perturb protein-protein</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Q9BVK2; O43889-2: CREB3; NbExp=3; IntAct=EBI-3921603, EBI-625022;</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; IPI from the HuRI human binary (Y2H) interactome map (Luck et al. 2020). Recorded interactors for ALG8 include CYB5R3 (P00387), CLRN1 (P58418), BIK (Q13323), FAM209A (Q5JX71), MFSD6 (Q6ZSS7), GPX8 (Q8TED1), CREB3L1 (Q96BA8) and SAR1A (Q9NR31). These are largely other ER/membrane proteins; none establishes a specific molecular function for ALG8, and the term itself is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative and derives from a proteome-scale Y2H screen; retained but flagged as over-annotation per policy for experimental IPIs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reference interactome map of human binary protein interactions</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Q9BVK2; P00387: CYB5R3; NbExp=3; IntAct=EBI-3921603, EBI-1046040;</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; IPI from the BioPlex 3.0 affinity-purification mass-spectrometry interactome (Huttlin et al. 2021). The recorded interactor is ALG6 (UniProtKB:Q9Y672), the alpha-1,3-glucosyltransferase that acts immediately before ALG8 in LLO assembly; a physical association between these two sequential ER-membrane glucosyltransferases is biologically plausible, but &#34;protein binding&#34; is still an uninformative MF term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Although the ALG6 interactor is pathway-relevant, GO:0005515 conveys no specific molecular function; retained but flagged as over-annotation per policy for experimental IPIs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">affinity-purification</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Q9BVK2; Q9Y672: ALG6; NbExp=2; IntAct=EBI-3921603, EBI-11337956;</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0006487" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IEA transfer from mouse ortholog (Q6P8H8) via Ensembl Compara to protein N-linked glycosylation. ALG8 builds the LLO glycan precursor that is transferred to nascent proteins, so involvement in N-linked glycosylation is correct, though it is one step removed from the direct enzymatic reaction (LLO assembly).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ALG8&#39;s role in assembling the Glc3Man9GlcNAc2 precursor makes it a genuine participant in protein N-linked glycosylation; consistent with experimental IMP and ISS annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the glycan precursors employed in
+CC       protein asparagine (N)-glycosylation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446193
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0006488" data-r="Reactome:R-HSA-446193" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS placing ALG8 in the LLO (dolichol lipid-linked oligosaccharide) biosynthesis and transfer pathway. This is the core biological process for ALG8 and is corroborated by experimental IMP annotations. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome authored the LLO biosynthesis pathway including the ALG8-catalyzed second glucose addition; consistent with IBA/IMP annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-446189
+
+                                </span>
+
+                                <div class="support-text">The second glucose (supplied from the donor dolichol-phosphate-glucose) is added to the N-glycan precursor, mediated by ALG8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098553" target="_blank" class="term-link">
+                                    GO:0098553
+                                </a>
+                            </span>
+                            <span class="term-label">lumenal side of endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15235028
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Clinical and molecular features of three patients with conge...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0098553" data-r="PMID:15235028" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Inferred by curator (IC) that ALG8 acts on the lumenal side of the ER membrane. The glucose additions occur after the LLO intermediate is flipped to the ER lumen, and ALG8 uses lumenal Dol-P-Glc; UniProt states the assembly &#34;finishes in its lumen&#34; and that ALG8 acts &#34;In the lumen of the endoplasmic reticulum&#34;. This precise topological localization is correct and biologically informative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The lumenal orientation of the ALG8-catalyzed glucosylation step is well established; the IC annotation captures the correct membrane topology and is consistent with UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the second glucose residue from dolichyl phosphate glucose</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link">
+                                        PMID:15235028
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">(CDG-Ih) (ALG8 deficiency)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15235028
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Clinical and molecular features of three patients with conge...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0005789" data-r="PMID:15235028" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IGI, with yeast Alg8 P40351) support that human ALG8 is active in the ER membrane, from the CDG-Ih characterization study (Schollen et al. 2004). ALG8 is a multi-pass ER membrane enzyme; this is the core cellular location. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genetic-interaction/complementation evidence (with the yeast ortholog) supports ER membrane activity; consistent with UniProt subcellular location. Curator read the full text of this abstract-only paper.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link">
+                                        PMID:15235028
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">(CDG-Ih) (ALG8 deficiency)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15235028
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Clinical and molecular features of three patients with conge...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0006487" data-r="PMID:15235028" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) evidence that ALG8 loss impairs protein N-linked glycosylation, from CDG-Ih patients with ALG8 deficiency who show under-glycosylated serum glycoproteins (Schollen et al. 2004). ALG8 builds the LLO precursor transferred to nascent proteins. Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Patient-derived loss-of-function characterization demonstrates ALG8&#39;s requirement for normal N-glycosylation; the curator read the full text.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link">
+                                        PMID:15235028
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">(CDG-Ih) (ALG8 deficiency)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the glycan precursors employed in
+CC       protein asparagine (N)-glycosylation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12480927
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A deficiency in dolichyl-P-glucose:Glc1Man9GlcNAc2-PP-dolich...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0006488" data-r="PMID:12480927" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) evidence from the founding CDG-Ih study (Chantret et al. 2003): patient fibroblasts with reduced ALG8 mRNA accumulate Man9GlcNAc2-PP-dolichol (and, with castanospermine, Glc1Man9GlcNAc2-PP-Dol), indicating inefficient addition of the second glucose to the LLO, and are rescued by wild-type ALG8 cDNA. This is the core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Loss-of-ALG8 blocks LLO maturation with accumulation of the immediate substrate, directly demonstrating involvement in dolichol-linked oligosaccharide biosynthesis. Core process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link">
+                                        PMID:12480927
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">suggesting inefficient addition of the second glucose residue onto</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link">
+                                        PMID:12480927
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">biosynthesis of the dolichyl-linked oligosaccharide</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15235028
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Clinical and molecular features of three patients with conge...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0006488" data-r="PMID:15235028" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) evidence from a second CDG-Ih cohort (Schollen et al. 2004): ALG8-deficient patients with characterized loss-of-function variants (T47P, G275D) show impaired LLO glucosylation. Confirms ALG8&#39;s role in dolichol-linked oligosaccharide biosynthesis. Core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Independent patient/variant characterization corroborates ALG8&#39;s requirement for LLO biosynthesis; curator read the full text.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link">
+                                        PMID:15235028
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">(CDG-Ih) (ALG8 deficiency)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">adds the second glucose residue from dolichyl phosphate glucose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042283" target="_blank" class="term-link">
+                                    GO:0042283
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12480927
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A deficiency in dolichyl-P-glucose:Glc1Man9GlcNAc2-PP-dolich...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0042283" data-r="PMID:12480927" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) support for ALG8&#39;s Dol-P-Glc:Glc1Man9GlcNAc2-PP-dolichyl alpha-1,3-glucosyltransferase activity: Chantret et al. 2003 identify ALG8 as the enzyme catalyzing addition of the second glucose to the LLO, with loss of function causing substrate accumulation and rescue by wild-type cDNA. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly demonstrates the characterized enzymatic activity (EC 2.4.1.265) via loss-of-function and complementation. Core MF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link">
+                                        PMID:12480927
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which catalyzes this reaction</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link">
+                                        PMID:12480927
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">suggesting inefficient addition of the second glucose residue onto</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042283" target="_blank" class="term-link">
+                                    GO:0042283
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15235028
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Clinical and molecular features of three patients with conge...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0042283" data-r="PMID:15235028" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) support for ALG8&#39;s glucosyltransferase activity from Schollen et al. 2004; UniProt records that the CDG1H variants T47P and G275D show &#34;decreased dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity&#34;, directly implicating ALG8 in this reaction. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Variant characterization demonstrates reduced enzymatic activity, an experimental measure of the annotated MF; curator read full text.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">decreased dolichyl pyrophosphate
+FT                   Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link">
+                                        PMID:15235028
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">(CDG-Ih) (ALG8 deficiency)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004583" target="_blank" class="term-link">
+                                    GO:0004583
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl-phosphate-glucose-glycolipid alpha-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446189
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0004583" data-r="Reactome:R-HSA-446189" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS to GO:0004583, the parent term for Dol-P-Glc-dependent alpha-glucosyltransferase activity. This is correct but less precise than the specific EC 2.4.1.265 term GO:0042283 that is already annotated experimentally. It captures the Dol-P-Glc donor specificity, which is biologically important.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The essence (Dol-P-Glc-dependent alpha-glucosyltransferase) is correct but too general; the specific activity term GO:0042283 (the exact reaction ALG8 catalyzes) is preferable.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042283" target="_blank" class="term-link">
+                                    dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-446189
+
+                                </span>
+
+                                <div class="support-text">The second glucose (supplied from the donor dolichol-phosphate-glucose) is added to the N-glycan precursor, mediated by ALG8</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004583" target="_blank" class="term-link">
+                                    GO:0004583
+                                </a>
+                            </span>
+                            <span class="term-label">dolichyl-phosphate-glucose-glycolipid alpha-glucosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-4724330
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0004583" data-r="Reactome:R-HSA-4724330" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS (from the &#34;Defective ALG8 causes CDG-1h&#34; disease reaction) to the parent term GO:0004583. Same activity as the sibling Reactome annotation; correct but less precise than the specific EC 2.4.1.265 term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct Dol-P-Glc-dependent glucosyltransferase activity but too general; prefer the specific GO:0042283 term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042283" target="_blank" class="term-link">
+                                    dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-4724330
+
+                                </span>
+
+                                <div class="support-text">normally adds the second glucose moiety to the lipid-linked oligosaccharide precursor (LLO aka N-glycan precursor) which is required for subsequent N-glycosylation of proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0006487" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer (from mouse ortholog Q6P8H8) to protein N-linked glycosylation. Consistent with the experimental IMP and the IEA (Ensembl) annotations to the same term; ALG8 assembles the glycan precursor used in N-glycosylation. Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Sequence-similarity inference to a well-supported process; redundant with but consistent with the human experimental annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the glycan precursors employed in
+CC       protein asparagine (N)-glycosylation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-4724330
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0005789" data-r="Reactome:R-HSA-4724330" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS ER membrane localization, consistent with the experimental and UniProt-curated ER membrane location. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reproduces the well-supported ER membrane localization of this multi-pass membrane enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446189
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0005789" data-r="Reactome:R-HSA-446189" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS ER membrane localization (duplicate of the sibling Reactome CC annotation), consistent with experimental and UniProt evidence. Correct and core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reproduces the well-supported ER membrane localization; duplicates are acceptable across evidence sources.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG8/ALG8-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12480927
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A deficiency in dolichyl-P-glucose:Glc1Man9GlcNAc2-PP-dolich...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BVK2" data-a="GO:0006487" data-r="PMID:12480927" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) evidence that ALG8 deficiency (CDG-Ih) impairs protein N-linked glycosylation (Chantret et al. 2003), which defined this new subtype of type I congenital disorders of glycosylation — disorders caused by defective assembly of the dolichyl-linked oligosaccharide required for protein glycosylation. Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Patient loss-of-function evidence links ALG8 to N-glycosylation via defective LLO assembly; consistent with other N-glycosylation annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link">
+                                        PMID:12480927
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the underlying cause of this new CDG I</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link">
+                                        PMID:12480927
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">biosynthesis of the dolichyl-linked oligosaccharide</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ER-lumenal, Dol-P-Glc-dependent alpha-1,3-glucosyltransferase (EC 2.4.1.265) that transfers the second glucose from dolichyl-phosphate-glucose onto Glc1Man9GlcNAc2-PP-dolichol to give Glc2Man9GlcNAc2-PP-dolichol during lipid-linked oligosaccharide (LLO) assembly.</h3>
+                <span class="vote-buttons" data-g="Q9BVK2" data-a="FUNCTION: ER-lumenal, Dol-P-Glc-dependent alpha-1,3-glucosyl..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042283" target="_blank" class="term-link">
+                            dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                dolichol-linked oligosaccharide biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098553" target="_blank" class="term-link">
+                                lumenal side of endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ALG8/ALG8-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">adds the second glucose residue from dolichyl phosphate glucose</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link">
+                                PMID:12480927
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">which catalyzes this reaction</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Through assembly of the mature Glc3Man9GlcNAc2 lipid-linked oligosaccharide precursor that is transferred en bloc to nascent polypeptides, ALG8 is required for protein N-linked glycosylation; its loss causes CDG-Ih.</h3>
+                <span class="vote-buttons" data-g="Q9BVK2" data-a="FUNCTION: Through assembly of the mature Glc3Man9GlcNAc2 lip..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042283" target="_blank" class="term-link">
+                            dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                protein N-linked glycosylation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link">
+                                PMID:12480927
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">biosynthesis of the dolichyl-linked oligosaccharide</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ALG8/ALG8-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">the glycan precursors employed in
+CC       protein asparagine (N)-glycosylation</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ALG8/ALG8-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB Q9BVK2 (ALG8_HUMAN)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12480927" target="_blank" class="term-link">
+                            PMID:12480927
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A deficiency in dolichyl-P-glucose:Glc1Man9GlcNAc2-PP-dolichyl alpha3-glucosyltransferase defines a new subtype of congenital disorders of glycosylation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15235028" target="_blank" class="term-link">
+                            PMID:15235028
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Clinical and molecular features of three patients with congenital disorders of glycosylation type Ih (CDG-Ih) (ALG8 deficiency).</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
+                            PMID:25910212
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446189
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Addition of a second glucose to the N-glycan precursor by ALG8</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446193
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide, LLO) and transfer to a nascent protein</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-4724330
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective ALG8 does not add glucose to the N-glycan precursor</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9BVK2
+gene_symbol: ALG8
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  ALG8 is the endoplasmic reticulum (ER)-lumenal, Dol-P-Glc-dependent
+  alpha-1,3-glucosyltransferase (EC 2.4.1.265) that catalyzes the second of the
+  three glucosylation steps in assembly of the dolichol-linked oligosaccharide
+  (LLO), the Glc3Man9GlcNAc2 glycan precursor used for protein N-linked
+  glycosylation. Acting on the lumenal face of the ER membrane, it transfers a
+  glucose residue from dolichyl-phosphate-glucose (Dol-P-Glc, not UDP-Glc) onto
+  the lipid-linked intermediate Glc1Man9GlcNAc2-PP-dolichol to give
+  Glc2Man9GlcNAc2-PP-dolichol, the substrate for the following enzyme ALG10.
+  ALG8 is a polytopic (multi-pass) ER membrane protein of the ALG6/ALG8
+  glucosyltransferase family (CAZy GT57). It functions in the dolichol-linked
+  oligosaccharide biosynthetic process and, downstream, in protein N-linked
+  glycosylation. Loss-of-function variants cause the autosomal recessive
+  multisystem congenital disorder of glycosylation type Ih (ALG8-CDG / CDG-Ih),
+  characterized by hypoglycosylation of serum glycoproteins; ALG8 variants are
+  also associated with isolated polycystic liver disease.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q9BVK2-1
+- name: &#39;2&#39;
+  id: Q9BVK2-2
+  sequence_note: VSP_046291
+existing_annotations:
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      ALG8 is an ER membrane enzyme; the phylogenetically inferred ER membrane
+      localization is fully consistent with experimental and UniProt evidence.
+      ALG8 is a multi-pass ER membrane protein that acts on the lumenal side of
+      the ER membrane during LLO assembly. Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      IBA localization to the ER membrane matches the UniProt-curated
+      subcellular location and the enzyme&#39;s role in ER-lumenal LLO assembly.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;Multi-pass membrane protein&#34;
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ALG8 adds the second glucose to the growing lipid-linked oligosaccharide
+      (LLO), a defining step of dolichol-linked oligosaccharide biosynthesis.
+      This is the core biological process for the gene and is supported by
+      experimental (IMP) evidence in humans as well as the phylogenetic
+      inference. Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      The gene&#39;s characterized enzymatic step (adding glucose to
+      Glc1Man9GlcNAc2-PP-Dol) is part of dolichol-linked oligosaccharide
+      biosynthesis; the IBA agrees with experimental annotations from
+      PubMed:12480927 and PubMed:15235028.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;adds the second glucose residue from dolichyl phosphate glucose&#34;
+- term:
+    id: GO:0042283
+    label: dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This is the precise, correct molecular function of ALG8: the
+      Dol-P-Glc-dependent alpha-1,3-glucosyltransferase (EC 2.4.1.265) that adds
+      the second glucose from Dol-P-Glc onto Glc1Man9GlcNAc2-PP-Dol to give
+      Glc2Man9GlcNAc2-PP-Dol. The phylogenetic inference agrees with human
+      experimental evidence and is the core enzymatic activity.
+    action: ACCEPT
+    reason: &gt;-
+      This IBA term is the exact characterized activity of ALG8 and matches the
+      UniProt catalytic-activity annotation and the experimental IMP
+      annotations. Core molecular function.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;adds the second glucose residue from dolichyl phosphate glucose&#34;
+      - reference_id: PMID:12480927
+        supporting_text: &#34;which catalyzes this reaction&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      IEA localization to the ER membrane derived from the UniProt
+      Swiss-Prot subcellular location mapping. This agrees with the
+      experimentally supported (PubMed:15235028) UniProt subcellular location
+      annotation. Correct.
+    action: ACCEPT
+    reason: &gt;-
+      The mapping reproduces the curated ER membrane location, which is
+      experimentally grounded.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0016758
+    label: hexosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO mapping (IPR004856, ALG6/ALG8 glucosyltransferase family) to
+      the generic parent term hexosyltransferase activity. This is correct but
+      much more general than ALG8&#39;s characterized activity (GO:0042283,
+      dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase
+      activity), which is already annotated.
+    action: MODIFY
+    reason: &gt;-
+      Not wrong, but too general given the specific EC 2.4.1.265 activity is
+      established. Replace with the specific glucosyltransferase term already
+      supported by experimental and phylogenetic evidence.
+    proposed_replacement_terms:
+      - id: GO:0042283
+        label: dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;Belongs to the ALG6/ALG8 glucosyltransferase family&#34;
+- term:
+    id: GO:0042283
+    label: dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Automated (RHEA:31307 / EC:2.4.1.265) assignment of the precise enzymatic
+      activity. This matches the UniProt catalytic activity annotation and the
+      experimental evidence. Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      RHEA/EC-based IEA reproduces the exact experimentally established activity
+      (EC 2.4.1.265), consistent with the IBA and IMP annotations to the same
+      term.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;adds the second glucose residue from dolichyl phosphate glucose&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25910212
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; IPI from a large-scale interactome/edgotyping study
+      (Sahni et al. 2015). The recorded interactor is CREB3 (UniProtKB:O43889-2).
+      This uninformative MF term does not describe ALG8&#39;s actual glucosyltransferase
+      function and the interaction has no established biological role for ALG8.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;Protein binding&#34; (GO:0005515) is uninformative and comes from a
+      high-throughput screen; it is retained but flagged as over-annotation
+      rather than removed, per curation policy for experimental IPIs.
+    supported_by:
+      - reference_id: PMID:25910212
+        supporting_text: &#34;two-thirds of disease-associated alleles perturb protein-protein&#34;
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;Q9BVK2; O43889-2: CREB3; NbExp=3; IntAct=EBI-3921603, EBI-625022;&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; IPI from the HuRI human binary (Y2H) interactome
+      map (Luck et al. 2020). Recorded interactors for ALG8 include CYB5R3
+      (P00387), CLRN1 (P58418), BIK (Q13323), FAM209A (Q5JX71), MFSD6 (Q6ZSS7),
+      GPX8 (Q8TED1), CREB3L1 (Q96BA8) and SAR1A (Q9NR31). These are largely
+      other ER/membrane proteins; none establishes a specific molecular
+      function for ALG8, and the term itself is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;Protein binding&#34; is uninformative and derives from a proteome-scale Y2H
+      screen; retained but flagged as over-annotation per policy for
+      experimental IPIs.
+    supported_by:
+      - reference_id: PMID:32296183
+        supporting_text: &#34;reference interactome map of human binary protein interactions&#34;
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;Q9BVK2; P00387: CYB5R3; NbExp=3; IntAct=EBI-3921603, EBI-1046040;&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; IPI from the BioPlex 3.0 affinity-purification
+      mass-spectrometry interactome (Huttlin et al. 2021). The recorded
+      interactor is ALG6 (UniProtKB:Q9Y672), the alpha-1,3-glucosyltransferase
+      that acts immediately before ALG8 in LLO assembly; a physical association
+      between these two sequential ER-membrane glucosyltransferases is
+      biologically plausible, but &#34;protein binding&#34; is still an uninformative
+      MF term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Although the ALG6 interactor is pathway-relevant, GO:0005515 conveys no
+      specific molecular function; retained but flagged as over-annotation per
+      policy for experimental IPIs.
+    supported_by:
+      - reference_id: PMID:33961781
+        supporting_text: &#34;affinity-purification&#34;
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;Q9BVK2; Q9Y672: ALG6; NbExp=2; IntAct=EBI-3921603, EBI-11337956;&#34;
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IEA transfer from mouse ortholog (Q6P8H8) via Ensembl Compara to protein
+      N-linked glycosylation. ALG8 builds the LLO glycan precursor that is
+      transferred to nascent proteins, so involvement in N-linked glycosylation
+      is correct, though it is one step removed from the direct enzymatic
+      reaction (LLO assembly).
+    action: ACCEPT
+    reason: &gt;-
+      ALG8&#39;s role in assembling the Glc3Man9GlcNAc2 precursor makes it a
+      genuine participant in protein N-linked glycosylation; consistent with
+      experimental IMP and ISS annotations to the same term.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;the glycan precursors employed in\nCC       protein asparagine (N)-glycosylation&#34;
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446193
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome TAS placing ALG8 in the LLO (dolichol lipid-linked
+      oligosaccharide) biosynthesis and transfer pathway. This is the core
+      biological process for ALG8 and is corroborated by experimental IMP
+      annotations. Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      Reactome authored the LLO biosynthesis pathway including the ALG8-catalyzed
+      second glucose addition; consistent with IBA/IMP annotations to the same
+      term.
+    supported_by:
+      - reference_id: Reactome:R-HSA-446189
+        supporting_text: &#34;The second glucose (supplied from the donor dolichol-phosphate-glucose) is added to the N-glycan precursor, mediated by ALG8&#34;
+- term:
+    id: GO:0098553
+    label: lumenal side of endoplasmic reticulum membrane
+  evidence_type: IC
+  original_reference_id: PMID:15235028
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Inferred by curator (IC) that ALG8 acts on the lumenal side of the ER
+      membrane. The glucose additions occur after the LLO intermediate is
+      flipped to the ER lumen, and ALG8 uses lumenal Dol-P-Glc; UniProt states
+      the assembly &#34;finishes in its lumen&#34; and that ALG8 acts &#34;In the lumen of
+      the endoplasmic reticulum&#34;. This precise topological localization is
+      correct and biologically informative.
+    action: ACCEPT
+    reason: &gt;-
+      The lumenal orientation of the ALG8-catalyzed glucosylation step is
+      well established; the IC annotation captures the correct membrane
+      topology and is consistent with UniProt.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;adds the second glucose residue from dolichyl phosphate glucose&#34;
+      - reference_id: PMID:15235028
+        supporting_text: &#34;(CDG-Ih) (ALG8 deficiency)&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IGI
+  original_reference_id: PMID:15235028
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Experimental (IGI, with yeast Alg8 P40351) support that human ALG8 is
+      active in the ER membrane, from the CDG-Ih characterization study
+      (Schollen et al. 2004). ALG8 is a multi-pass ER membrane enzyme; this is
+      the core cellular location. Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      Genetic-interaction/complementation evidence (with the yeast ortholog)
+      supports ER membrane activity; consistent with UniProt subcellular
+      location. Curator read the full text of this abstract-only paper.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+      - reference_id: PMID:15235028
+        supporting_text: &#34;(CDG-Ih) (ALG8 deficiency)&#34;
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IMP
+  original_reference_id: PMID:15235028
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) evidence that ALG8 loss impairs protein N-linked
+      glycosylation, from CDG-Ih patients with ALG8 deficiency who show
+      under-glycosylated serum glycoproteins (Schollen et al. 2004). ALG8 builds
+      the LLO precursor transferred to nascent proteins. Correct.
+    action: ACCEPT
+    reason: &gt;-
+      Patient-derived loss-of-function characterization demonstrates ALG8&#39;s
+      requirement for normal N-glycosylation; the curator read the full text.
+    supported_by:
+      - reference_id: PMID:15235028
+        supporting_text: &#34;(CDG-Ih) (ALG8 deficiency)&#34;
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;the glycan precursors employed in\nCC       protein asparagine (N)-glycosylation&#34;
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:12480927
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) evidence from the founding CDG-Ih study (Chantret et
+      al. 2003): patient fibroblasts with reduced ALG8 mRNA accumulate
+      Man9GlcNAc2-PP-dolichol (and, with castanospermine, Glc1Man9GlcNAc2-PP-Dol),
+      indicating inefficient addition of the second glucose to the LLO, and are
+      rescued by wild-type ALG8 cDNA. This is the core biological process.
+    action: ACCEPT
+    reason: &gt;-
+      Loss-of-ALG8 blocks LLO maturation with accumulation of the immediate
+      substrate, directly demonstrating involvement in dolichol-linked
+      oligosaccharide biosynthesis. Core process.
+    supported_by:
+      - reference_id: PMID:12480927
+        supporting_text: &#34;suggesting inefficient addition of the second glucose residue onto&#34;
+      - reference_id: PMID:12480927
+        supporting_text: &#34;biosynthesis of the dolichyl-linked oligosaccharide&#34;
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:15235028
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) evidence from a second CDG-Ih cohort (Schollen et al.
+      2004): ALG8-deficient patients with characterized loss-of-function
+      variants (T47P, G275D) show impaired LLO glucosylation. Confirms ALG8&#39;s
+      role in dolichol-linked oligosaccharide biosynthesis. Core process.
+    action: ACCEPT
+    reason: &gt;-
+      Independent patient/variant characterization corroborates ALG8&#39;s
+      requirement for LLO biosynthesis; curator read the full text.
+    supported_by:
+      - reference_id: PMID:15235028
+        supporting_text: &#34;(CDG-Ih) (ALG8 deficiency)&#34;
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;adds the second glucose residue from dolichyl phosphate glucose&#34;
+- term:
+    id: GO:0042283
+    label: dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  evidence_type: IMP
+  original_reference_id: PMID:12480927
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (IMP) support for ALG8&#39;s Dol-P-Glc:Glc1Man9GlcNAc2-PP-dolichyl
+      alpha-1,3-glucosyltransferase activity: Chantret et al. 2003 identify ALG8
+      as the enzyme catalyzing addition of the second glucose to the LLO, with
+      loss of function causing substrate accumulation and rescue by wild-type
+      cDNA. Core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Directly demonstrates the characterized enzymatic activity (EC 2.4.1.265)
+      via loss-of-function and complementation. Core MF.
+    supported_by:
+      - reference_id: PMID:12480927
+        supporting_text: &#34;which catalyzes this reaction&#34;
+      - reference_id: PMID:12480927
+        supporting_text: &#34;suggesting inefficient addition of the second glucose residue onto&#34;
+- term:
+    id: GO:0042283
+    label: dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  evidence_type: IMP
+  original_reference_id: PMID:15235028
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental (IMP) support for ALG8&#39;s glucosyltransferase activity from
+      Schollen et al. 2004; UniProt records that the CDG1H variants T47P and
+      G275D show &#34;decreased dolichyl pyrophosphate Glc1Man9GlcNAc2
+      alpha-1,3-glucosyltransferase activity&#34;, directly implicating ALG8 in this
+      reaction. Core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Variant characterization demonstrates reduced enzymatic activity, an
+      experimental measure of the annotated MF; curator read full text.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;decreased dolichyl pyrophosphate\nFT                   Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity&#34;
+      - reference_id: PMID:15235028
+        supporting_text: &#34;(CDG-Ih) (ALG8 deficiency)&#34;
+- term:
+    id: GO:0004583
+    label: dolichyl-phosphate-glucose-glycolipid alpha-glucosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446189
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome TAS to GO:0004583, the parent term for Dol-P-Glc-dependent
+      alpha-glucosyltransferase activity. This is correct but less precise than
+      the specific EC 2.4.1.265 term GO:0042283 that is already annotated
+      experimentally. It captures the Dol-P-Glc donor specificity, which is
+      biologically important.
+    action: MODIFY
+    reason: &gt;-
+      The essence (Dol-P-Glc-dependent alpha-glucosyltransferase) is correct but
+      too general; the specific activity term GO:0042283 (the exact reaction
+      ALG8 catalyzes) is preferable.
+    proposed_replacement_terms:
+      - id: GO:0042283
+        label: dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+    supported_by:
+      - reference_id: Reactome:R-HSA-446189
+        supporting_text: &#34;The second glucose (supplied from the donor dolichol-phosphate-glucose) is added to the N-glycan precursor, mediated by ALG8&#34;
+- term:
+    id: GO:0004583
+    label: dolichyl-phosphate-glucose-glycolipid alpha-glucosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-4724330
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome TAS (from the &#34;Defective ALG8 causes CDG-1h&#34; disease reaction) to
+      the parent term GO:0004583. Same activity as the sibling Reactome
+      annotation; correct but less precise than the specific EC 2.4.1.265 term.
+    action: MODIFY
+    reason: &gt;-
+      Correct Dol-P-Glc-dependent glucosyltransferase activity but too general;
+      prefer the specific GO:0042283 term.
+    proposed_replacement_terms:
+      - id: GO:0042283
+        label: dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+    supported_by:
+      - reference_id: Reactome:R-HSA-4724330
+        supporting_text: &#34;normally adds the second glucose moiety to the lipid-linked oligosaccharide precursor (LLO aka N-glycan precursor) which is required for subsequent N-glycosylation of proteins&#34;
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ISS transfer (from mouse ortholog Q6P8H8) to protein N-linked
+      glycosylation. Consistent with the experimental IMP and the IEA (Ensembl)
+      annotations to the same term; ALG8 assembles the glycan precursor used in
+      N-glycosylation. Correct.
+    action: ACCEPT
+    reason: &gt;-
+      Sequence-similarity inference to a well-supported process; redundant with
+      but consistent with the human experimental annotation.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;the glycan precursors employed in\nCC       protein asparagine (N)-glycosylation&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-4724330
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS ER membrane localization, consistent with the experimental
+      and UniProt-curated ER membrane location. Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      Reproduces the well-supported ER membrane localization of this multi-pass
+      membrane enzyme.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446189
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS ER membrane localization (duplicate of the sibling Reactome
+      CC annotation), consistent with experimental and UniProt evidence.
+      Correct and core.
+    action: ACCEPT
+    reason: &gt;-
+      Reproduces the well-supported ER membrane localization; duplicates are
+      acceptable across evidence sources.
+    supported_by:
+      - reference_id: file:human/ALG8/ALG8-uniprot.txt
+        supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IMP
+  original_reference_id: PMID:12480927
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) evidence that ALG8 deficiency (CDG-Ih) impairs protein
+      N-linked glycosylation (Chantret et al. 2003), which defined this new
+      subtype of type I congenital disorders of glycosylation — disorders caused
+      by defective assembly of the dolichyl-linked oligosaccharide required for
+      protein glycosylation. Correct.
+    action: ACCEPT
+    reason: &gt;-
+      Patient loss-of-function evidence links ALG8 to N-glycosylation via
+      defective LLO assembly; consistent with other N-glycosylation annotations.
+    supported_by:
+      - reference_id: PMID:12480927
+        supporting_text: &#34;the underlying cause of this new CDG I&#34;
+      - reference_id: PMID:12480927
+        supporting_text: &#34;biosynthesis of the dolichyl-linked oligosaccharide&#34;
+references:
+- id: file:human/ALG8/ALG8-uniprot.txt
+  title: UniProtKB Q9BVK2 (ALG8_HUMAN)
+  findings: []
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:12480927
+  title: A deficiency in dolichyl-P-glucose:Glc1Man9GlcNAc2-PP-dolichyl alpha3-glucosyltransferase
+    defines a new subtype of congenital disorders of glycosylation.
+  findings: []
+- id: PMID:15235028
+  title: Clinical and molecular features of three patients with congenital disorders
+    of glycosylation type Ih (CDG-Ih) (ALG8 deficiency).
+  findings: []
+- id: PMID:25910212
+  title: Widespread macromolecular interaction perturbations in human genetic disorders.
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+- id: Reactome:R-HSA-446189
+  title: Addition of a second glucose to the N-glycan precursor by ALG8
+  findings: []
+- id: Reactome:R-HSA-446193
+  title: Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide,
+    LLO) and transfer to a nascent protein
+  findings: []
+- id: Reactome:R-HSA-4724330
+  title: Defective ALG8 does not add glucose to the N-glycan precursor
+  findings: []
+core_functions:
+- description: &gt;-
+    ER-lumenal, Dol-P-Glc-dependent alpha-1,3-glucosyltransferase (EC 2.4.1.265)
+    that transfers the second glucose from dolichyl-phosphate-glucose onto
+    Glc1Man9GlcNAc2-PP-dolichol to give Glc2Man9GlcNAc2-PP-dolichol during
+    lipid-linked oligosaccharide (LLO) assembly.
+  molecular_function:
+    id: GO:0042283
+    label: dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  directly_involved_in:
+    - id: GO:0006488
+      label: dolichol-linked oligosaccharide biosynthetic process
+  locations:
+    - id: GO:0005789
+      label: endoplasmic reticulum membrane
+    - id: GO:0098553
+      label: lumenal side of endoplasmic reticulum membrane
+  supported_by:
+    - reference_id: file:human/ALG8/ALG8-uniprot.txt
+      supporting_text: &#34;adds the second glucose residue from dolichyl phosphate glucose&#34;
+    - reference_id: PMID:12480927
+      supporting_text: &#34;which catalyzes this reaction&#34;
+- description: &gt;-
+    Through assembly of the mature Glc3Man9GlcNAc2 lipid-linked oligosaccharide
+    precursor that is transferred en bloc to nascent polypeptides, ALG8 is
+    required for protein N-linked glycosylation; its loss causes CDG-Ih.
+  molecular_function:
+    id: GO:0042283
+    label: dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity
+  directly_involved_in:
+    - id: GO:0006487
+      label: protein N-linked glycosylation
+  locations:
+    - id: GO:0005789
+      label: endoplasmic reticulum membrane
+  supported_by:
+    - reference_id: PMID:12480927
+      supporting_text: &#34;biosynthesis of the dolichyl-linked oligosaccharide&#34;
+    - reference_id: file:human/ALG8/ALG8-uniprot.txt
+      supporting_text: &#34;the glycan precursors employed in\nCC       protein asparagine (N)-glycosylation&#34;
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/ALG9/ALG9-ai-review.html
+++ b/genes/human/ALG9/ALG9-ai-review.html
@@ -1,0 +1,4258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ALG9 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ALG9</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9H6U8" target="_blank" class="term-link">
+                        Q9H6U8
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ALG9";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9H6U8" data-a="DESCRIPTION: ALG9 is a Dol-P-Man-dependent alpha-1,2-mannosyltr..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ALG9 is a Dol-P-Man-dependent alpha-1,2-mannosyltransferase of the glycosyltransferase 22 (GT22) family that acts in the assembly of the dolichol-linked oligosaccharide (LLO), the 14-sugar glycan precursor used for protein N-linked glycosylation. It is a multi-pass endoplasmic reticulum membrane protein whose catalytic mannose-transfer steps occur on the lumenal side of the ER membrane. Using dolichyl-phosphate-mannose (Dol-P-Man, not GDP-mannose) as the mannose donor, ALG9 catalyses two sequential lumenal reactions in LLO assembly. It adds the seventh alpha-1,2-linked mannose onto Man(6)GlcNAc(2)-PP-dolichol (EC 2.4.1.259) and the ninth alpha-1,2-linked mannose onto Man(8)GlcNAc(2)-PP-dolichol (EC 2.4.1.261). Loss of ALG9 function causes intracellular accumulation of GlcNAc(2)Man(6) and GlcNAc(2)Man(8) lipid-linked intermediates and hypoglycosylation of serum glycoproteins. Biallelic pathogenic variants cause ALG9-CDG (congenital disorder of glycosylation type Il, CDG-Il) and the severe skeletal dysplasia Gillessen-Kaesbach-Nishimura syndrome.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000026" target="_blank" class="term-link">
+                                    GO:0000026
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0000026" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of the parent alpha-1,2-mannosyltransferase molecular function. This is correct but general; ALG9&#39;s two experimentally defined activities are the more specific Dol-P-Man Man(6/8)GlcNAc(2)-PP-Dol terms (GO:0052926, GO:0052918).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The activity is correct for ALG9 but is the generic parent of the two EC-specific terms it actually catalyses. The specific terms capture the exact substrate and donor and are the core molecular functions; this broad term is retained as accurate-but-general.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the addition of the seventh and ninth alpha-1,2-linked</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ALG9 is a multi-pass ER membrane protein and is active in the ER membrane, consistent with the phylogenetic assignment and with UniProt subcellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ER membrane localization is well supported. UniProt records the subcellular location as ER membrane, multi-pass membrane protein, and the topology assigns seven transmembrane helices; the IBA assignment is at the correct level.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0006487" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ALG9 builds the LLO glycan precursor that is transferred en bloc to nascent proteins, so it is involved in protein N-linked glycosylation. Correct but broader than the LLO biosynthetic-process term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The LLO that ALG9 helps assemble is the substrate for protein N-glycosylation, and ALG9 deficiency causes hypoglycosylation of serum glycoproteins (CDG). The IBA assignment is appropriate at this level.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the glycan precursors employed in</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link">
+                                        PMID:15945070
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Hypoglycosylation was confirmed by the typical CDG type 1 pattern</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCell mapping of the ER membrane subcellular location. Consistent with all other evidence for ER membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct electronic mapping from the UniProt subcellular-location annotation; agrees with the IBA and Reactome ER membrane annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016757" target="_blank" class="term-link">
+                                    GO:0016757
+                                </a>
+                            </span>
+                            <span class="term-label">glycosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0016757" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping to the generic glycosyltransferase activity from the GT22 and Glyco_transf_22 domain (IPR005599). Correct but very general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The domain-based mapping is accurate (ALG9 is a glycosyltransferase) but is a broad grandparent of the specific mannosyltransferase activities ALG9 actually catalyses. Kept as accurate-but-general rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the glycosyltransferase 22 family.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052918" target="_blank" class="term-link">
+                                    GO:0052918
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(8)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0052918" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (RHEA/EC) assignment of the activity that adds the ninth mannose onto Man(8)GlcNAc(2)-PP-dolichol (EC 2.4.1.261, RHEA 29539). This is one of the two core catalytic activities of ALG9 and is independently supported experimentally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> EC 2.4.1.261 is one of ALG9&#39;s two experimentally established catalytic activities (UniProt CATALYTIC ACTIVITY, ECO 0000269 PubMed 15148656 and PubMed 15945070); the RHEA/EC electronic mapping correctly assigns this specific term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.4.1.261</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the addition of the seventh and ninth alpha-1,2-linked</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052926" target="_blank" class="term-link">
+                                    GO:0052926
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(6)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0052926" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (RHEA/EC) assignment of the activity that adds the seventh mannose onto Man(6)GlcNAc(2)-PP-dolichol (EC 2.4.1.259, RHEA 29531). This is the second core catalytic activity of ALG9 and is independently supported experimentally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> EC 2.4.1.259 is one of ALG9&#39;s two experimentally established catalytic activities (UniProt CATALYTIC ACTIVITY, ECO 0000269 PubMed 15148656 and PubMed 15945070); the RHEA/EC electronic mapping correctly assigns this specific term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.4.1.259</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the addition of the seventh and ninth alpha-1,2-linked</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446193
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0006488" data-r="Reactome:R-HSA-446193" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable assignment placing ALG9 in the biosynthesis of the dolichol lipid-linked oligosaccharide (LLO) N-glycan precursor. This is the most precise core biological process for ALG9.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ALG9 performs two of the mannose-addition steps in LLO assembly; the Reactome pathway covers the 14-step synthesis of the dolichol lipid-linked oligosaccharide precursor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-446193
+
+                                </span>
+
+                                <div class="support-text">N-linked glycosylation commences with the 14-step synthesis of a dolichol lipid-linked oligosaccharide (LLO)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098553" target="_blank" class="term-link">
+                                    GO:0098553
+                                </a>
+                            </span>
+                            <span class="term-label">lumenal side of endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15148656
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional analysis of a defect in the hu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0098553" data-r="PMID:15148656" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator inference (IC) that ALG9 is active on the lumenal side of the ER membrane. The Dol-P-Man-dependent mannose additions catalysed by ALG9 occur in the ER lumen, so this refinement of the ER membrane location is well justified.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LLO assembly finishes in the ER lumen, and ALG9&#39;s mannose-transfer reactions are lumenal (UniProt FUNCTION; Reactome). This IC annotation appropriately specifies the lumenal side of the ER membrane as the site of catalysis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">begins on the cytosolic side of the endoplasmic</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-446215
+
+                                </span>
+
+                                <div class="support-text">This reaction occurs in the ER lumen and uses dolichyl phosphate D-mannose as the mannose donor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15148656
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional analysis of a defect in the hu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0006487" data-r="PMID:15148656" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) evidence that ALG9 is required for protein N-linked glycosylation. A CDG patient with an ALG9 deficiency (E523K) showed transfer of incomplete oligosaccharide precursors to protein, and the defect was confirmed by yeast complementation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Frank et al. 2004 experimentally established the requirement of ALG9 for N-linked glycosylation via a patient defect plus yeast complementation. The full text was read by the curator; the abstract already documents the underglycosylation phenotype.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link">
+                                        PMID:15148656
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">paralleled by the transfer of incomplete oligosaccharides precursors to protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                    GO:0006487
+                                </a>
+                            </span>
+                            <span class="term-label">protein N-linked glycosylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15945070
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CDG-IL: an infant with a novel mutation in the ALG9 gene and...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0006487" data-r="PMID:15945070" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Second experimental (IMP) confirmation, in an independent CDG-Il patient (p.Y286C), that ALG9 deficiency impairs protein N-linked glycosylation, shown by the typical CDG type 1 transferrin isoelectric-focusing pattern.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Weinstein et al. 2005 report a second ALG9-deficient patient with confirmed hypoglycosylation and yeast-complementation validation of the causal mutation, supporting the requirement of ALG9 for N-glycosylation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link">
+                                        PMID:15945070
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Hypoglycosylation was confirmed by the typical CDG type 1 pattern</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15148656
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional analysis of a defect in the hu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0006488" data-r="PMID:15148656" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction (IGI) evidence with S. cerevisiae ALG9 (UniProtKB P53868). Functional homology and rescue of the alg9-deficient yeast confirmed ALG9&#39;s role in LLO biosynthesis, with patient cells accumulating GlcNAc(2)Man(6) and GlcNAc(2)Man(8) LLO.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The yeast complementation assay and the accumulation of the two LLO intermediates directly place ALG9 in the dolichol-linked oligosaccharide biosynthetic process; this is a core biological process for the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link">
+                                        PMID:15148656
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link">
+                                        PMID:15148656
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">confirmed by a yeast</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                    GO:0006488
+                                </a>
+                            </span>
+                            <span class="term-label">dolichol-linked oligosaccharide biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15945070
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CDG-IL: an infant with a novel mutation in the ALG9 gene and...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0006488" data-r="PMID:15945070" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Second genetic-interaction (IGI) with yeast ALG9 (UniProtKB P53868). The causal effect of the patient mutation was demonstrated by complementation in alg9-deficient yeast, with accumulation of DolPP-GlcNAc2Man6 and DolPP-GlcNAc2Man8 confirming the LLO defect.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Independent yeast-complementation evidence for ALG9&#39;s role in LLO biosynthesis, corroborating the core biological process assignment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link">
+                                        PMID:15945070
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">shown by complementation assays in alg9 deficient</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link">
+                                        PMID:15945070
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accumulation of the DolPP-GlcNAc2Man6 and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052918" target="_blank" class="term-link">
+                                    GO:0052918
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(8)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15148656
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional analysis of a defect in the hu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0052918" data-r="PMID:15148656" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction (IGI) evidence, via yeast ALG9 complementation, for the activity that adds the ninth mannose (EC 2.4.1.261). Accumulation of GlcNAc(2)Man(8) LLO in patient cells directly indicates loss of the Man(8) to Man(9) mannosyltransferase step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The Man(8)GlcNAc(2) accumulation, plus functional complementation of yeast alg9, supports ALG9&#39;s Man(8)-acceptor alpha-1,2-mannosyltransferase activity; a core molecular function. Experimental annotation, full text read by curator.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link">
+                                        PMID:15148656
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052918" target="_blank" class="term-link">
+                                    GO:0052918
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(8)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15945070
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CDG-IL: an infant with a novel mutation in the ALG9 gene and...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0052918" data-r="PMID:15945070" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Second IGI (yeast complementation) supporting the Man(8)-acceptor alpha-1,2- mannosyltransferase activity (ninth-mannose addition, EC 2.4.1.261), with DolPP-GlcNAc2Man8 accumulating in the patient&#39;s fibroblasts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Independent genetic evidence for the Man(8)GlcNAc(2)-PP-Dol mannosyltransferase activity; corroborates the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link">
+                                        PMID:15945070
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accumulation of the DolPP-GlcNAc2Man6 and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052926" target="_blank" class="term-link">
+                                    GO:0052926
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(6)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15148656
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional analysis of a defect in the hu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0052926" data-r="PMID:15148656" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction (IGI) evidence, via yeast ALG9 complementation, for the activity that adds the seventh mannose (EC 2.4.1.259). Accumulation of GlcNAc(2)Man(6) LLO in patient cells directly indicates loss of the Man(6) to Man(7) mannosyltransferase step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The Man(6)GlcNAc(2) accumulation, plus functional complementation of yeast alg9, supports ALG9&#39;s Man(6)-acceptor alpha-1,2-mannosyltransferase activity; a core molecular function. Experimental annotation, full text read by curator.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link">
+                                        PMID:15148656
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052926" target="_blank" class="term-link">
+                                    GO:0052926
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(6)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15945070
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CDG-IL: an infant with a novel mutation in the ALG9 gene and...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0052926" data-r="PMID:15945070" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Second IGI (yeast complementation) supporting the Man(6)-acceptor alpha-1,2- mannosyltransferase activity (seventh-mannose addition, EC 2.4.1.259), with DolPP-GlcNAc2Man6 accumulating in the patient&#39;s fibroblasts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Independent genetic evidence for the Man(6)GlcNAc(2)-PP-Dol mannosyltransferase activity; corroborates the core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link">
+                                        PMID:15945070
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accumulation of the DolPP-GlcNAc2Man6 and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000026" target="_blank" class="term-link">
+                                    GO:0000026
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446215
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0000026" data-r="Reactome:R-HSA-446215" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for the alpha-1,2-mannosyltransferase activity, specifically the reaction in which ALG9 adds the seventh mannose to the (GlcNAc)2(Man)6(PP-Dol)1 precursor in the ER lumen. Correct but at the generic parent level.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct activity, but the generic parent of the EC-specific GO:0052926 term that precisely captures this Man(6)-acceptor reaction; retained as accurate-but-general.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-446215
+
+                                </span>
+
+                                <div class="support-text">The seventh mannose is added to the N-glycan precursor.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000026" target="_blank" class="term-link">
+                                    GO:0000026
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446216
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0000026" data-r="Reactome:R-HSA-446216" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS for the alpha-1,2-mannosyltransferase activity, specifically the reaction in which ALG9 adds the last (ninth) mannose to the (GlcNAc)2(Man)8(PP-Dol)1 precursor in the ER lumen. Correct but at the generic parent level.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct activity, but the generic parent of the EC-specific GO:0052918 term that precisely captures this Man(8)-acceptor reaction; retained as accurate-but-general.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-446216
+
+                                </span>
+
+                                <div class="support-text">The last mannose is added to the N-glycan precursor.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000026" target="_blank" class="term-link">
+                                    GO:0000026
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-4720478
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0000026" data-r="Reactome:R-HSA-4720478" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS derived from the disease reaction &#34;Defective ALG9 does not add the seventh mannose&#34;, asserting the normal alpha-1,2-mannosyltransferase activity of ALG9. Correct but generic.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct activity but the generic parent of the specific EC-mapped terms; retained as accurate-but-general.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-4720478
+
+                                </span>
+
+                                <div class="support-text">It adds the 7th and 9th mannose moieties to LLO.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000026" target="_blank" class="term-link">
+                                    GO:0000026
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9035514
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0000026" data-r="Reactome:R-HSA-9035514" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS derived from the disease reaction &#34;Defective ALG9 does not add the last mannose&#34;, asserting the normal alpha-1,2-mannosyltransferase activity of ALG9. Correct but generic.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct activity but the generic parent of the specific EC-mapped terms; retained as accurate-but-general.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-9035514
+
+                                </span>
+
+                                <div class="support-text">It adds the 7th and 9th mannose moieties to LLO.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-4720478
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0005789" data-r="Reactome:R-HSA-4720478" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localizing ALG9 to the ER membrane, from the CDG disease reaction. Agrees with all other ER membrane evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent ER membrane localization; ALG9&#39;s lumenal mannose additions occur at the ER membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9035514
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0005789" data-r="Reactome:R-HSA-9035514" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localizing ALG9 to the ER membrane, from the CDG disease reaction. Agrees with all other ER membrane evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent ER membrane localization for this multi-pass membrane enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomics (HDA) detected ALG9 in an NK-cell membrane-proteome study. Consistent with ALG9 being an integral membrane protein but far less specific than the ER membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ALG9 is a multi-pass membrane protein, so detection in a membrane proteome is expected, but the generic membrane term is uninformative relative to the well-supported ER membrane localization. Kept as accurate-but-general.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Isolated membranes were</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446215
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0005789" data-r="Reactome:R-HSA-446215" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localizing ALG9 to the ER membrane, from the seventh-mannose transfer reaction. Agrees with all other ER membrane evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent ER membrane localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-446216
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H6U8" data-a="GO:0005789" data-r="Reactome:R-HSA-446216" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localizing ALG9 to the ER membrane, from the last-mannose transfer reaction. Agrees with all other ER membrane evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent ER membrane localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ALG9/ALG9-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Dol-P-Man-dependent alpha-1,2-mannosyltransferase adding the seventh mannose onto Man(6)GlcNAc(2)-PP-dolichol during lumenal LLO assembly (EC 2.4.1.259)</h3>
+                <span class="vote-buttons" data-g="Q9H6U8" data-a="FUNCTION: Dol-P-Man-dependent alpha-1,2-mannosyltransferase ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052926" target="_blank" class="term-link">
+                            dol-P-Man:Man(6)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                dolichol-linked oligosaccharide biosynthetic process
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                protein N-linked glycosylation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ALG9/ALG9-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">the addition of the seventh and ninth alpha-1,2-linked</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link">
+                                PMID:15148656
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Dol-P-Man-dependent alpha-1,2-mannosyltransferase adding the ninth (last) mannose onto Man(8)GlcNAc(2)-PP-dolichol during lumenal LLO assembly (EC 2.4.1.261)</h3>
+                <span class="vote-buttons" data-g="Q9H6U8" data-a="FUNCTION: Dol-P-Man-dependent alpha-1,2-mannosyltransferase ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052918" target="_blank" class="term-link">
+                            dol-P-Man:Man(8)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006488" target="_blank" class="term-link">
+                                dolichol-linked oligosaccharide biosynthetic process
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006487" target="_blank" class="term-link">
+                                protein N-linked glycosylation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ALG9/ALG9-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">the addition of the seventh and ninth alpha-1,2-linked</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link">
+                                PMID:15148656
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15148656" target="_blank" class="term-link">
+                            PMID:15148656
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification and functional analysis of a defect in the human ALG9 gene: definition of congenital disorder of glycosylation type IL.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15945070" target="_blank" class="term-link">
+                            PMID:15945070
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CDG-IL: an infant with a novel mutation in the ALG9 gene and additional phenotypic features.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446193
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide, LLO) and transfer to a nascent protein</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446215
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ALG9 transfers Man to N-glycan precursor (GlcNAc)2 (Man)6 (PP-Dol)1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-446216
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ALG9 transfers Man to N-glycan precursor (GlcNAc)2 (Man)8 (PP-Dol)1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-4720478
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective ALG9 does not add the seventh mannose to the N-glycan precursor</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9035514
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective ALG9 does not add the last mannose to the N-glycan precursor</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ALG9/ALG9-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q9H6U8 (ALG9_HUMAN), Alpha-1,2-mannosyltransferase ALG9</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ALG9-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9H6U8" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="alg9-q9h6u8-review-notes">ALG9 (Q9H6U8) review notes</h1>
+<h2 id="summary-of-verified-biology">Summary of verified biology</h2>
+<p>ALG9 is an ER-lumenal alpha-1,2-mannosyltransferase in the dolichol-linked oligosaccharide (LLO)<br />
+assembly pathway for protein N-glycosylation. It catalyses <strong>two</strong> sequential lumenal steps using<br />
+<strong>Dol-P-Man</strong> (dolichyl-phosphate-mannose, NOT GDP-Man) as the mannose donor:</p>
+<ul>
+<li>Adds the <strong>7th mannose</strong> onto Man(6)GlcNAc(2)-PP-dolichol → EC 2.4.1.259 → GO:0052926<br />
+  (RHEA:29531). Reactome R-HSA-446215.</li>
+<li>Adds the <strong>9th mannose</strong> onto Man(8)GlcNAc(2)-PP-dolichol → EC 2.4.1.261 → GO:0052918<br />
+  (RHEA:29539). Reactome R-HSA-446216.</li>
+</ul>
+<p>Multi-pass ER membrane protein (7 TM helices per UniProt topology); catalytic mannose transfer<br />
+occurs on the lumenal side of the ER membrane. GT22 family (CAZy), Glyco_transf_22 Pfam,<br />
+InterPro IPR005599.</p>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>ALG9-CDG (CDG-Il / CDG type IL), MIM:608776. Frank et al. 2004 (PMID:15148656, E523K) and<br />
+  Weinstein et al. 2005 (PMID:15945070, p.Y286C in the abstract's numbering). LLO profiling<br />
+  shows accumulation of GlcNAc2Man6 and GlcNAc2Man8 lipid-linked structures — exactly the two<br />
+  substrates whose downstream mannose is missing when ALG9 is defective.</li>
+<li>Gillessen-Kaesbach-Nishimura syndrome (GIKANIS), MIM:263210 — Tham et al. 2016<br />
+  (PMID:25966638), severe skeletal dysplasia / polycystic kidney disease.</li>
+<li>DIBD1 / bipolar association (PMID:12030331 translocation) was later refuted (PMID:16859551).</li>
+</ul>
+<h2 id="annotation-review-decisions">Annotation review decisions</h2>
+<ul>
+<li>GOA carries BOTH EC-specific MF terms (GO:0052926 Man6→7th; GO:0052918 Man8→9th) plus the<br />
+  parent GO:0000026 (alpha-1,2-mannosyltransferase activity). The two specific terms are the<br />
+  core MFs; GO:0000026 (parent) and GO:0016757 (glycosyltransferase activity, generic) are<br />
+  correct-but-general.</li>
+<li>BP: GO:0006488 (dolichol-linked oligosaccharide biosynthetic process) is the most precise<br />
+  core BP; GO:0006487 (protein N-linked glycosylation) is the correct broader outcome.</li>
+<li>CC: GO:0005789 (ER membrane) core; GO:0098553 (lumenal side of ER membrane) is a precise<br />
+  IC-supported refinement consistent with lumenal catalysis; GO:0016020 (membrane) HDA is<br />
+  correct but general (over-annotation).</li>
+</ul>
+<h2 id="provenance">Provenance</h2>
+<p>All supporting_text quotes are verbatim substrings of the cited cached publication<br />
+(publications/PMID_15148656.md, PMID_15945070.md), the cached Reactome entries, or<br />
+file:human/ALG9/ALG9-uniprot.txt. All publications are abstract-only (full_text_available:<br />
+false) — experimental IMP/IGI/IC annotations from those PMIDs are ACCEPTED (curator read the<br />
+full text), not removed.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9H6U8
+gene_symbol: ALG9
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  ALG9 is a Dol-P-Man-dependent alpha-1,2-mannosyltransferase of the glycosyltransferase 22
+  (GT22) family that acts in the assembly of the dolichol-linked oligosaccharide (LLO), the
+  14-sugar glycan precursor used for protein N-linked glycosylation. It is a multi-pass
+  endoplasmic reticulum membrane protein whose catalytic mannose-transfer steps occur on the
+  lumenal side of the ER membrane. Using dolichyl-phosphate-mannose (Dol-P-Man, not GDP-mannose)
+  as the mannose donor, ALG9 catalyses two sequential lumenal reactions in LLO assembly. It adds
+  the seventh alpha-1,2-linked mannose onto Man(6)GlcNAc(2)-PP-dolichol (EC 2.4.1.259) and the
+  ninth alpha-1,2-linked mannose onto Man(8)GlcNAc(2)-PP-dolichol (EC 2.4.1.261). Loss of ALG9
+  function causes intracellular accumulation of GlcNAc(2)Man(6) and GlcNAc(2)Man(8) lipid-linked
+  intermediates and hypoglycosylation of serum glycoproteins. Biallelic pathogenic variants cause
+  ALG9-CDG (congenital disorder of glycosylation type Il, CDG-Il) and the severe skeletal
+  dysplasia Gillessen-Kaesbach-Nishimura syndrome.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q9H6U8-1
+- name: &#39;2&#39;
+  id: Q9H6U8-2
+  sequence_note: VSP_015434
+- name: &#39;3&#39;
+  id: Q9H6U8-3
+  sequence_note: VSP_015435
+- name: &#39;4&#39;
+  id: Q9H6U8-4
+  sequence_note: VSP_015434, VSP_015435
+existing_annotations:
+- term:
+    id: GO:0000026
+    label: alpha-1,2-mannosyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) assignment of the parent alpha-1,2-mannosyltransferase molecular
+      function. This is correct but general; ALG9&#39;s two experimentally defined activities are the
+      more specific Dol-P-Man Man(6/8)GlcNAc(2)-PP-Dol terms (GO:0052926, GO:0052918).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The activity is correct for ALG9 but is the generic parent of the two EC-specific
+      terms it actually catalyses. The specific terms capture the exact substrate and donor and
+      are the core molecular functions; this broad term is retained as accurate-but-general.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: the addition of the seventh and ninth alpha-1,2-linked
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: ALG9 is a multi-pass ER membrane protein and is active in the ER membrane, consistent
+      with the phylogenetic assignment and with UniProt subcellular location.
+    action: ACCEPT
+    reason: ER membrane localization is well supported. UniProt records the subcellular location
+      as ER membrane, multi-pass membrane protein, and the topology assigns seven transmembrane
+      helices; the IBA assignment is at the correct level.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: Multi-pass membrane protein
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: ALG9 builds the LLO glycan precursor that is transferred en bloc to nascent proteins,
+      so it is involved in protein N-linked glycosylation. Correct but broader than the LLO
+      biosynthetic-process term.
+    action: ACCEPT
+    reason: The LLO that ALG9 helps assemble is the substrate for protein N-glycosylation, and
+      ALG9 deficiency causes hypoglycosylation of serum glycoproteins (CDG). The IBA assignment
+      is appropriate at this level.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: the glycan precursors employed in
+    - reference_id: PMID:15945070
+      supporting_text: Hypoglycosylation was confirmed by the typical CDG type 1 pattern
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt SubCell mapping of the ER membrane subcellular location. Consistent with all
+      other evidence for ER membrane localization.
+    action: ACCEPT
+    reason: Correct electronic mapping from the UniProt subcellular-location annotation; agrees
+      with the IBA and Reactome ER membrane annotations.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0016757
+    label: glycosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO mapping to the generic glycosyltransferase activity from the GT22 and
+      Glyco_transf_22 domain (IPR005599). Correct but very general.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The domain-based mapping is accurate (ALG9 is a glycosyltransferase) but is a broad
+      grandparent of the specific mannosyltransferase activities ALG9 actually catalyses. Kept as
+      accurate-but-general rather than removed.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: Belongs to the glycosyltransferase 22 family.
+- term:
+    id: GO:0052918
+    label: dol-P-Man:Man(8)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic (RHEA/EC) assignment of the activity that adds the ninth mannose onto
+      Man(8)GlcNAc(2)-PP-dolichol (EC 2.4.1.261, RHEA 29539). This is one of the two core
+      catalytic activities of ALG9 and is independently supported experimentally.
+    action: ACCEPT
+    reason: EC 2.4.1.261 is one of ALG9&#39;s two experimentally established catalytic activities
+      (UniProt CATALYTIC ACTIVITY, ECO 0000269 PubMed 15148656 and PubMed 15945070); the
+      RHEA/EC electronic mapping correctly assigns this specific term.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: EC=2.4.1.261
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: the addition of the seventh and ninth alpha-1,2-linked
+- term:
+    id: GO:0052926
+    label: dol-P-Man:Man(6)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic (RHEA/EC) assignment of the activity that adds the seventh mannose onto
+      Man(6)GlcNAc(2)-PP-dolichol (EC 2.4.1.259, RHEA 29531). This is the second core catalytic
+      activity of ALG9 and is independently supported experimentally.
+    action: ACCEPT
+    reason: EC 2.4.1.259 is one of ALG9&#39;s two experimentally established catalytic activities
+      (UniProt CATALYTIC ACTIVITY, ECO 0000269 PubMed 15148656 and PubMed 15945070); the
+      RHEA/EC electronic mapping correctly assigns this specific term.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: EC=2.4.1.259
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: the addition of the seventh and ninth alpha-1,2-linked
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446193
+  qualifier: involved_in
+  review:
+    summary: Reactome traceable assignment placing ALG9 in the biosynthesis of the dolichol
+      lipid-linked oligosaccharide (LLO) N-glycan precursor. This is the most precise core
+      biological process for ALG9.
+    action: ACCEPT
+    reason: ALG9 performs two of the mannose-addition steps in LLO assembly; the Reactome pathway
+      covers the 14-step synthesis of the dolichol lipid-linked oligosaccharide precursor.
+    supported_by:
+    - reference_id: Reactome:R-HSA-446193
+      supporting_text: N-linked glycosylation commences with the 14-step synthesis of a dolichol
+        lipid-linked oligosaccharide (LLO)
+- term:
+    id: GO:0098553
+    label: lumenal side of endoplasmic reticulum membrane
+  evidence_type: IC
+  original_reference_id: PMID:15148656
+  qualifier: is_active_in
+  review:
+    summary: Curator inference (IC) that ALG9 is active on the lumenal side of the ER membrane.
+      The Dol-P-Man-dependent mannose additions catalysed by ALG9 occur in the ER lumen, so this
+      refinement of the ER membrane location is well justified.
+    action: ACCEPT
+    reason: LLO assembly finishes in the ER lumen, and ALG9&#39;s mannose-transfer reactions are
+      lumenal (UniProt FUNCTION; Reactome). This IC annotation appropriately specifies the
+      lumenal side of the ER membrane as the site of catalysis.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: begins on the cytosolic side of the endoplasmic
+    - reference_id: Reactome:R-HSA-446215
+      supporting_text: This reaction occurs in the ER lumen and uses dolichyl phosphate D-mannose
+        as the mannose donor
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IMP
+  original_reference_id: PMID:15148656
+  qualifier: involved_in
+  review:
+    summary: Experimental (IMP) evidence that ALG9 is required for protein N-linked glycosylation.
+      A CDG patient with an ALG9 deficiency (E523K) showed transfer of incomplete oligosaccharide
+      precursors to protein, and the defect was confirmed by yeast complementation.
+    action: ACCEPT
+    reason: Frank et al. 2004 experimentally established the requirement of ALG9 for N-linked
+      glycosylation via a patient defect plus yeast complementation. The full text was read by the
+      curator; the abstract already documents the underglycosylation phenotype.
+    supported_by:
+    - reference_id: PMID:15148656
+      supporting_text: paralleled by the transfer of incomplete oligosaccharides precursors to
+        protein
+- term:
+    id: GO:0006487
+    label: protein N-linked glycosylation
+  evidence_type: IMP
+  original_reference_id: PMID:15945070
+  qualifier: involved_in
+  review:
+    summary: Second experimental (IMP) confirmation, in an independent CDG-Il patient (p.Y286C),
+      that ALG9 deficiency impairs protein N-linked glycosylation, shown by the typical CDG type 1
+      transferrin isoelectric-focusing pattern.
+    action: ACCEPT
+    reason: Weinstein et al. 2005 report a second ALG9-deficient patient with confirmed
+      hypoglycosylation and yeast-complementation validation of the causal mutation, supporting
+      the requirement of ALG9 for N-glycosylation.
+    supported_by:
+    - reference_id: PMID:15945070
+      supporting_text: Hypoglycosylation was confirmed by the typical CDG type 1 pattern
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IGI
+  original_reference_id: PMID:15148656
+  qualifier: involved_in
+  review:
+    summary: Genetic-interaction (IGI) evidence with S. cerevisiae ALG9 (UniProtKB P53868).
+      Functional homology and rescue of the alg9-deficient yeast confirmed ALG9&#39;s role in LLO
+      biosynthesis, with patient cells accumulating GlcNAc(2)Man(6) and GlcNAc(2)Man(8) LLO.
+    action: ACCEPT
+    reason: The yeast complementation assay and the accumulation of the two LLO intermediates
+      directly place ALG9 in the dolichol-linked oligosaccharide biosynthetic process; this is a
+      core biological process for the gene.
+    supported_by:
+    - reference_id: PMID:15148656
+      supporting_text: accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures
+    - reference_id: PMID:15148656
+      supporting_text: confirmed by a yeast
+- term:
+    id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  evidence_type: IGI
+  original_reference_id: PMID:15945070
+  qualifier: involved_in
+  review:
+    summary: Second genetic-interaction (IGI) with yeast ALG9 (UniProtKB P53868). The causal
+      effect of the patient mutation was demonstrated by complementation in alg9-deficient yeast,
+      with accumulation of DolPP-GlcNAc2Man6 and DolPP-GlcNAc2Man8 confirming the LLO defect.
+    action: ACCEPT
+    reason: Independent yeast-complementation evidence for ALG9&#39;s role in LLO biosynthesis,
+      corroborating the core biological process assignment.
+    supported_by:
+    - reference_id: PMID:15945070
+      supporting_text: shown by complementation assays in alg9 deficient
+    - reference_id: PMID:15945070
+      supporting_text: accumulation of the DolPP-GlcNAc2Man6 and
+- term:
+    id: GO:0052918
+    label: dol-P-Man:Man(8)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity
+  evidence_type: IGI
+  original_reference_id: PMID:15148656
+  qualifier: enables
+  review:
+    summary: Genetic-interaction (IGI) evidence, via yeast ALG9 complementation, for the activity
+      that adds the ninth mannose (EC 2.4.1.261). Accumulation of GlcNAc(2)Man(8) LLO in patient
+      cells directly indicates loss of the Man(8) to Man(9) mannosyltransferase step.
+    action: ACCEPT
+    reason: The Man(8)GlcNAc(2) accumulation, plus functional complementation of yeast alg9,
+      supports ALG9&#39;s Man(8)-acceptor alpha-1,2-mannosyltransferase activity; a core molecular
+      function. Experimental annotation, full text read by curator.
+    supported_by:
+    - reference_id: PMID:15148656
+      supporting_text: accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures
+- term:
+    id: GO:0052918
+    label: dol-P-Man:Man(8)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity
+  evidence_type: IGI
+  original_reference_id: PMID:15945070
+  qualifier: enables
+  review:
+    summary: Second IGI (yeast complementation) supporting the Man(8)-acceptor alpha-1,2-
+      mannosyltransferase activity (ninth-mannose addition, EC 2.4.1.261), with DolPP-GlcNAc2Man8
+      accumulating in the patient&#39;s fibroblasts.
+    action: ACCEPT
+    reason: Independent genetic evidence for the Man(8)GlcNAc(2)-PP-Dol mannosyltransferase
+      activity; corroborates the core molecular function.
+    supported_by:
+    - reference_id: PMID:15945070
+      supporting_text: accumulation of the DolPP-GlcNAc2Man6 and
+- term:
+    id: GO:0052926
+    label: dol-P-Man:Man(6)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity
+  evidence_type: IGI
+  original_reference_id: PMID:15148656
+  qualifier: enables
+  review:
+    summary: Genetic-interaction (IGI) evidence, via yeast ALG9 complementation, for the activity
+      that adds the seventh mannose (EC 2.4.1.259). Accumulation of GlcNAc(2)Man(6) LLO in patient
+      cells directly indicates loss of the Man(6) to Man(7) mannosyltransferase step.
+    action: ACCEPT
+    reason: The Man(6)GlcNAc(2) accumulation, plus functional complementation of yeast alg9,
+      supports ALG9&#39;s Man(6)-acceptor alpha-1,2-mannosyltransferase activity; a core molecular
+      function. Experimental annotation, full text read by curator.
+    supported_by:
+    - reference_id: PMID:15148656
+      supporting_text: accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures
+- term:
+    id: GO:0052926
+    label: dol-P-Man:Man(6)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity
+  evidence_type: IGI
+  original_reference_id: PMID:15945070
+  qualifier: enables
+  review:
+    summary: Second IGI (yeast complementation) supporting the Man(6)-acceptor alpha-1,2-
+      mannosyltransferase activity (seventh-mannose addition, EC 2.4.1.259), with DolPP-GlcNAc2Man6
+      accumulating in the patient&#39;s fibroblasts.
+    action: ACCEPT
+    reason: Independent genetic evidence for the Man(6)GlcNAc(2)-PP-Dol mannosyltransferase
+      activity; corroborates the core molecular function.
+    supported_by:
+    - reference_id: PMID:15945070
+      supporting_text: accumulation of the DolPP-GlcNAc2Man6 and
+- term:
+    id: GO:0000026
+    label: alpha-1,2-mannosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446215
+  qualifier: enables
+  review:
+    summary: Reactome TAS for the alpha-1,2-mannosyltransferase activity, specifically the reaction
+      in which ALG9 adds the seventh mannose to the (GlcNAc)2(Man)6(PP-Dol)1 precursor in the ER
+      lumen. Correct but at the generic parent level.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Correct activity, but the generic parent of the EC-specific GO:0052926 term that
+      precisely captures this Man(6)-acceptor reaction; retained as accurate-but-general.
+    supported_by:
+    - reference_id: Reactome:R-HSA-446215
+      supporting_text: The seventh mannose is added to the N-glycan precursor.
+- term:
+    id: GO:0000026
+    label: alpha-1,2-mannosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446216
+  qualifier: enables
+  review:
+    summary: Reactome TAS for the alpha-1,2-mannosyltransferase activity, specifically the reaction
+      in which ALG9 adds the last (ninth) mannose to the (GlcNAc)2(Man)8(PP-Dol)1 precursor in the
+      ER lumen. Correct but at the generic parent level.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Correct activity, but the generic parent of the EC-specific GO:0052918 term that
+      precisely captures this Man(8)-acceptor reaction; retained as accurate-but-general.
+    supported_by:
+    - reference_id: Reactome:R-HSA-446216
+      supporting_text: The last mannose is added to the N-glycan precursor.
+- term:
+    id: GO:0000026
+    label: alpha-1,2-mannosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-4720478
+  qualifier: enables
+  review:
+    summary: Reactome TAS derived from the disease reaction &#34;Defective ALG9 does not add the
+      seventh mannose&#34;, asserting the normal alpha-1,2-mannosyltransferase activity of ALG9.
+      Correct but generic.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Correct activity but the generic parent of the specific EC-mapped terms; retained as
+      accurate-but-general.
+    supported_by:
+    - reference_id: Reactome:R-HSA-4720478
+      supporting_text: It adds the 7th and 9th mannose moieties to LLO.
+- term:
+    id: GO:0000026
+    label: alpha-1,2-mannosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9035514
+  qualifier: enables
+  review:
+    summary: Reactome TAS derived from the disease reaction &#34;Defective ALG9 does not add the last
+      mannose&#34;, asserting the normal alpha-1,2-mannosyltransferase activity of ALG9. Correct but
+      generic.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Correct activity but the generic parent of the specific EC-mapped terms; retained as
+      accurate-but-general.
+    supported_by:
+    - reference_id: Reactome:R-HSA-9035514
+      supporting_text: It adds the 7th and 9th mannose moieties to LLO.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-4720478
+  qualifier: located_in
+  review:
+    summary: Reactome TAS localizing ALG9 to the ER membrane, from the CDG disease reaction. Agrees
+      with all other ER membrane evidence.
+    action: ACCEPT
+    reason: Consistent ER membrane localization; ALG9&#39;s lumenal mannose additions occur at the ER
+      membrane.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9035514
+  qualifier: located_in
+  review:
+    summary: Reactome TAS localizing ALG9 to the ER membrane, from the CDG disease reaction. Agrees
+      with all other ER membrane evidence.
+    action: ACCEPT
+    reason: Consistent ER membrane localization for this multi-pass membrane enzyme.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomics (HDA) detected ALG9 in an NK-cell membrane-proteome study.
+      Consistent with ALG9 being an integral membrane protein but far less specific than the
+      ER membrane annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ALG9 is a multi-pass membrane protein, so detection in a membrane proteome is
+      expected, but the generic membrane term is uninformative relative to the well-supported
+      ER membrane localization. Kept as accurate-but-general.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: Isolated membranes were
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: Multi-pass membrane protein
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446215
+  qualifier: located_in
+  review:
+    summary: Reactome TAS localizing ALG9 to the ER membrane, from the seventh-mannose transfer
+      reaction. Agrees with all other ER membrane evidence.
+    action: ACCEPT
+    reason: Consistent ER membrane localization.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446216
+  qualifier: located_in
+  review:
+    summary: Reactome TAS localizing ALG9 to the ER membrane, from the last-mannose transfer
+      reaction. Agrees with all other ER membrane evidence.
+    action: ACCEPT
+    reason: Consistent ER membrane localization.
+    supported_by:
+    - reference_id: file:human/ALG9/ALG9-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+core_functions:
+- description: Dol-P-Man-dependent alpha-1,2-mannosyltransferase adding the seventh mannose onto
+    Man(6)GlcNAc(2)-PP-dolichol during lumenal LLO assembly (EC 2.4.1.259)
+  molecular_function:
+    id: GO:0052926
+    label: dol-P-Man:Man(6)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  - id: GO:0006487
+    label: protein N-linked glycosylation
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: file:human/ALG9/ALG9-uniprot.txt
+    supporting_text: the addition of the seventh and ninth alpha-1,2-linked
+  - reference_id: PMID:15148656
+    supporting_text: accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures
+- description: Dol-P-Man-dependent alpha-1,2-mannosyltransferase adding the ninth (last) mannose
+    onto Man(8)GlcNAc(2)-PP-dolichol during lumenal LLO assembly (EC 2.4.1.261)
+  molecular_function:
+    id: GO:0052918
+    label: dol-P-Man:Man(8)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006488
+    label: dolichol-linked oligosaccharide biosynthetic process
+  - id: GO:0006487
+    label: protein N-linked glycosylation
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: file:human/ALG9/ALG9-uniprot.txt
+    supporting_text: the addition of the seventh and ninth alpha-1,2-linked
+  - reference_id: PMID:15148656
+    supporting_text: accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:15148656
+  title: &#39;Identification and functional analysis of a defect in the human ALG9 gene:
+    definition of congenital disorder of glycosylation type IL.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract-only cache. Establishes ALG9 as the alpha-1,2-mannosyltransferase
+      whose deficiency (E523K) accumulates GlcNAc2Man6/GlcNAc2Man8 LLO and defines CDG-IL;
+      confirmed by yeast complementation. Supports the MF, LLO-biosynthesis BP, and
+      N-glycosylation IMP annotations.
+- id: PMID:15945070
+  title: &#39;CDG-IL: an infant with a novel mutation in the ALG9 gene and additional
+    phenotypic features.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Abstract-only cache. Second CDG-IL patient (p.Y286C); DolPP-GlcNAc2Man6/Man8
+      accumulation and yeast complementation independently corroborate ALG9&#39;s LLO
+      mannosyltransferase function and role in N-glycosylation.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput NK-cell membrane proteomics; supports only the generic
+      membrane localization, not a specific ALG9 function.
+- id: Reactome:R-HSA-446193
+  title: Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide,
+    LLO) and transfer to a nascent protein
+  findings: []
+- id: Reactome:R-HSA-446215
+  title: ALG9 transfers Man to N-glycan precursor (GlcNAc)2 (Man)6 (PP-Dol)1
+  findings: []
+- id: Reactome:R-HSA-446216
+  title: ALG9 transfers Man to N-glycan precursor (GlcNAc)2 (Man)8 (PP-Dol)1
+  findings: []
+- id: Reactome:R-HSA-4720478
+  title: Defective ALG9 does not add the seventh mannose to the N-glycan precursor
+  findings: []
+- id: Reactome:R-HSA-9035514
+  title: Defective ALG9 does not add the last mannose to the N-glycan precursor
+  findings: []
+- id: file:human/ALG9/ALG9-uniprot.txt
+  title: UniProtKB entry Q9H6U8 (ALG9_HUMAN), Alpha-1,2-mannosyltransferase ALG9
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -285,7 +285,7 @@
 
     <section class="toolbar">
         <input class="search" type="search" placeholder="Filter modules" data-module-search>
-        <div class="count"><span data-visible-count>135</span> / 135 modules</div>
+        <div class="count"><span data-visible-count>136</span> / 136 modules</div>
     </section>
 
     <div class="table-wrap">
@@ -2592,6 +2592,29 @@ The regulatory structure is transcribed from the biosustain Maud kinetic model `
                         0
                     </td>
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/n_glycan_llo_assembly_cytoplasmic.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="N-glycan LLO assembly II — ER-lumenal face + glucosylation (to Glc3Man9GlcNAc2-PP-dolichol); ALG3/ALG9/ALG12/ALG6/ALG8/ALG10">
+                        <a class="module-name" href="n_glycan_llo_assembly_lumenal.html">N-glycan LLO assembly II — ER-lumenal face + glucosylation (to Glc3Man9GlcNAc2-PP-dolichol); ALG3/ALG9/ALG12/ALG6/ALG8/ALG10</a><span class="module-id">MODULE:n_glycan_llo_assembly_lumenal</span>                        <span class="module-desc">After the Man5GlcNAc2-PP-dolichol intermediate is flipped from the cytoplasmic to the lumenal face of the endoplasmic-reticulum membrane (by the...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">After the Man5GlcNAc2-PP-dolichol intermediate is flipped from the cytoplasmic to the lumenal face of the endoplasmic-reticulum membrane (by the RFT1 flippase), the dolichol-linked oligosaccharide (LLO) is completed inside the ER lumen to the mature Glc3Man9GlcNAc2-PP-dolichol donor for protein N-linked glycosylation. Unlike the cytoplasmic-face steps, the lumenal glycosyltransferases use lipid-linked donors: dolichyl-phosphate-mannose (Dol-P-Man) for the mannose additions and dolichyl-phosphate-glucose (Dol-P-Glc) for the glucose additions. Four mannoses are added: ALG3 (alpha-1,3) adds the sixth mannose, ALG9 (alpha-1,2) adds the seventh and, later, the ninth mannose, and ALG12 (alpha-1,6) adds the eighth, giving Man9GlcNAc2-PP-dolichol. Three glucoses then cap the glycan: ALG6 (alpha-1,3) adds the first glucose, ALG8 (alpha-1,3) the second, and ALG10 (alpha-1,2) the third and terminal glucose, producing the mature Glc3Man9GlcNAc2-PP-dolichol. The terminal glucose is the recognition signal for efficient transfer of the glycan to nascent proteins by the oligosaccharyltransferase (and, after transfer, for glucosidase trimming and calnexin/calreticulin quality control). Inherited defects in each step cause a congenital disorder of glycosylation (CDG type I): ALG3-CDG (CDG-Id), ALG9-CDG (CDG-Il / Gillessen-Kaesbach-Nishimura syndrome), ALG12-CDG (CDG-Ig), ALG6-CDG (CDG-Ic, one of the commonest CDG-I subtypes) and ALG8-CDG (CDG-Ih).</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="2">                        <div class="concepts">                            <span class="pill">dolichol-linked oligosaccharide biosynthetic process</span>                            <span class="pill">protein N-linked glycosylation</span>                        </div>                    </td>
+                    <td class="num">8</td>
+                    <td class="num">7</td>
+                    <td class="num">7</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">6</td>                    <td class="num" data-sort-value="6">
+                        6/6
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/n_glycan_llo_assembly_lumenal.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="NLR signaling pathway module">
                         <a class="module-name" href="nlr_signaling.html">NLR signaling pathway module</a><span class="module-id">MODULE:nlr_signaling</span>                        <span class="module-desc">Nucleotide-binding leucine-rich-repeat receptors detect intracellular perturbations and assemble RIPK-, ASC-, or caspase-containing signaling...</span>                        <details class="module-desc-more">

--- a/pages/modules/n_glycan_llo_assembly_lumenal.html
+++ b/pages/modules/n_glycan_llo_assembly_lumenal.html
@@ -1,0 +1,1075 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>N-glycan LLO assembly II — ER-lumenal face + glucosylation (to Glc3Man9GlcNAc2-PP-dolichol); ALG3/ALG9/ALG12/ALG6/ALG8/ALG10 - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / N-glycan LLO assembly II — ER-lumenal face + glucosylation (to Glc3Man9GlcNAc2-PP-dolichol); ALG3/ALG9/ALG12/ALG6/ALG8/ALG10
+    </nav>
+
+    <header class="header">
+        <h1>N-glycan LLO assembly II — ER-lumenal face + glucosylation (to Glc3Man9GlcNAc2-PP-dolichol); ALG3/ALG9/ALG12/ALG6/ALG8/ALG10</h1>            <p class="description">After the Man5GlcNAc2-PP-dolichol intermediate is flipped from the cytoplasmic to the lumenal face of the endoplasmic-reticulum membrane (by the RFT1 flippase), the dolichol-linked oligosaccharide (LLO) is completed inside the ER lumen to the mature Glc3Man9GlcNAc2-PP-dolichol donor for protein N-linked glycosylation. Unlike the cytoplasmic-face steps, the lumenal glycosyltransferases use lipid-linked donors: dolichyl-phosphate-mannose (Dol-P-Man) for the mannose additions and dolichyl-phosphate-glucose (Dol-P-Glc) for the glucose additions. Four mannoses are added: ALG3 (alpha-1,3) adds the sixth mannose, ALG9 (alpha-1,2) adds the seventh and, later, the ninth mannose, and ALG12 (alpha-1,6) adds the eighth, giving Man9GlcNAc2-PP-dolichol. Three glucoses then cap the glycan: ALG6 (alpha-1,3) adds the first glucose, ALG8 (alpha-1,3) the second, and ALG10 (alpha-1,2) the third and terminal glucose, producing the mature Glc3Man9GlcNAc2-PP-dolichol. The terminal glucose is the recognition signal for efficient transfer of the glycan to nascent proteins by the oligosaccharyltransferase (and, after transfer, for glucosidase trimming and calnexin/calreticulin quality control). Inherited defects in each step cause a congenital disorder of glycosylation (CDG type I): ALG3-CDG (CDG-Id), ALG9-CDG (CDG-Il / Gillessen-Kaesbach-Nishimura syndrome), ALG12-CDG (CDG-Ig), ALG6-CDG (CDG-Ic, one of the commonest CDG-I subtypes) and ALG8-CDG (CDG-Ih).</p>        <div class="meta-row"><span class="pill">MODULE:n_glycan_llo_assembly_lumenal</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/n_glycan_llo_assembly_lumenal.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>dolichol-linked oligosaccharide biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006488" target="_blank" rel="noopener">GO:0006488</a></span>                <span class="descriptor">
+            <span>protein N-linked glycosylation</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006487" target="_blank" rel="noopener">GO:0006487</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006488" target="_blank" rel="noopener">GO:0006488</a><div><strong>dolichol-linked oligosaccharide biosynthetic process</strong></div><div>The module is grounded in dolichol-linked oligosaccharide biosynthetic process (GO:0006488); it covers the lumenal-face completion of the LLO to Glc3Man9GlcNAc2-PP-dolichol.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006487" target="_blank" rel="noopener">GO:0006487</a><div><strong>protein N-linked glycosylation</strong></div><div>The mature glucosylated LLO is the donor for protein N-linked glycosylation (GO:0006487); each enzyme&#39;s loss reduces N-glycan occupancy (CDG type I).</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-446193</span><div><strong>Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide, LLO) and transfer to a nascent protein</strong></div><div>Step order, intermediates and reaction stoichiometries follow the human Reactome LLO biosynthesis sub-pathway (R-HSA-446188/446215/446198/446216/446202/446189 for the lumenal steps).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ALG3/ALG3-ai-review.yaml</span><div><strong>ALG3 gene review (human)</strong></div><div>The first lumenal mannose (6th, alpha-1,3) step (UniProtKB:Q92685, GO:0052925) matches the completed human ALG3 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ALG9/ALG9-ai-review.yaml</span><div><strong>ALG9 gene review (human)</strong></div><div>The 7th- and 9th-mannose (alpha-1,2) steps (UniProtKB:Q9H6U8, GO:0052926/GO:0052918) match the completed human ALG9 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ALG12/ALG12-ai-review.yaml</span><div><strong>ALG12 gene review (human)</strong></div><div>The 8th-mannose (alpha-1,6) step (UniProtKB:Q9BV10, GO:0052917) matches the completed human ALG12 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ALG6/ALG6-ai-review.yaml</span><div><strong>ALG6 gene review (human)</strong></div><div>The first-glucose (alpha-1,3) step (UniProtKB:Q9Y672, GO:0042281) matches the completed human ALG6 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ALG8/ALG8-ai-review.yaml</span><div><strong>ALG8 gene review (human)</strong></div><div>The second-glucose (alpha-1,3) step (UniProtKB:Q9BVK2, GO:0042283) matches the completed human ALG8 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ALG10/ALG10-ai-review.yaml</span><div><strong>ALG10 gene review (human)</strong></div><div>The third/terminal-glucose (alpha-1,2) step (UniProtKB:Q5BKT4, GO:0106073) matches the completed human ALG10 review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">8</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">7</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">7</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:n_glycan_llo_assembly_lumenal</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(6/6 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        6 complete review(s) &middot;
+                        0 with deep research &middot;
+                        0 missing review &middot;
+                        6 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>ALG10
+                                        <span class="muted term-id">Q5BKT4</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>ALG12
+                                        <span class="muted term-id">Q9BV10</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>ALG3
+                                        <span class="muted term-id">Q92685</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>ALG6
+                                        <span class="muted term-id">Q9Y672</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>ALG8
+                                        <span class="muted term-id">Q9BVK2</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>ALG9
+                                        <span class="muted term-id">Q9H6U8</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-n_glycan_llo_assembly_lumenal">N-glycan LLO assembly, lumenal face + glucosylation (to Glc3Man9GlcNAc2-PP-dolichol)</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">n_glycan_llo_assembly_lumenal</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. 6th mannose (alpha-1,3), first lumenal step</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-alg3_step">Man5GlcNAc2-PP-dolichol to Man6GlcNAc2-PP-dolichol</a><span class="pill type">Reaction</span><span class="tree-id">alg3_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-alg3_activity">ALG3: Dol-P-Man alpha-1,3-mannosyltransferase</a>
+                                <span class="tree-id">Family: ALG3 mannosyltransferase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. 7th mannose (alpha-1,2)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-alg9_step7">Man6GlcNAc2-PP-dolichol to Man7GlcNAc2-PP-dolichol</a><span class="pill type">Reaction</span><span class="tree-id">alg9_step7</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-alg9_activity_m7">ALG9: Dol-P-Man alpha-1,2-mannosyltransferase (7th Man)</a>
+                                <span class="tree-id">Family: ALG9/ALG12 Dol-P-Man mannosyltransferase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. 8th mannose (alpha-1,6)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-alg12_step">Man7GlcNAc2-PP-dolichol to Man8GlcNAc2-PP-dolichol</a><span class="pill type">Reaction</span><span class="tree-id">alg12_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-alg12_activity">ALG12: Dol-P-Man alpha-1,6-mannosyltransferase</a>
+                                <span class="tree-id">Family: ALG9/ALG12 Dol-P-Man mannosyltransferase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. 9th mannose (alpha-1,2) — completes Man9</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-alg9_step9">Man8GlcNAc2-PP-dolichol to Man9GlcNAc2-PP-dolichol</a><span class="pill type">Reaction</span><span class="tree-id">alg9_step9</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-alg9_activity_m9">ALG9: Dol-P-Man alpha-1,2-mannosyltransferase (9th Man)</a>
+                                <span class="tree-id">Family: ALG9/ALG12 Dol-P-Man mannosyltransferase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">5. 1st glucose (alpha-1,3)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-alg6_step">Man9GlcNAc2-PP-dolichol to Glc1Man9GlcNAc2-PP-dolichol</a><span class="pill type">Reaction</span><span class="tree-id">alg6_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-alg6_activity">ALG6: Dol-P-Glc alpha-1,3-glucosyltransferase</a>
+                                <span class="tree-id">Family: ALG6/ALG8 Dol-P-Glc glucosyltransferase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">6. 2nd glucose (alpha-1,3)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-alg8_step">Glc1Man9GlcNAc2-PP-dolichol to Glc2Man9GlcNAc2-PP-dolichol</a><span class="pill type">Reaction</span><span class="tree-id">alg8_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-alg8_activity">ALG8: Dol-P-Glc alpha-1,3-glucosyltransferase</a>
+                                <span class="tree-id">Family: ALG6/ALG8 Dol-P-Glc glucosyltransferase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">7. 3rd/terminal glucose (alpha-1,2) — mature LLO</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-alg10_step">Glc2Man9GlcNAc2-PP-dolichol to Glc3Man9GlcNAc2-PP-dolichol (mature LLO)</a><span class="pill type">Reaction</span><span class="tree-id">alg10_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-alg10_activity">ALG10: Dol-P-Glc alpha-1,2-glucosyltransferase</a>
+                                <span class="tree-id">Family: ALG10 Dol-P-Glc alpha-1,2-glucosyltransferase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>lumenal side of endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0098553" target="_blank" rel="noopener">GO:0098553</a></span>                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-n_glycan_llo_assembly_lumenal">
+        <div class="node-heading">
+            <span class="node-title">N-glycan LLO assembly, lumenal face + glucosylation (to Glc3Man9GlcNAc2-PP-dolichol)</span><span class="pill type">Metabolic Pathway</span><span class="pill">n_glycan_llo_assembly_lumenal</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>dolichol-linked oligosaccharide biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006488" target="_blank" rel="noopener">GO:0006488</a></span>                <span class="descriptor">
+            <span>protein N-linked glycosylation</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006487" target="_blank" rel="noopener">GO:0006487</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>lumenal side of endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0098553" target="_blank" rel="noopener">GO:0098553</a></span>                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>
+
+            </div>
+        <p class="muted small">Lumenal-face + glucosylation segment of dolichol-linked oligosaccharide (LLO) assembly, grounded to the human enzymes ALG3 (UniProtKB:Q92685, GO:0052925, EC 2.4.1.258), ALG9 (Q9H6U8, GO:0052926 + GO:0052918, EC 2.4.1.259/261), ALG12 (Q9BV10, GO:0052917, EC 2.4.1.260), ALG6 (Q9Y672, GO:0042281, EC 2.4.1.267), ALG8 (Q9BVK2, GO:0042283, EC 2.4.1.265) and ALG10 (Q5BKT4, GO:0106073, EC 2.4.1.256). GO molecular-function/location terms were taken from the completed human gene reviews and verified against the local go.db; Reactome reaction ids/titles were verified against the local reactome cache (ALG10 has no cached WT Reactome reaction, so its node is grounded on EC 2.4.1.256 and the umbrella pathway R-HSA-446193). Each step uses a PANTHER family selector with the human enzyme as representative so the module generalises across orthologs/paralogs; ALG9/ALG12 share PTHR22760 and ALG6/ALG8 share PTHR12413. ALG9 appears twice (steps 2 and 4) because it is bifunctional (adds both the 7th and 9th mannoses). All lumenal steps use lipid-linked donors — Dol-P-Man for mannoses, Dol-P-Glc for glucoses — supplied by the dolichol/sugar-donor module (DOLK, SRD5A3, DPM1/2/3, MPDU1, ALG5; to follow). Upstream is the cytoplasmic-face module (DPAGT1/ALG13/ALG14/ALG1/ALG2/ALG11 -&gt; Man5GlcNAc2-PP-Dol, flipped by RFT1); downstream the mature Glc3Man9GlcNAc2-PP-Dol is transferred to protein by the oligosaccharyltransferase. Disorders: each step&#39;s loss is a CDG type I (ALG3-, ALG9-, ALG12-, ALG6-, ALG8-CDG; ALG6-CDG/CDG-Ic is one of the commonest).</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-alg3_step">alg3_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-alg9_step7">alg9_step7</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Man6GlcNAc2-PP-dolichol from ALG3 receives the 7th mannose from ALG9.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-alg9_step7">alg9_step7</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-alg12_step">alg12_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Man7GlcNAc2-PP-dolichol receives the 8th mannose from ALG12.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-alg12_step">alg12_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-alg9_step9">alg9_step9</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Man8GlcNAc2-PP-dolichol receives the 9th mannose from ALG9, completing Man9.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-alg9_step9">alg9_step9</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-alg6_step">alg6_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Man9GlcNAc2-PP-dolichol receives the first glucose from ALG6.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-alg6_step">alg6_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-alg8_step">alg8_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Glc1Man9GlcNAc2-PP-dolichol receives the second glucose from ALG8.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-alg8_step">alg8_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-alg10_step">alg10_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Glc2Man9GlcNAc2-PP-dolichol receives the terminal glucose from ALG10, giving the mature LLO.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: 6th mannose (alpha-1,3), first lumenal step</div>
+                <section class="node-detail depth-1" id="node-alg3_step">
+        <div class="node-heading">
+            <span class="node-title">Man5GlcNAc2-PP-dolichol to Man6GlcNAc2-PP-dolichol</span><span class="pill type">Reaction</span><span class="pill">alg3_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-alg3_activity">
+        <div class="annoton-title">ALG3: Dol-P-Man alpha-1,3-mannosyltransferase</div>
+        <div class="small muted">alg3_activity</div>            <div class="small"><strong>Participant:</strong> Family: ALG3 mannosyltransferase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>ALG3 mannosyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12646" target="_blank" rel="noopener">PANTHER:PTHR12646</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ALG3 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q92685/entry" target="_blank" rel="noopener">UniProtKB:Q92685</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dol-P-Man:Man(5)GlcNAc(2)-PP-Dol alpha-1,3-mannosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0052925" target="_blank" rel="noopener">GO:0052925</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>dolichyl-phosphate-mannose (Dol-P-Man)</span></span>                            <span class="descriptor">
+            <span>Man5GlcNAc2-PP-dolichol</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>Man6GlcNAc2-PP-dolichol</span></span>                            <span class="descriptor">
+            <span>dolichyl phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">First lumenal mannose; deficiency = ALG3-CDG (CDG-Id).</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: 7th mannose (alpha-1,2)</div>
+                <section class="node-detail depth-1" id="node-alg9_step7">
+        <div class="node-heading">
+            <span class="node-title">Man6GlcNAc2-PP-dolichol to Man7GlcNAc2-PP-dolichol</span><span class="pill type">Reaction</span><span class="pill">alg9_step7</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-alg9_activity_m7">
+        <div class="annoton-title">ALG9: Dol-P-Man alpha-1,2-mannosyltransferase (7th Man)</div>
+        <div class="small muted">alg9_activity_m7</div>            <div class="small"><strong>Participant:</strong> Family: ALG9/ALG12 Dol-P-Man mannosyltransferase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>ALG9/ALG12 Dol-P-Man mannosyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR22760" target="_blank" rel="noopener">PANTHER:PTHR22760</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ALG9 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9H6U8/entry" target="_blank" rel="noopener">UniProtKB:Q9H6U8</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dol-P-Man:Man(6)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0052926" target="_blank" rel="noopener">GO:0052926</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>dolichyl-phosphate-mannose (Dol-P-Man)</span></span>                            <span class="descriptor">
+            <span>Man6GlcNAc2-PP-dolichol</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>Man7GlcNAc2-PP-dolichol</span></span>                            <span class="descriptor">
+            <span>dolichyl phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">7th mannose; ALG9 is bifunctional and later adds the 9th mannose. Deficiency = ALG9-CDG (CDG-Il) / Gillessen-Kaesbach-Nishimura syndrome.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: 8th mannose (alpha-1,6)</div>
+                <section class="node-detail depth-1" id="node-alg12_step">
+        <div class="node-heading">
+            <span class="node-title">Man7GlcNAc2-PP-dolichol to Man8GlcNAc2-PP-dolichol</span><span class="pill type">Reaction</span><span class="pill">alg12_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-alg12_activity">
+        <div class="annoton-title">ALG12: Dol-P-Man alpha-1,6-mannosyltransferase</div>
+        <div class="small muted">alg12_activity</div>            <div class="small"><strong>Participant:</strong> Family: ALG9/ALG12 Dol-P-Man mannosyltransferase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>ALG9/ALG12 Dol-P-Man mannosyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR22760" target="_blank" rel="noopener">PANTHER:PTHR22760</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ALG12 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9BV10/entry" target="_blank" rel="noopener">UniProtKB:Q9BV10</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dol-P-Man:Man(7)GlcNAc(2)-PP-Dol alpha-1,6-mannosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0052917" target="_blank" rel="noopener">GO:0052917</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>dolichyl-phosphate-mannose (Dol-P-Man)</span></span>                            <span class="descriptor">
+            <span>Man7GlcNAc2-PP-dolichol</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>Man8GlcNAc2-PP-dolichol</span></span>                            <span class="descriptor">
+            <span>dolichyl phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">8th mannose; deficiency = ALG12-CDG (CDG-Ig).</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 4: 9th mannose (alpha-1,2) — completes Man9</div>
+                <section class="node-detail depth-1" id="node-alg9_step9">
+        <div class="node-heading">
+            <span class="node-title">Man8GlcNAc2-PP-dolichol to Man9GlcNAc2-PP-dolichol</span><span class="pill type">Reaction</span><span class="pill">alg9_step9</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-alg9_activity_m9">
+        <div class="annoton-title">ALG9: Dol-P-Man alpha-1,2-mannosyltransferase (9th Man)</div>
+        <div class="small muted">alg9_activity_m9</div>            <div class="small"><strong>Participant:</strong> Family: ALG9/ALG12 Dol-P-Man mannosyltransferase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>ALG9/ALG12 Dol-P-Man mannosyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR22760" target="_blank" rel="noopener">PANTHER:PTHR22760</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ALG9 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9H6U8/entry" target="_blank" rel="noopener">UniProtKB:Q9H6U8</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dol-P-Man:Man(8)GlcNAc(2)-PP-Dol alpha-1,2-mannosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0052918" target="_blank" rel="noopener">GO:0052918</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>dolichyl-phosphate-mannose (Dol-P-Man)</span></span>                            <span class="descriptor">
+            <span>Man8GlcNAc2-PP-dolichol</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>Man9GlcNAc2-PP-dolichol</span></span>                            <span class="descriptor">
+            <span>dolichyl phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">9th mannose (same enzyme as step 2), completing the Man9 core.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 5: 1st glucose (alpha-1,3)</div>
+                <section class="node-detail depth-1" id="node-alg6_step">
+        <div class="node-heading">
+            <span class="node-title">Man9GlcNAc2-PP-dolichol to Glc1Man9GlcNAc2-PP-dolichol</span><span class="pill type">Reaction</span><span class="pill">alg6_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-alg6_activity">
+        <div class="annoton-title">ALG6: Dol-P-Glc alpha-1,3-glucosyltransferase</div>
+        <div class="small muted">alg6_activity</div>            <div class="small"><strong>Participant:</strong> Family: ALG6/ALG8 Dol-P-Glc glucosyltransferase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>ALG6/ALG8 Dol-P-Glc glucosyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12413" target="_blank" rel="noopener">PANTHER:PTHR12413</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ALG6 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9Y672/entry" target="_blank" rel="noopener">UniProtKB:Q9Y672</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dolichyl pyrophosphate Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042281" target="_blank" rel="noopener">GO:0042281</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>dolichyl-phosphate-glucose (Dol-P-Glc)</span></span>                            <span class="descriptor">
+            <span>Man9GlcNAc2-PP-dolichol</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>Glc1Man9GlcNAc2-PP-dolichol</span></span>                            <span class="descriptor">
+            <span>dolichyl phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">First glucose; deficiency = ALG6-CDG (CDG-Ic, a common CDG-I subtype).</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 6: 2nd glucose (alpha-1,3)</div>
+                <section class="node-detail depth-1" id="node-alg8_step">
+        <div class="node-heading">
+            <span class="node-title">Glc1Man9GlcNAc2-PP-dolichol to Glc2Man9GlcNAc2-PP-dolichol</span><span class="pill type">Reaction</span><span class="pill">alg8_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-alg8_activity">
+        <div class="annoton-title">ALG8: Dol-P-Glc alpha-1,3-glucosyltransferase</div>
+        <div class="small muted">alg8_activity</div>            <div class="small"><strong>Participant:</strong> Family: ALG6/ALG8 Dol-P-Glc glucosyltransferase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>ALG6/ALG8 Dol-P-Glc glucosyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12413" target="_blank" rel="noopener">PANTHER:PTHR12413</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ALG8 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9BVK2/entry" target="_blank" rel="noopener">UniProtKB:Q9BVK2</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dolichyl pyrophosphate Glc1Man9GlcNAc2 alpha-1,3-glucosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042283" target="_blank" rel="noopener">GO:0042283</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>dolichyl-phosphate-glucose (Dol-P-Glc)</span></span>                            <span class="descriptor">
+            <span>Glc1Man9GlcNAc2-PP-dolichol</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>Glc2Man9GlcNAc2-PP-dolichol</span></span>                            <span class="descriptor">
+            <span>dolichyl phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>lumenal side of endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0098553" target="_blank" rel="noopener">GO:0098553</a></span>        </div>            <p class="role-description">Second glucose; deficiency = ALG8-CDG (CDG-Ih).</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 7: 3rd/terminal glucose (alpha-1,2) — mature LLO</div>
+                <section class="node-detail depth-1" id="node-alg10_step">
+        <div class="node-heading">
+            <span class="node-title">Glc2Man9GlcNAc2-PP-dolichol to Glc3Man9GlcNAc2-PP-dolichol (mature LLO)</span><span class="pill type">Reaction</span><span class="pill">alg10_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-alg10_activity">
+        <div class="annoton-title">ALG10: Dol-P-Glc alpha-1,2-glucosyltransferase</div>
+        <div class="small muted">alg10_activity</div>            <div class="small"><strong>Participant:</strong> Family: ALG10 Dol-P-Glc alpha-1,2-glucosyltransferase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>ALG10 Dol-P-Glc alpha-1,2-glucosyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12989" target="_blank" rel="noopener">PANTHER:PTHR12989</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ALG10 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q5BKT4/entry" target="_blank" rel="noopener">UniProtKB:Q5BKT4</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dolichyl pyrophosphate Glc2Man9GlcNAc2 alpha-1,2-glucosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0106073" target="_blank" rel="noopener">GO:0106073</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>dolichyl-phosphate-glucose (Dol-P-Glc)</span></span>                            <span class="descriptor">
+            <span>Glc2Man9GlcNAc2-PP-dolichol</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>Glc3Man9GlcNAc2-PP-dolichol (mature LLO)</span></span>                            <span class="descriptor">
+            <span>dolichyl phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Terminal glucose completing Glc3Man9GlcNAc2-PP-dolichol, the mature LLO transferred to protein by the oligosaccharyltransferase.</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3202 |
| Gene review HTML pages | 3202 |
| Project pages | 1111 |
| Module pages | 137 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
