### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/ABCD4/ABCD4-ai-review.html
+++ b/genes/human/ABCD4/ABCD4-ai-review.html
@@ -1,0 +1,7293 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ABCD4 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ABCD4</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O14678" target="_blank" class="term-link">
+                        O14678
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ABCD4";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O14678" data-a="DESCRIPTION: ABCD4 (cblJ complementation group; formerly PMP69/..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ABCD4 (cblJ complementation group; formerly PMP69/P70R/PXMP1-L) is a half-size ATP-binding cassette (ABC) transporter of subfamily D that exports cobalamin (vitamin B12) from the lysosomal lumen to the cytosol in an ATP-dependent manner. Unlike its peroxisomal paralogs ABCD1-ABCD3, ABCD4 lacks its own organelle-targeting signal; it is co-translationally inserted into the endoplasmic reticulum membrane and requires the lysosomal escort protein LMBD1 (LMBRD1) to translocate to and localize at the lysosomal membrane, where it functions as a homodimer. After transcobalamin-bound cobalamin is endocytosed and degraded in the lysosome, ABCD4 (in concert with LMBD1 and the cytosolic processing protein MMACHC) delivers free cobalamin to the cytosol for conversion to methylcobalamin and adenosylcobalamin, the cofactors of methionine synthase and methylmalonyl-CoA mutase. Loss-of-function mutations cause methylmalonic aciduria and homocystinuria type cblJ (MAHCJ), characterized by failure to release cobalamin from lysosomes and reduced levels of both cobalamin cofactors.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005778" target="_blank" class="term-link">
+                                    GO:0005778
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005778" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) propagation of a peroxisomal-membrane location from the peroxisomal ABCD1-ABCD3 paralogs. ABCD4 is not peroxisomal; it resides in the ER and lysosomal membranes and lacks the N-terminal peroxisomal targeting signal.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence shows ABCD4 localizes to the ER and lysosomal membrane, not peroxisomes, and the original peroxisomal assignment has been overturned (UniProt CAUTION note). This IBA is over-propagated from peroxisomal paralogs and is contradicted by the primary data.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P28288</span>
+
+
+
+                                    <div class="propagation-comment">ABCD3/PMP70, peroxisomal-membrane paralog; peroxisomal location does not transfer to lysosomal/ER ABCD4.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P33897</span>
+
+
+
+                                    <div class="propagation-comment">ABCD1/ALDP, peroxisomal-membrane paralog; peroxisomal location does not transfer to ABCD4.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 was not a peroxisomal protein, but rather, an ER protein</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19010322" target="_blank" class="term-link">
+                                        PMID:19010322
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reticulum (ER), not to peroxisomes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042626" target="_blank" class="term-link">
+                                    GO:0042626
+                                </a>
+                            </span>
+                            <span class="term-label">ATPase-coupled transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0042626" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General ABC-transporter molecular function (ATPase-coupled transmembrane transport) inferred phylogenetically. This is correct for ABCD4 in essence but is more general than the demonstrated cobalamin-specific activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 is an ATP-driven transmembrane transporter, so the parent term is not wrong, but experimental data define its substrate as cobalamin. Replace with the specific ABC-type vitamin B12 transporter activity that is directly supported.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN008319914</span>
+
+
+
+                                    <div class="propagation-comment">Family-level ATPase-coupled transporter activity is true but too broad; ABCD4&#39;s substrate-specific vitamin B12 transporter activity is experimentally established.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015420" target="_blank" class="term-link">
+                                    ABC-type vitamin B12 transporter activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 transports cobalamin from the inside to the outside of liposomes in a manner that is dependent on ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005324" target="_blank" class="term-link">
+                                    GO:0005324
+                                </a>
+                            </span>
+                            <span class="term-label">long-chain fatty acid transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005324" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Long-chain fatty acid transporter activity propagated from the peroxisomal fatty-acyl-CoA transporters ABCD1-ABCD3. ABCD4&#39;s demonstrated substrate is cobalamin, not fatty acids.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The substrate of ABCD4 has been experimentally established as cobalamin; there is no evidence it transports long-chain fatty acids. This IBA is an over-propagation from the peroxisomal ABCD paralogs and is biologically incorrect for ABCD4.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P28288</span>
+
+
+
+                                    <div class="propagation-comment">ABCD3/PMP70 transports long-chain fatty acyl-CoA; ABCD4 diverged to a cobalamin substrate.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P33897</span>
+
+
+
+                                    <div class="propagation-comment">ABCD1/ALDP transports very-long-chain fatty acyl-CoA; substrate does not transfer to ABCD4.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cobalamin inside liposomes is recognized by ABCD4 as substrate and stimulates the ATP hydrolysis of ABCD4</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006635" target="_blank" class="term-link">
+                                    GO:0006635
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid beta-oxidation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0006635" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Fatty acid beta-oxidation is the peroxisomal process served by ABCD1-ABCD3; propagated to ABCD4 phylogenetically. ABCD4 acts in lysosomal cobalamin export, not fatty acid catabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No evidence links ABCD4 to fatty acid beta-oxidation; its established role is in cobalamin transport/metabolism. This IBA is over-propagated from the peroxisomal fatty-acid-transporting paralogs.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P28288</span>
+
+
+
+                                    <div class="propagation-comment">ABCD3/PMP70 feeds peroxisomal beta-oxidation; ABCD4 acts in lysosomal cobalamin export, not fatty acid catabolism.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P33897</span>
+
+
+
+                                    <div class="propagation-comment">ABCD1/ALDP feeds peroxisomal beta-oxidation; role does not transfer to ABCD4.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922874" target="_blank" class="term-link">
+                                        PMID:22922874
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the ATPase activity of ABCD4 may</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015910" target="_blank" class="term-link">
+                                    GO:0015910
+                                </a>
+                            </span>
+                            <span class="term-label">long-chain fatty acid import into peroxisome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0015910" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Peroxisomal long-chain fatty acid import propagated from ABCD1-ABCD3. Both the process (fatty acid import) and the location (peroxisome) are incorrect for ABCD4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 is not peroxisomal and does not transport fatty acids; it exports cobalamin across the lysosomal membrane. This IBA is doubly contradicted by the experimental localization and substrate data.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P28288</span>
+
+
+
+                                    <div class="propagation-comment">ABCD3/PMP70 imports fatty acids into peroxisomes; neither the substrate nor the peroxisomal compartment transfers to ABCD4.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P33897</span>
+
+
+
+                                    <div class="propagation-comment">ABCD1/ALDP imports VLCFA into peroxisomes; process and compartment do not transfer to lysosomal ABCD4.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 was not a peroxisomal protein, but rather, an ER protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042760" target="_blank" class="term-link">
+                                    GO:0042760
+                                </a>
+                            </span>
+                            <span class="term-label">very long-chain fatty acid catabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0042760" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Very-long-chain fatty acid catabolism, the peroxisomal role of ABCD1-ABCD3, propagated to ABCD4. Not supported for ABCD4, whose substrate is cobalamin.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No evidence supports a role for ABCD4 in VLCFA catabolism; this IBA is over-propagated from the peroxisomal ABCD paralogs and is contradicted by the demonstrated cobalamin-transport function.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P33897</span>
+
+
+
+                                    <div class="propagation-comment">ABCD1/ALDP supplies VLCFA for peroxisomal catabolism; role does not transfer to cobalamin-transporting ABCD4.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P28288</span>
+
+
+
+                                    <div class="propagation-comment">ABCD3/PMP70 acts in peroxisomal fatty acid catabolism; not transferable to ABCD4.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cobalamin inside liposomes is recognized by ABCD4 as substrate and stimulates the ATP hydrolysis of ABCD4</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005524" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ATP binding by the nucleotide-binding domain, inferred phylogenetically and consistent with the Walker A/B motifs and demonstrated ATPase-dependent transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 contains a canonical ABC nucleotide-binding domain (Walker A motif, residues 421-428) and its transport activity is ATP-hydrolysis-dependent (K427A Walker A mutant abolishes activity), so ATP binding is well supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 (K427A) had lost transport activity in addition to ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007031" target="_blank" class="term-link">
+                                    GO:0007031
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisome organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0007031" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Peroxisome organization propagated from peroxisomal paralogs. ABCD4 is not a peroxisomal protein and has no established role in peroxisome biogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 localizes to ER/lysosome, not peroxisomes; there is no evidence it participates in peroxisome organization. This IBA is over-propagated from the peroxisomal ABCD subfamily.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P28288</span>
+
+
+
+                                    <div class="propagation-comment">ABCD3/PMP70 is a peroxisomal-membrane protein linked to peroxisome organization; not applicable to lysosomal/ER ABCD4.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:P33897</span>
+
+
+
+                                    <div class="propagation-comment">ABCD1/ALDP is peroxisomal; peroxisome-organization role does not transfer to ABCD4.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19010322" target="_blank" class="term-link">
+                                        PMID:19010322
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reticulum (ER), not to peroxisomes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based ATP binding from the ABC transporter ATP-binding domain signatures. Consistent with the experimentally supported nucleotide-binding domain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro domain signatures (ABC transporter-like ATP-binding domain) correctly identify the nucleotide-binding domain; ATP binding is supported by the Walker A motif and ATPase-dependent transport.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 (K427A) had lost transport activity in addition to ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005765" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt Subcellular Location mapping to the lysosomal membrane, corroborated by multiple experimental studies.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The lysosomal membrane is the functional location of ABCD4, established experimentally; the SubCell IEA is consistent with the direct evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ABCD4/ABCD4-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Lysosome membrane {ECO</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922874" target="_blank" class="term-link">
+                                        PMID:22922874
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in failure to release vitamin B12 from lysosomes, which mimics the cblF defect</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005789" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (multi-method) mapping to the ER membrane. ABCD4 is co-translationally inserted into the ER before LMBD1-dependent translocation to lysosomes, so ER membrane is a genuine (biosynthetic-intermediate) location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental studies show endogenous ABCD4 resides in both the ER and lysosomal membranes, the ER being the site of synthesis/insertion prior to LMBD1-mediated lysosomal targeting.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 was not a peroxisomal protein, but rather, an ER protein</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19010322" target="_blank" class="term-link">
+                                        PMID:19010322
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">P70R-HA was localized to the endoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015420" target="_blank" class="term-link">
+                                    GO:0015420
+                                </a>
+                            </span>
+                            <span class="term-label">ABC-type vitamin B12 transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000003
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0015420" data-r="GO_REF:0000003" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> EC 7.6.2.8 (ABC-type vitamin B12 transporter) mapped to the specific GO molecular function. This matches the experimentally demonstrated cobalamin transport activity of ABCD4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core molecular function of ABCD4, independently supported by direct in vitro transport assays. The EC-to-GO mapping is correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 transports cobalamin from the inside to the outside of liposomes in a manner that is dependent on ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic membrane localization from InterPro transmembrane-domain signatures. Correct but uninformative given the specific lysosomal/ER membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 is a multi-pass membrane protein, so &#34;membrane&#34; is not wrong, but it is subsumed by the more specific lysosomal membrane and ER membrane annotations and adds no information.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ABCD4/ABCD4-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Lysosome membrane {ECO</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0016887" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ATP hydrolysis activity from InterPro ABC ATP-binding domain signatures. Directly supported by ATPase assays on purified, reconstituted ABCD4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reconstituted ABCD4 exhibits ATPase activity that is stimulated by luminal cobalamin and abolished by the Walker A K427A mutation, confirming ATP hydrolysis as an intrinsic activity coupled to transport.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cobalamin inside liposomes is recognized by ABCD4 as substrate and stimulates the ATP hydrolysis of ABCD4</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055085" target="_blank" class="term-link">
+                                    GO:0055085
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0055085" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic transmembrane transport from InterPro. Correct but far more general than the specific cobalamin transport process ABCD4 mediates.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 does mediate transmembrane transport, but this is a high-level parent of the specific and better-supported cobalamin transport annotation; it is uninformative on its own.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 transports cobalamin from the inside to the outside of liposomes in a manner that is dependent on ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140359" target="_blank" class="term-link">
+                                    GO:0140359
+                                </a>
+                            </span>
+                            <span class="term-label">ABC-type transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0140359" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General ABC-type transporter activity from InterPro ABC signatures. True but more general than the specific ABC-type vitamin B12 transporter activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 is an ABC-type transporter, so the term is not wrong, but the substrate-specific GO:0015420 (ABC-type vitamin B12 transporter activity) is experimentally established and preferred; this parent term over-annotates.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 transports cobalamin from the inside to the outside of liposomes in a manner that is dependent on ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005515" data-r="PMID:27456980" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI capturing the ABCD4-LMBD1 (LMBRD1, Q9NUN5) interaction. This is a functionally important interaction (LMBD1 escorts ABCD4 from the ER to the lysosome), but the bare &#34;protein binding&#34; term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The underlying interaction with LMBD1 is real and biologically central, but &#34;protein binding&#34; conveys no specific molecular function. Per curation guidelines, such bare GO:0005515 IPIs should not be treated as core; the functional partnership is captured in the description and core functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">this translocation depends on the lysosomal targeting ability of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; IPI from a proteome-scale interactome screen (BioPlex) capturing the FAM234B (A2RU67) interaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput interactome hit with an uninformative term; no specific molecular function is defined and the physiological relevance of the FAM234B hit is unestablished.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                                        PMID:28514442
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28572511
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Clinical or ATPase domain mutations in ABCD4 disrupt the int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005515" data-r="PMID:28572511" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI capturing the ABCD4-LMBD1 interaction demonstrated by a live-cell FRET assay. Functionally important but the bare term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ABCD4-LMBD1 interaction is real and central to ABCD4 targeting and function, but &#34;protein binding&#34; is non-informative; the partnership is captured elsewhere in the review.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link">
+                                        PMID:28572511
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we demonstrated selective</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; IPI from a proteome-scale interactome screen (BioPlex 3.0) capturing the FAM234B (A2RU67) interaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput interactome hit with an uninformative term; no specific molecular function is defined.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0042802" data-r="PMID:27456980" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Self-interaction (homodimerization) of ABCD4, consistent with its function as a half-size ABC transporter that operates as a homodimer.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 is a half-transporter that assembles into a homodimer to form the functional unit, so identical protein binding is genuine and biologically meaningful, but it is a structural/assembly property rather than the core catalytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consistent in mass with dimeric ABCD4</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0042802" data-r="PMID:40205054" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Self-interaction of ABCD4 detected in a multimodal cell-mapping/interactome study, consistent with homodimer assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supports the homodimeric assembly of ABCD4; genuine but a structural property rather than the core transport function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                                        PMID:40205054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9758881
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0015889" data-r="Reactome:R-HSA-9758881" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted involvement in cobalamin transport (dietary cobalamin uptake pathway). This is the core biological process of ABCD4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cobalamin transport across the lysosomal membrane is the established core role of ABCD4, independently supported by experimental transport and disease data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 plays a key role in the transport of cobalamin from the lysosomal lumen to the cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9758890
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0015889" data-r="Reactome:R-HSA-9758890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted involvement in cobalamin transport (transport of RCbl within the body). Core biological process of ABCD4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicate assertion of the core cobalamin-transport role from a related Reactome pathway; well supported by experimental and clinical evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 plays a key role in the transport of cobalamin from the lysosomal lumen to the cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015420" target="_blank" class="term-link">
+                                    GO:0015420
+                                </a>
+                            </span>
+                            <span class="term-label">ABC-type vitamin B12 transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0015420" data-r="PMID:33845046" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct in vitro demonstration that purified, reconstituted ABCD4 transports cobalamin across liposomal membranes in an ATP-dependent manner. This is the definitive core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The strongest evidence for ABCD4&#39;s function - reconstituted ABCD4 transports cobalamin (Km 426 uM), the activity is ATPase-dependent, and the Walker A K427A mutant abolishes both ATPase and transport. Defines the exact core MF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 transports cobalamin from the inside to the outside of liposomes in a manner that is dependent on ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922874" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922874
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in ABCD4 cause a new inborn error of vitamin B12 m...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005765" data-r="PMID:22922874" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental demonstration that ABCD4 colocalizes with the lysosomal markers LAMP1 and LMBD1, establishing lysosomal membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental localization to the lysosomal membrane, the functional site of ABCD4&#39;s cobalamin-export activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922874" target="_blank" class="term-link">
+                                        PMID:22922874
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in failure to release vitamin B12 from lysosomes, which mimics the cblF defect</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25535791
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and interaction analyses of two human lysosomal...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005765" data-r="PMID:25535791" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Lysosomal vitamin B12 transporter localization from the ABCD4/LMBD1 purification and interaction study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent, well-supported lysosomal membrane localization; ABCD4 is one of the two lysosomal membrane B12 transporters characterized in this work.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link">
+                                        PMID:25535791
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mutations in human LMBRD1 and ABCD4 prevent lysosomal export of vitamin B(12) to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28572511
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Clinical or ATPase domain mutations in ABCD4 disrupt the int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005765" data-r="PMID:28572511" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Lysosomal targeting of ABCD4 (dependent on LMBD1 co-expression) shown by live-cell assays.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental support for lysosomal membrane localization; the study also shows this localization depends on interaction with LMBD1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link">
+                                        PMID:28572511
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">targeting depends on co-expression of, and interaction with, LMBD1. These data</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005765" data-r="PMID:33845046" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ABCD4 is active (transports cobalamin) at the lysosomal membrane, its physiological site of action.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The lysosomal membrane is where ABCD4 performs its cobalamin-export function; is_active_in is appropriate given the demonstrated transport activity and lysosomal localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 is located on lysosomal membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0009235" data-r="PMID:33845046" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ABCD4 participates in cobalamin metabolism by exporting lysosomal cobalamin to the cytosol for cofactor synthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> By delivering cobalamin to the cytosol for conversion to methylcobalamin and adenosylcobalamin, ABCD4 is a core component of intracellular cobalamin metabolism; directly supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cobalamin is released into the cytosol and converted into two active cofactors: methylcobalamin and adenosylcobalamin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015420" target="_blank" class="term-link">
+                                    GO:0015420
+                                </a>
+                            </span>
+                            <span class="term-label">ABC-type vitamin B12 transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0015420" data-r="PMID:33845046" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay support (IDA) for the ABC-type vitamin B12 transporter activity of ABCD4. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same definitive in vitro transport evidence; the exact GOA MF term for ABCD4&#39;s core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 transports cobalamin from the inside to the outside of liposomes in a manner that is dependent on ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005765" data-r="PMID:33845046" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay lysosomal membrane localization of ABCD4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with all other experimental evidence for lysosomal membrane localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 is located on lysosomal membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005515" data-r="PMID:33845046" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI capturing the ABCD4-LMBD1 (Q9NUN5) interaction from the in vitro pull-down/crosslinking analyses. Functionally central but the bare term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The purified ABCD4-LMBD1 interaction (1:1 stoichiometry) is genuine and biologically important, but &#34;protein binding&#34; is a non-informative term; the partnership is captured in the description and core functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">purified ABCD4 and LMBD1 interact each other with a 1:1 stoichiometry</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015420" target="_blank" class="term-link">
+                                    GO:0015420
+                                </a>
+                            </span>
+                            <span class="term-label">ABC-type vitamin B12 transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0015420" data-r="PMID:33845046" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype support (IMP) for the ABC-type vitamin B12 transporter activity - disease and engineered mutations abolish cobalamin transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Loss-of-function mutations (e.g. Walker A K427A, clinical Y319C) abolish cobalamin transport, providing mutant-phenotype evidence for this core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 (K427A) had lost transport activity in addition to ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0015889" data-r="PMID:33845046" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype support for ABCD4&#39;s role in cobalamin transport. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mutations that impair ABCD4 abolish cobalamin transport across the lysosomal membrane, directly implicating ABCD4 in this process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 plays a key role in the transport of cobalamin from the lysosomal lumen to the cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005765" data-r="PMID:27456980" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay lysosomal membrane localization; ABCD4 localizes to lysosomes upon LMBD1-mediated translocation from the ER.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported experimental localization; the study establishes that lysosomal localization is achieved via LMBD1-dependent translocation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">this translocation depends on the lysosomal targeting ability of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005789" data-r="PMID:27456980" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay ER membrane localization; ABCD4 is an ER-resident protein before LMBD1-dependent lysosomal targeting.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally demonstrated ER localization (biosynthetic-intermediate site); endogenous ABCD4 distributes between ER and lysosome, with LMBD1 controlling the lysosomal fraction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 was not a peroxisomal protein, but rather, an ER protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25535791
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and interaction analyses of two human lysosomal...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005515" data-r="PMID:25535791" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI capturing the ABCD4 interactions with LMBD1 (Q9NUN5) and MMACHC (Q9Y4U1) from SPR/biophysical analyses. Both are functionally central (lysosomal cobalamin-to-cytosol trafficking complex), but the bare term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ABCD4-LMBD1 and ABCD4-MMACHC interactions (both low nanomolar affinity) are genuine and important for vectorial cobalamin delivery, but &#34;protein binding&#34; is non-informative; the interactions are captured in the description and core functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link">
+                                        PMID:25535791
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 and ABCD4 interact with low</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link">
+                                        PMID:25535791
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMACHC also interacts with LMBD1 and ABCD4 with low nanomolar affinity.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
+                                    GO:0005777
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+                        <span class="not-badge" title="This is a NOT annotation - gene does NOT have this function">NOT</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19010322" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19010322
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    70-kDa peroxisomal membrane protein related protein (P70R/AB...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005777" data-r="PMID:19010322" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NOT annotation - ABCD4 does NOT localize to peroxisomes. This study showed P70R/ABCD4 localizes to the ER, not peroxisomes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct negative annotation directly supported by the primary data overturning the original peroxisomal assignment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19010322" target="_blank" class="term-link">
+                                        PMID:19010322
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reticulum (ER), not to peroxisomes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
+                                    GO:0005777
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+                        <span class="not-badge" title="This is a NOT annotation - gene does NOT have this function">NOT</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005777" data-r="PMID:27456980" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NOT annotation - ABCD4 does NOT localize to peroxisomes; it is an ER/lysosomal protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct negative annotation; the study explicitly shows ABCD4 is not a peroxisomal protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 was not a peroxisomal protein, but rather, an ER protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
+                                    GO:0005777
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14533738" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14533738
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Targeting of the human adrenoleukodystrophy protein to the p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005777" data-r="PMID:14533738" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Positive peroxisome localization reflecting the superseded early view of ABCD4 as a peroxisomal half-transporter. This paper is principally about ALDP (ABCD1) peroxisomal targeting and uses a PMP69/ABCD4 fragment fused to reporter.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The peroxisomal localization of full-length ABCD4 has been overturned by subsequent direct evidence (ER/lysosome; NOT|peroxisome IDAs; UniProt CAUTION). This positive peroxisome annotation is contradicted by the current consensus and should be removed in favor of the negated peroxisome and lysosomal annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 was not a peroxisomal protein, but rather, an ER protein</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19010322" target="_blank" class="term-link">
+                                        PMID:19010322
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reticulum (ER), not to peroxisomes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
+                                    GO:0005777
+                                </a>
+                            </span>
+                            <span class="term-label">peroxisome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9302272" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9302272
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of a fourth half ABC transporter in the human...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005777" data-r="PMID:9302272" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Original identification of ABCD4 (P70R) as a fourth half ABC transporter in the human peroxisomal membrane - the initial, now-superseded peroxisomal assignment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This early peroxisomal-membrane localization has been overturned; ABCD4 is an ER/lysosomal protein lacking a peroxisomal targeting signal (UniProt CAUTION; PMID:19010322, PMID:27456980). The positive peroxisome annotation is contradicted by the subsequent NOT|peroxisome experimental data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19010322" target="_blank" class="term-link">
+                                        PMID:19010322
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reticulum (ER), not to peroxisomes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-5683325
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005765" data-r="Reactome:R-HSA-5683325" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted lysosomal membrane localization (defective-transport event). Consistent with all experimental localization data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct lysosomal membrane localization, agreeing with the direct experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922874" target="_blank" class="term-link">
+                                        PMID:22922874
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in failure to release vitamin B12 from lysosomes, which mimics the cblF defect</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-5223313
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005765" data-r="Reactome:R-HSA-5223313" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted lysosomal membrane localization (RCbl transport in gut mucosal cells). Consistent with experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct lysosomal membrane localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 is located on lysosomal membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9759206
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005765" data-r="Reactome:R-HSA-9759206" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-asserted lysosomal membrane localization (ABCD4-LMBRD1 transports RCbl from lysosomal lumen to cytosol). Consistent with experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct lysosomal membrane localization, matching the functional ABCD4-LMBRD1 export event.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 is located on lysosomal membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922874" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922874
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in ABCD4 cause a new inborn error of vitamin B12 m...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0009235" data-r="PMID:22922874" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype support for ABCD4&#39;s role in cobalamin metabolism - mutations cause a new inborn error of vitamin B12 metabolism (cblJ).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 mutations cause failure to release cobalamin from lysosomes and impaired cofactor synthesis, directly implicating ABCD4 in cobalamin metabolism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22922874" target="_blank" class="term-link">
+                                        PMID:22922874
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the ATPase activity of ABCD4 may</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9266848" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9266848
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Primary structure of human PMP69, a putative peroxisomal ABC...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0005524" data-r="PMID:9266848" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author statement of ATP binding based on the ABC-half-transporter sequence identification. Consistent with the experimentally confirmed nucleotide-binding domain.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP binding is supported by the canonical ABC nucleotide-binding domain and by subsequent ATPase-dependent transport assays; the NAS assertion is correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9266848" target="_blank" class="term-link">
+                                        PMID:9266848
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABC-half-transporters require a partner</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9266848" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9266848
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Primary structure of human PMP69, a putative peroxisomal ABC...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0016020" data-r="PMID:9266848" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author statement of membrane localization from the original cloning paper. Generic; subsumed by the specific lysosomal/ER membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 is a membrane protein, so this is not wrong, but the term is uninformative relative to the specific lysosomal membrane and ER membrane annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ABCD4/ABCD4-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Lysosome membrane {ECO</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042626" target="_blank" class="term-link">
+                                    GO:0042626
+                                </a>
+                            </span>
+                            <span class="term-label">ATPase-coupled transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9266848" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9266848
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Primary structure of human PMP69, a putative peroxisomal ABC...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0042626" data-r="PMID:9266848" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated ABC (ATPase-coupled) transporter activity from the original cloning paper. Correct at the family level but more general than the demonstrated cobalamin-specific activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The essence (ATP-driven transmembrane transport) is correct, but the specific ABC-type vitamin B12 transporter activity is now experimentally established and should be used.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015420" target="_blank" class="term-link">
+                                    ABC-type vitamin B12 transporter activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 transports cobalamin from the inside to the outside of liposomes in a manner that is dependent on ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043190" target="_blank" class="term-link">
+                                    GO:0043190
+                                </a>
+                            </span>
+                            <span class="term-label">ATP-binding cassette (ABC) transporter complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9266848" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9266848
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Primary structure of human PMP69, a putative peroxisomal ABC...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0043190" data-r="PMID:9266848" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author statement that ABCD4 is part of an ABC transporter complex. ABCD4 is a half-transporter that functions as a homodimer (and associates with LMBD1), so it is part of an ABC transporter complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As a half-size ABC transporter, ABCD4 assembles into a homodimeric functional complex, consistent with this cellular-component annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9266848" target="_blank" class="term-link">
+                                        PMID:9266848
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABC-half-transporter to constitute a functional complex, either as a homodimer</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055085" target="_blank" class="term-link">
+                                    GO:0055085
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9266848" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9266848
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Primary structure of human PMP69, a putative peroxisomal ABC...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O14678" data-a="GO:0055085" data-r="PMID:9266848" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author statement of transmembrane transport involvement. Correct but far more general than the specific cobalamin transport process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ABCD4 mediates transmembrane transport, but this high-level parent is subsumed by the specific and better-supported cobalamin transport annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 transports cobalamin from the inside to the outside of liposomes in a manner that is dependent on ATPase activity</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP-dependent lysosomal cobalamin (vitamin B12) exporter that hydrolyzes ATP to translocate cobalamin from the lysosomal lumen to the cytosol, functioning as a homodimer at the lysosomal membrane.</h3>
+                <span class="vote-buttons" data-g="O14678" data-a="FUNCTION: ATP-dependent lysosomal cobalamin (vitamin B12) ex..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015420" target="_blank" class="term-link">
+                            ABC-type vitamin B12 transporter activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                cobalamin metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                lysosomal membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                PMID:33845046
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">ABCD4 transports cobalamin from the inside to the outside of liposomes in a manner that is dependent on ATPase activity</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ABCD4/ABCD4-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">from the lysosomal lumen to the cytosol in an ATP-dependent manner</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Intrinsic ATPase / nucleotide-binding activity of the ABC transporter nucleotide-binding domain that energizes cobalamin transport; ATP binding and hydrolysis are coupled to substrate translocation (Walker A K427 is essential).</h3>
+                <span class="vote-buttons" data-g="O14678" data-a="FUNCTION: Intrinsic ATPase / nucleotide-binding activity of ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                            ATP hydrolysis activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                lysosomal membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                PMID:33845046
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the cobalamin inside liposomes is recognized by ABCD4 as substrate and stimulates the ATP hydrolysis of ABCD4</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000003.md" target="_blank" class="term-link">
+                            GO_REF:0000003
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on Enzyme Commission mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14533738" target="_blank" class="term-link">
+                            PMID:14533738
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Targeting of the human adrenoleukodystrophy protein to the peroxisomal membrane by an internal region containing a highly conserved motif.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19010322" target="_blank" class="term-link">
+                            PMID:19010322
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">70-kDa peroxisomal membrane protein related protein (P70R/ABCD4) localizes to endoplasmic reticulum not peroxisomes, and NH2-terminal hydrophobic property determines the subcellular localization of ABC subfamily D proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22922874" target="_blank" class="term-link">
+                            PMID:22922874
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in ABCD4 cause a new inborn error of vitamin B12 metabolism.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link">
+                            PMID:25535791
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Purification and interaction analyses of two human lysosomal vitamin B12 transporters: LMBD1 and ABCD4.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                            PMID:27456980
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Translocation of the ABC transporter ABCD4 from the endoplasmic reticulum to lysosomes requires the escort protein LMBD1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link">
+                            PMID:28572511
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Clinical or ATPase domain mutations in ABCD4 disrupt the interaction between the vitamin B(12)-trafficking proteins ABCD4 and LMBD1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                            PMID:33845046
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The lysosomal protein ABCD4 can transport vitamin B(12) across liposomal membranes in vitro.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9266848" target="_blank" class="term-link">
+                            PMID:9266848
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Primary structure of human PMP69, a putative peroxisomal ABC-transporter.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9302272" target="_blank" class="term-link">
+                            PMID:9302272
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of a fourth half ABC transporter in the human peroxisomal membrane.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-5223313
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ABCD4:LMBRD1 transports RCbl from lysosomal lumen to cytosol (gut mucosal cells)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-5683325
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective ABCD4:LMBRD1 does not transport Cbl from lysosomal lumen to cytosol</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9758881
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Uptake of dietary cobalamins into enterocytes</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9758890
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Transport of RCbl within the body</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9759206
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ABCD4:LMBRD1 transports RCbl from lysosomal lumen to cytosol</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ABCD4/ABCD4-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ABCD4 UniProtKB record (O14678)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ABCD4-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O14678" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="abcd4-o14678-review-notes">ABCD4 (O14678) review notes</h1>
+<p>Human ABCD4 / cblJ complementation group. ATP-binding cassette sub-family D member 4,<br />
+also historically PMP69 / P70R / PXMP1-L. HGNC:68. Chromosome 14q24.3, 606 aa.</p>
+<h2 id="verified-biology-grounded-in-uniprot-o14678-cached-pmids">Verified biology (grounded in UniProt O14678 + cached PMIDs)</h2>
+<ul>
+<li>
+<p><strong>Molecular function</strong>: ATP-dependent lysosomal cobalamin (vitamin B12) exporter.<br />
+  ABC transporter that hydrolyzes ATP and translocates cobalamin across the lysosomal<br />
+  membrane. EC 7.6.2.8; Rhea RHEA:17873 (R-cob(III)alamin(out) + ATP + H2O =<br />
+  R-cob(III)alamin(in) + ADP + Pi + H+). Km 426 uM cobalamin, Vmax 667 pmol/min/mg<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/33845046">PMID:33845046</a>. Reconstituted purified ABCD4 in liposomes transported cobalamin<br />
+  from inside to outside in an ATPase-dependent manner; the Walker A K427A mutant lost<br />
+  both ATPase and transport activity <a href="https://pubmed.ncbi.nlm.nih.gov/33845046">PMID:33845046</a>. GOA current MF term:<br />
+  GO:0015420 "ABC-type vitamin B12 transporter activity" (EXP/IDA/IMP, PMID:33845046).</p>
+</li>
+<li>
+<p><strong>Biological process</strong>: cobalamin transport (GO:0015889) / cobalamin metabolic<br />
+  process (GO:0009235). After transcobalamin-bound cobalamin is endocytosed and<br />
+  degraded in the lysosome, ABCD4 exports free cobalamin to the cytosol where MMACHC<br />
+  processes it into methylcobalamin (methionine synthase cofactor) and<br />
+  adenosylcobalamin (methylmalonyl-CoA mutase cofactor) [PMID:33845046, PMID:27456980].</p>
+</li>
+<li>
+<p><strong>Localization</strong>: Lysosomal membrane (GO:0005765), multi-pass. Also ER membrane<br />
+  (GO:0005789) as biosynthetic intermediate — ABCD4 lacks its own peroxisomal<br />
+  targeting signal (no NH2-terminal hydrophilic region), is co-translationally<br />
+  inserted into the ER, and requires the escort protein LMBD1 (LMBRD1, Q9NUN5) to<br />
+  translocate to the lysosomal membrane [PMID:27456980, PMID:19010322, PMID:28572511].<br />
+  NOT peroxisomal — original peroxisomal assignment (PMID:9266848, PMID:9302272,<br />
+  PMID:14533738) was overturned; UniProt CAUTION note documents this. NOT|located_in<br />
+  peroxisome is experimentally supported [PMID:19010322, PMID:27456980].</p>
+</li>
+<li>
+<p><strong>Interactions</strong>: LMBD1/LMBRD1 (Q9NUN5) escort/complex partner (functional, well<br />
+  supported); MMACHC (cytosolic B12 processing) forms trafficking complex<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25535791">PMID:25535791</a>. Homodimer (self, O14678). High-throughput interactome hits:<br />
+  FAM234B (A2RU67), LMBRD1, self — from proteome-scale screens (PMID:28514442,<br />
+  PMID:33961781, PMID:40205054); these are bare "protein binding" and non-informative.</p>
+</li>
+<li>
+<p><strong>Disease</strong>: Methylmalonic aciduria and homocystinuria type cblJ (MAHCJ, MIM:614857).<br />
+  Failure to release cobalamin from lysosomes; decreased AdoCbl and MeCbl<br />
+  [PMID:22922874, PMID:23141461, PMID:28572511].</p>
+</li>
+</ul>
+<h2 id="curation-decisions">Curation decisions</h2>
+<p>Peroxisomal/fatty-acid IBA cluster (GO:0005778 peroxisomal membrane; GO:0005324<br />
+long-chain FA transmembrane transporter; GO:0006635 FA beta-oxidation; GO:0015910<br />
+LCFA import into peroxisome; GO:0042760 VLCFA catabolic process; GO:0007031<br />
+peroxisome organization) are propagated from peroxisomal ABCD1-3 paralogs and are<br />
+contradicted by ABCD4's demonstrated lysosomal localization and cobalamin (not fatty<br />
+acid) substrate. These are wrong for ABCD4 -&gt; REMOVE (IBA over-propagation, arguable<br />
+on biological grounds per curation policy). GO:0005777 peroxisome IDA (PMID:14533738,<br />
+PMID:9302272) reflects the superseded early assignment; the NOT|peroxisome IDAs and<br />
+UniProt CAUTION overrule them.</p>
+<p>Core: GO:0015420 (MF) + GO:0015889 cobalamin transport / GO:0009235 cobalamin<br />
+metabolic process (BP) + GO:0005765 lysosomal membrane (CC); ATP binding / ATP<br />
+hydrolysis secondary.</p>
+<p>Deep research: falcon out of credits (HTTP 402); grounded in UniProt + GOA + cached PMIDs.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O14678
+gene_symbol: ABCD4
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: ABCD4 (cblJ complementation group; formerly PMP69/P70R/PXMP1-L) is a half-size
+  ATP-binding cassette (ABC) transporter of subfamily D that exports cobalamin (vitamin
+  B12) from the lysosomal lumen to the cytosol in an ATP-dependent manner. Unlike its
+  peroxisomal paralogs ABCD1-ABCD3, ABCD4 lacks its own organelle-targeting signal; it
+  is co-translationally inserted into the endoplasmic reticulum membrane and requires
+  the lysosomal escort protein LMBD1 (LMBRD1) to translocate to and localize at the
+  lysosomal membrane, where it functions as a homodimer. After transcobalamin-bound
+  cobalamin is endocytosed and degraded in the lysosome, ABCD4 (in concert with LMBD1
+  and the cytosolic processing protein MMACHC) delivers free cobalamin to the cytosol
+  for conversion to methylcobalamin and adenosylcobalamin, the cofactors of methionine
+  synthase and methylmalonyl-CoA mutase. Loss-of-function mutations cause methylmalonic
+  aciduria and homocystinuria type cblJ (MAHCJ), characterized by failure to release
+  cobalamin from lysosomes and reduced levels of both cobalamin cofactors.
+existing_annotations:
+- term:
+    id: GO:0005778
+    label: peroxisomal membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) propagation of a peroxisomal-membrane location from the
+      peroxisomal ABCD1-ABCD3 paralogs. ABCD4 is not peroxisomal; it resides in the ER
+      and lysosomal membranes and lacks the N-terminal peroxisomal targeting signal.
+    action: REMOVE
+    reason: Direct experimental evidence shows ABCD4 localizes to the ER and lysosomal
+      membrane, not peroxisomes, and the original peroxisomal assignment has been
+      overturned (UniProt CAUTION note). This IBA is over-propagated from peroxisomal
+      paralogs and is contradicted by the primary data.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: UniProtKB:P28288
+        comment: ABCD3/PMP70, peroxisomal-membrane paralog; peroxisomal location does
+          not transfer to lysosomal/ER ABCD4.
+      - source_id: UniProtKB:P33897
+        comment: ABCD1/ALDP, peroxisomal-membrane paralog; peroxisomal location does not
+          transfer to ABCD4.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &#34;ABCD4 was not a peroxisomal protein, but rather, an ER protein&#34;
+    - reference_id: PMID:19010322
+      supporting_text: &#34;reticulum (ER), not to peroxisomes.&#34;
+- term:
+    id: GO:0042626
+    label: ATPase-coupled transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: General ABC-transporter molecular function (ATPase-coupled transmembrane
+      transport) inferred phylogenetically. This is correct for ABCD4 in essence but
+      is more general than the demonstrated cobalamin-specific activity.
+    action: MODIFY
+    reason: ABCD4 is an ATP-driven transmembrane transporter, so the parent term is not
+      wrong, but experimental data define its substrate as cobalamin. Replace with the
+      specific ABC-type vitamin B12 transporter activity that is directly supported.
+    proposed_replacement_terms:
+    - id: GO:0015420
+      label: ABC-type vitamin B12 transporter activity
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN008319914
+        comment: Family-level ATPase-coupled transporter activity is true but too broad;
+          ABCD4&#39;s substrate-specific vitamin B12 transporter activity is experimentally
+          established.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 transports cobalamin from the inside to the outside of liposomes
+        in a manner that is dependent on ATPase activity
+- term:
+    id: GO:0005324
+    label: long-chain fatty acid transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Long-chain fatty acid transporter activity propagated from the peroxisomal
+      fatty-acyl-CoA transporters ABCD1-ABCD3. ABCD4&#39;s demonstrated substrate is
+      cobalamin, not fatty acids.
+    action: REMOVE
+    reason: The substrate of ABCD4 has been experimentally established as cobalamin;
+      there is no evidence it transports long-chain fatty acids. This IBA is an
+      over-propagation from the peroxisomal ABCD paralogs and is biologically incorrect
+      for ABCD4.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: UniProtKB:P28288
+        comment: ABCD3/PMP70 transports long-chain fatty acyl-CoA; ABCD4 diverged to a
+          cobalamin substrate.
+      - source_id: UniProtKB:P33897
+        comment: ABCD1/ALDP transports very-long-chain fatty acyl-CoA; substrate does not
+          transfer to ABCD4.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: the cobalamin inside liposomes is recognized by ABCD4 as substrate
+        and stimulates the ATP hydrolysis of ABCD4
+- term:
+    id: GO:0006635
+    label: fatty acid beta-oxidation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Fatty acid beta-oxidation is the peroxisomal process served by ABCD1-ABCD3;
+      propagated to ABCD4 phylogenetically. ABCD4 acts in lysosomal cobalamin export,
+      not fatty acid catabolism.
+    action: REMOVE
+    reason: No evidence links ABCD4 to fatty acid beta-oxidation; its established role
+      is in cobalamin transport/metabolism. This IBA is over-propagated from the
+      peroxisomal fatty-acid-transporting paralogs.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: UniProtKB:P28288
+        comment: ABCD3/PMP70 feeds peroxisomal beta-oxidation; ABCD4 acts in lysosomal
+          cobalamin export, not fatty acid catabolism.
+      - source_id: UniProtKB:P33897
+        comment: ABCD1/ALDP feeds peroxisomal beta-oxidation; role does not transfer to
+          ABCD4.
+    supported_by:
+    - reference_id: PMID:22922874
+      supporting_text: &#34;the ATPase activity of ABCD4 may&#34;
+- term:
+    id: GO:0015910
+    label: long-chain fatty acid import into peroxisome
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Peroxisomal long-chain fatty acid import propagated from ABCD1-ABCD3. Both
+      the process (fatty acid import) and the location (peroxisome) are incorrect for
+      ABCD4.
+    action: REMOVE
+    reason: ABCD4 is not peroxisomal and does not transport fatty acids; it exports
+      cobalamin across the lysosomal membrane. This IBA is doubly contradicted by the
+      experimental localization and substrate data.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: UniProtKB:P28288
+        comment: ABCD3/PMP70 imports fatty acids into peroxisomes; neither the substrate
+          nor the peroxisomal compartment transfers to ABCD4.
+      - source_id: UniProtKB:P33897
+        comment: ABCD1/ALDP imports VLCFA into peroxisomes; process and compartment do
+          not transfer to lysosomal ABCD4.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &#34;ABCD4 was not a peroxisomal protein, but rather, an ER protein&#34;
+- term:
+    id: GO:0042760
+    label: very long-chain fatty acid catabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Very-long-chain fatty acid catabolism, the peroxisomal role of ABCD1-ABCD3,
+      propagated to ABCD4. Not supported for ABCD4, whose substrate is cobalamin.
+    action: REMOVE
+    reason: No evidence supports a role for ABCD4 in VLCFA catabolism; this IBA is
+      over-propagated from the peroxisomal ABCD paralogs and is contradicted by the
+      demonstrated cobalamin-transport function.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: UniProtKB:P33897
+        comment: ABCD1/ALDP supplies VLCFA for peroxisomal catabolism; role does not
+          transfer to cobalamin-transporting ABCD4.
+      - source_id: UniProtKB:P28288
+        comment: ABCD3/PMP70 acts in peroxisomal fatty acid catabolism; not transferable
+          to ABCD4.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: the cobalamin inside liposomes is recognized by ABCD4 as substrate
+        and stimulates the ATP hydrolysis of ABCD4
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: ATP binding by the nucleotide-binding domain, inferred phylogenetically and
+      consistent with the Walker A/B motifs and demonstrated ATPase-dependent transport.
+    action: ACCEPT
+    reason: ABCD4 contains a canonical ABC nucleotide-binding domain (Walker A motif,
+      residues 421-428) and its transport activity is ATP-hydrolysis-dependent (K427A
+      Walker A mutant abolishes activity), so ATP binding is well supported.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 (K427A) had lost transport activity in addition to ATPase activity
+- term:
+    id: GO:0007031
+    label: peroxisome organization
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Peroxisome organization propagated from peroxisomal paralogs. ABCD4 is not
+      a peroxisomal protein and has no established role in peroxisome biogenesis.
+    action: REMOVE
+    reason: ABCD4 localizes to ER/lysosome, not peroxisomes; there is no evidence it
+      participates in peroxisome organization. This IBA is over-propagated from the
+      peroxisomal ABCD subfamily.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      source_entities:
+      - source_id: UniProtKB:P28288
+        comment: ABCD3/PMP70 is a peroxisomal-membrane protein linked to peroxisome
+          organization; not applicable to lysosomal/ER ABCD4.
+      - source_id: UniProtKB:P33897
+        comment: ABCD1/ALDP is peroxisomal; peroxisome-organization role does not transfer
+          to ABCD4.
+    supported_by:
+    - reference_id: PMID:19010322
+      supporting_text: &#34;reticulum (ER), not to peroxisomes.&#34;
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro-based ATP binding from the ABC transporter ATP-binding domain
+      signatures. Consistent with the experimentally supported nucleotide-binding
+      domain.
+    action: ACCEPT
+    reason: The InterPro domain signatures (ABC transporter-like ATP-binding domain)
+      correctly identify the nucleotide-binding domain; ATP binding is supported by the
+      Walker A motif and ATPase-dependent transport.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 (K427A) had lost transport activity in addition to ATPase activity
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt Subcellular Location mapping to the lysosomal membrane, corroborated
+      by multiple experimental studies.
+    action: ACCEPT
+    reason: The lysosomal membrane is the functional location of ABCD4, established
+      experimentally; the SubCell IEA is consistent with the direct evidence.
+    supported_by:
+    - reference_id: file:human/ABCD4/ABCD4-uniprot.txt
+      supporting_text: Lysosome membrane {ECO
+    - reference_id: PMID:22922874
+      supporting_text: &#34;in failure to release vitamin B12 from lysosomes, which mimics the cblF defect&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Automated (multi-method) mapping to the ER membrane. ABCD4 is co-translationally
+      inserted into the ER before LMBD1-dependent translocation to lysosomes, so ER
+      membrane is a genuine (biosynthetic-intermediate) location.
+    action: ACCEPT
+    reason: Experimental studies show endogenous ABCD4 resides in both the ER and
+      lysosomal membranes, the ER being the site of synthesis/insertion prior to
+      LMBD1-mediated lysosomal targeting.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &#34;ABCD4 was not a peroxisomal protein, but rather, an ER protein&#34;
+    - reference_id: PMID:19010322
+      supporting_text: &#34;P70R-HA was localized to the endoplasmic&#34;
+- term:
+    id: GO:0015420
+    label: ABC-type vitamin B12 transporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000003
+  qualifier: enables
+  review:
+    summary: EC 7.6.2.8 (ABC-type vitamin B12 transporter) mapped to the specific GO
+      molecular function. This matches the experimentally demonstrated cobalamin
+      transport activity of ABCD4.
+    action: ACCEPT
+    reason: This is the core molecular function of ABCD4, independently supported by
+      direct in vitro transport assays. The EC-to-GO mapping is correct.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 transports cobalamin from the inside to the outside of liposomes
+        in a manner that is dependent on ATPase activity
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: Generic membrane localization from InterPro transmembrane-domain signatures.
+      Correct but uninformative given the specific lysosomal/ER membrane annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ABCD4 is a multi-pass membrane protein, so &#34;membrane&#34; is not wrong, but it
+      is subsumed by the more specific lysosomal membrane and ER membrane annotations
+      and adds no information.
+    supported_by:
+    - reference_id: file:human/ABCD4/ABCD4-uniprot.txt
+      supporting_text: Lysosome membrane {ECO
+- term:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: ATP hydrolysis activity from InterPro ABC ATP-binding domain signatures.
+      Directly supported by ATPase assays on purified, reconstituted ABCD4.
+    action: ACCEPT
+    reason: Reconstituted ABCD4 exhibits ATPase activity that is stimulated by luminal
+      cobalamin and abolished by the Walker A K427A mutation, confirming ATP hydrolysis
+      as an intrinsic activity coupled to transport.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: the cobalamin inside liposomes is recognized by ABCD4 as substrate
+        and stimulates the ATP hydrolysis of ABCD4
+- term:
+    id: GO:0055085
+    label: transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: Generic transmembrane transport from InterPro. Correct but far more general
+      than the specific cobalamin transport process ABCD4 mediates.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ABCD4 does mediate transmembrane transport, but this is a high-level parent
+      of the specific and better-supported cobalamin transport annotation; it is
+      uninformative on its own.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 transports cobalamin from the inside to the outside of liposomes
+        in a manner that is dependent on ATPase activity
+- term:
+    id: GO:0140359
+    label: ABC-type transporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: General ABC-type transporter activity from InterPro ABC signatures. True
+      but more general than the specific ABC-type vitamin B12 transporter activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ABCD4 is an ABC-type transporter, so the term is not wrong, but the
+      substrate-specific GO:0015420 (ABC-type vitamin B12 transporter activity) is
+      experimentally established and preferred; this parent term over-annotates.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 transports cobalamin from the inside to the outside of liposomes
+        in a manner that is dependent on ATPase activity
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:27456980
+  qualifier: enables
+  review:
+    summary: IPI capturing the ABCD4-LMBD1 (LMBRD1, Q9NUN5) interaction. This is a
+      functionally important interaction (LMBD1 escorts ABCD4 from the ER to the
+      lysosome), but the bare &#34;protein binding&#34; term is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The underlying interaction with LMBD1 is real and biologically central, but
+      &#34;protein binding&#34; conveys no specific molecular function. Per curation guidelines,
+      such bare GO:0005515 IPIs should not be treated as core; the functional partnership
+      is captured in the description and core functions.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &#34;this translocation depends on the lysosomal targeting ability of&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: Bare &#34;protein binding&#34; IPI from a proteome-scale interactome screen
+      (BioPlex) capturing the FAM234B (A2RU67) interaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: High-throughput interactome hit with an uninformative term; no specific
+      molecular function is defined and the physiological relevance of the FAM234B hit
+      is unestablished.
+    supported_by:
+    - reference_id: PMID:28514442
+      supporting_text: Architecture of the human interactome defines protein communities
+        and disease networks.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28572511
+  qualifier: enables
+  review:
+    summary: IPI capturing the ABCD4-LMBD1 interaction demonstrated by a live-cell FRET
+      assay. Functionally important but the bare term is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The ABCD4-LMBD1 interaction is real and central to ABCD4 targeting and
+      function, but &#34;protein binding&#34; is non-informative; the partnership is captured
+      elsewhere in the review.
+    supported_by:
+    - reference_id: PMID:28572511
+      supporting_text: &#34;we demonstrated selective&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: Bare &#34;protein binding&#34; IPI from a proteome-scale interactome screen
+      (BioPlex 3.0) capturing the FAM234B (A2RU67) interaction.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: High-throughput interactome hit with an uninformative term; no specific
+      molecular function is defined.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: Dual proteome-scale networks reveal cell-specific remodeling of
+        the human interactome.
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:27456980
+  qualifier: enables
+  review:
+    summary: Self-interaction (homodimerization) of ABCD4, consistent with its function
+      as a half-size ABC transporter that operates as a homodimer.
+    action: KEEP_AS_NON_CORE
+    reason: ABCD4 is a half-transporter that assembles into a homodimer to form the
+      functional unit, so identical protein binding is genuine and biologically
+      meaningful, but it is a structural/assembly property rather than the core
+      catalytic function.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: consistent in mass with dimeric ABCD4
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: Self-interaction of ABCD4 detected in a multimodal cell-mapping/interactome
+      study, consistent with homodimer assembly.
+    action: KEEP_AS_NON_CORE
+    reason: Supports the homodimeric assembly of ABCD4; genuine but a structural
+      property rather than the core transport function.
+    supported_by:
+    - reference_id: PMID:40205054
+      supporting_text: Multimodal cell maps as a foundation for structural and functional
+        genomics.
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9758881
+  qualifier: involved_in
+  review:
+    summary: Reactome-asserted involvement in cobalamin transport (dietary cobalamin
+      uptake pathway). This is the core biological process of ABCD4.
+    action: ACCEPT
+    reason: Cobalamin transport across the lysosomal membrane is the established core
+      role of ABCD4, independently supported by experimental transport and disease data.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 plays a key role in the transport of cobalamin from the
+        lysosomal lumen to the cytosol
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9758890
+  qualifier: involved_in
+  review:
+    summary: Reactome-asserted involvement in cobalamin transport (transport of RCbl
+      within the body). Core biological process of ABCD4.
+    action: ACCEPT
+    reason: Duplicate assertion of the core cobalamin-transport role from a related
+      Reactome pathway; well supported by experimental and clinical evidence.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 plays a key role in the transport of cobalamin from the
+        lysosomal lumen to the cytosol
+- term:
+    id: GO:0015420
+    label: ABC-type vitamin B12 transporter activity
+  evidence_type: EXP
+  original_reference_id: PMID:33845046
+  qualifier: enables
+  review:
+    summary: Direct in vitro demonstration that purified, reconstituted ABCD4 transports
+      cobalamin across liposomal membranes in an ATP-dependent manner. This is the
+      definitive core molecular function.
+    action: ACCEPT
+    reason: The strongest evidence for ABCD4&#39;s function - reconstituted ABCD4 transports
+      cobalamin (Km 426 uM), the activity is ATPase-dependent, and the Walker A K427A
+      mutant abolishes both ATPase and transport. Defines the exact core MF.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 transports cobalamin from the inside to the outside of liposomes
+        in a manner that is dependent on ATPase activity
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: EXP
+  original_reference_id: PMID:22922874
+  qualifier: located_in
+  review:
+    summary: Experimental demonstration that ABCD4 colocalizes with the lysosomal
+      markers LAMP1 and LMBD1, establishing lysosomal membrane localization.
+    action: ACCEPT
+    reason: Directly supported experimental localization to the lysosomal membrane,
+      the functional site of ABCD4&#39;s cobalamin-export activity.
+    supported_by:
+    - reference_id: PMID:22922874
+      supporting_text: &#34;in failure to release vitamin B12 from lysosomes, which mimics the cblF defect&#34;
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: EXP
+  original_reference_id: PMID:25535791
+  qualifier: located_in
+  review:
+    summary: Lysosomal vitamin B12 transporter localization from the ABCD4/LMBD1
+      purification and interaction study.
+    action: ACCEPT
+    reason: Consistent, well-supported lysosomal membrane localization; ABCD4 is one of
+      the two lysosomal membrane B12 transporters characterized in this work.
+    supported_by:
+    - reference_id: PMID:25535791
+      supporting_text: Mutations in human LMBRD1 and ABCD4 prevent lysosomal export of vitamin B(12) to
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: EXP
+  original_reference_id: PMID:28572511
+  qualifier: located_in
+  review:
+    summary: Lysosomal targeting of ABCD4 (dependent on LMBD1 co-expression) shown by
+      live-cell assays.
+    action: ACCEPT
+    reason: Experimental support for lysosomal membrane localization; the study also
+      shows this localization depends on interaction with LMBD1.
+    supported_by:
+    - reference_id: PMID:28572511
+      supporting_text: &#34;targeting depends on co-expression of, and interaction with, LMBD1. These data&#34;
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: IDA
+  original_reference_id: PMID:33845046
+  qualifier: is_active_in
+  review:
+    summary: ABCD4 is active (transports cobalamin) at the lysosomal membrane, its
+      physiological site of action.
+    action: ACCEPT
+    reason: The lysosomal membrane is where ABCD4 performs its cobalamin-export
+      function; is_active_in is appropriate given the demonstrated transport activity
+      and lysosomal localization.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 is located on lysosomal membrane
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:33845046
+  qualifier: involved_in
+  review:
+    summary: ABCD4 participates in cobalamin metabolism by exporting lysosomal cobalamin
+      to the cytosol for cofactor synthesis.
+    action: ACCEPT
+    reason: By delivering cobalamin to the cytosol for conversion to methylcobalamin and
+      adenosylcobalamin, ABCD4 is a core component of intracellular cobalamin metabolism;
+      directly supported.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: &#34;cobalamin is released into the cytosol and converted into two active cofactors: methylcobalamin and adenosylcobalamin&#34;
+- term:
+    id: GO:0015420
+    label: ABC-type vitamin B12 transporter activity
+  evidence_type: IDA
+  original_reference_id: PMID:33845046
+  qualifier: enables
+  review:
+    summary: Direct-assay support (IDA) for the ABC-type vitamin B12 transporter
+      activity of ABCD4. Core molecular function.
+    action: ACCEPT
+    reason: Same definitive in vitro transport evidence; the exact GOA MF term for
+      ABCD4&#39;s core function.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 transports cobalamin from the inside to the outside of liposomes
+        in a manner that is dependent on ATPase activity
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: IDA
+  original_reference_id: PMID:33845046
+  qualifier: located_in
+  review:
+    summary: Direct-assay lysosomal membrane localization of ABCD4.
+    action: ACCEPT
+    reason: Consistent with all other experimental evidence for lysosomal membrane
+      localization.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 is located on lysosomal membrane
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33845046
+  qualifier: enables
+  review:
+    summary: IPI capturing the ABCD4-LMBD1 (Q9NUN5) interaction from the in vitro
+      pull-down/crosslinking analyses. Functionally central but the bare term is
+      uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The purified ABCD4-LMBD1 interaction (1:1 stoichiometry) is genuine and
+      biologically important, but &#34;protein binding&#34; is a non-informative term; the
+      partnership is captured in the description and core functions.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: purified ABCD4 and LMBD1 interact each other with a 1:1 stoichiometry
+- term:
+    id: GO:0015420
+    label: ABC-type vitamin B12 transporter activity
+  evidence_type: IMP
+  original_reference_id: PMID:33845046
+  qualifier: enables
+  review:
+    summary: Mutant-phenotype support (IMP) for the ABC-type vitamin B12 transporter
+      activity - disease and engineered mutations abolish cobalamin transport.
+    action: ACCEPT
+    reason: Loss-of-function mutations (e.g. Walker A K427A, clinical Y319C) abolish
+      cobalamin transport, providing mutant-phenotype evidence for this core molecular
+      function.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 (K427A) had lost transport activity in addition to ATPase activity
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IMP
+  original_reference_id: PMID:33845046
+  qualifier: involved_in
+  review:
+    summary: Mutant-phenotype support for ABCD4&#39;s role in cobalamin transport. Core
+      biological process.
+    action: ACCEPT
+    reason: Mutations that impair ABCD4 abolish cobalamin transport across the lysosomal
+      membrane, directly implicating ABCD4 in this process.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 plays a key role in the transport of cobalamin from the
+        lysosomal lumen to the cytosol
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: IDA
+  original_reference_id: PMID:27456980
+  qualifier: located_in
+  review:
+    summary: Direct-assay lysosomal membrane localization; ABCD4 localizes to lysosomes
+      upon LMBD1-mediated translocation from the ER.
+    action: ACCEPT
+    reason: Well-supported experimental localization; the study establishes that
+      lysosomal localization is achieved via LMBD1-dependent translocation.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &#34;this translocation depends on the lysosomal targeting ability of&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:27456980
+  qualifier: located_in
+  review:
+    summary: Direct-assay ER membrane localization; ABCD4 is an ER-resident protein
+      before LMBD1-dependent lysosomal targeting.
+    action: ACCEPT
+    reason: Experimentally demonstrated ER localization (biosynthetic-intermediate site);
+      endogenous ABCD4 distributes between ER and lysosome, with LMBD1 controlling the
+      lysosomal fraction.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &#34;ABCD4 was not a peroxisomal protein, but rather, an ER protein&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25535791
+  qualifier: enables
+  review:
+    summary: IPI capturing the ABCD4 interactions with LMBD1 (Q9NUN5) and MMACHC (Q9Y4U1)
+      from SPR/biophysical analyses. Both are functionally central (lysosomal
+      cobalamin-to-cytosol trafficking complex), but the bare term is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The ABCD4-LMBD1 and ABCD4-MMACHC interactions (both low nanomolar affinity)
+      are genuine and important for vectorial cobalamin delivery, but &#34;protein binding&#34;
+      is non-informative; the interactions are captured in the description and core
+      functions.
+    supported_by:
+    - reference_id: PMID:25535791
+      supporting_text: &#34;LMBD1 and ABCD4 interact with low&#34;
+    - reference_id: PMID:25535791
+      supporting_text: MMACHC also interacts with LMBD1 and ABCD4 with low nanomolar affinity.
+- term:
+    id: GO:0005777
+    label: peroxisome
+  evidence_type: IDA
+  original_reference_id: PMID:19010322
+  qualifier: located_in
+  negated: true
+  review:
+    summary: NOT annotation - ABCD4 does NOT localize to peroxisomes. This study showed
+      P70R/ABCD4 localizes to the ER, not peroxisomes.
+    action: ACCEPT
+    reason: Correct negative annotation directly supported by the primary data
+      overturning the original peroxisomal assignment.
+    supported_by:
+    - reference_id: PMID:19010322
+      supporting_text: &#34;reticulum (ER), not to peroxisomes.&#34;
+- term:
+    id: GO:0005777
+    label: peroxisome
+  evidence_type: IDA
+  original_reference_id: PMID:27456980
+  qualifier: located_in
+  negated: true
+  review:
+    summary: NOT annotation - ABCD4 does NOT localize to peroxisomes; it is an ER/lysosomal
+      protein.
+    action: ACCEPT
+    reason: Correct negative annotation; the study explicitly shows ABCD4 is not a
+      peroxisomal protein.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &#34;ABCD4 was not a peroxisomal protein, but rather, an ER protein&#34;
+- term:
+    id: GO:0005777
+    label: peroxisome
+  evidence_type: IDA
+  original_reference_id: PMID:14533738
+  qualifier: located_in
+  review:
+    summary: Positive peroxisome localization reflecting the superseded early view of
+      ABCD4 as a peroxisomal half-transporter. This paper is principally about ALDP
+      (ABCD1) peroxisomal targeting and uses a PMP69/ABCD4 fragment fused to reporter.
+    action: REMOVE
+    reason: The peroxisomal localization of full-length ABCD4 has been overturned by
+      subsequent direct evidence (ER/lysosome; NOT|peroxisome IDAs; UniProt CAUTION).
+      This positive peroxisome annotation is contradicted by the current consensus and
+      should be removed in favor of the negated peroxisome and lysosomal annotations.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &#34;ABCD4 was not a peroxisomal protein, but rather, an ER protein&#34;
+    - reference_id: PMID:19010322
+      supporting_text: &#34;reticulum (ER), not to peroxisomes.&#34;
+- term:
+    id: GO:0005777
+    label: peroxisome
+  evidence_type: IDA
+  original_reference_id: PMID:9302272
+  qualifier: located_in
+  review:
+    summary: Original identification of ABCD4 (P70R) as a fourth half ABC transporter in
+      the human peroxisomal membrane - the initial, now-superseded peroxisomal
+      assignment.
+    action: REMOVE
+    reason: This early peroxisomal-membrane localization has been overturned; ABCD4 is
+      an ER/lysosomal protein lacking a peroxisomal targeting signal (UniProt CAUTION;
+      PMID:19010322, PMID:27456980). The positive peroxisome annotation is contradicted
+      by the subsequent NOT|peroxisome experimental data.
+    supported_by:
+    - reference_id: PMID:19010322
+      supporting_text: &#34;reticulum (ER), not to peroxisomes.&#34;
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5683325
+  qualifier: located_in
+  review:
+    summary: Reactome-asserted lysosomal membrane localization (defective-transport
+      event). Consistent with all experimental localization data.
+    action: ACCEPT
+    reason: Correct lysosomal membrane localization, agreeing with the direct
+      experimental evidence.
+    supported_by:
+    - reference_id: PMID:22922874
+      supporting_text: &#34;in failure to release vitamin B12 from lysosomes, which mimics the cblF defect&#34;
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5223313
+  qualifier: located_in
+  review:
+    summary: Reactome-asserted lysosomal membrane localization (RCbl transport in gut
+      mucosal cells). Consistent with experimental data.
+    action: ACCEPT
+    reason: Correct lysosomal membrane localization.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 is located on lysosomal membrane
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9759206
+  qualifier: located_in
+  review:
+    summary: Reactome-asserted lysosomal membrane localization (ABCD4-LMBRD1 transports
+      RCbl from lysosomal lumen to cytosol). Consistent with experimental data.
+    action: ACCEPT
+    reason: Correct lysosomal membrane localization, matching the functional
+      ABCD4-LMBRD1 export event.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 is located on lysosomal membrane
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IMP
+  original_reference_id: PMID:22922874
+  qualifier: involved_in
+  review:
+    summary: Mutant-phenotype support for ABCD4&#39;s role in cobalamin metabolism -
+      mutations cause a new inborn error of vitamin B12 metabolism (cblJ).
+    action: ACCEPT
+    reason: ABCD4 mutations cause failure to release cobalamin from lysosomes and
+      impaired cofactor synthesis, directly implicating ABCD4 in cobalamin metabolism.
+    supported_by:
+    - reference_id: PMID:22922874
+      supporting_text: &#34;the ATPase activity of ABCD4 may&#34;
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: NAS
+  original_reference_id: PMID:9266848
+  qualifier: enables
+  review:
+    summary: Author statement of ATP binding based on the ABC-half-transporter sequence
+      identification. Consistent with the experimentally confirmed nucleotide-binding
+      domain.
+    action: ACCEPT
+    reason: ATP binding is supported by the canonical ABC nucleotide-binding domain and
+      by subsequent ATPase-dependent transport assays; the NAS assertion is correct.
+    supported_by:
+    - reference_id: PMID:9266848
+      supporting_text: &#34;ABC-half-transporters require a partner&#34;
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: NAS
+  original_reference_id: PMID:9266848
+  qualifier: located_in
+  review:
+    summary: Author statement of membrane localization from the original cloning paper.
+      Generic; subsumed by the specific lysosomal/ER membrane annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ABCD4 is a membrane protein, so this is not wrong, but the term is
+      uninformative relative to the specific lysosomal membrane and ER membrane
+      annotations.
+    supported_by:
+    - reference_id: file:human/ABCD4/ABCD4-uniprot.txt
+      supporting_text: Lysosome membrane {ECO
+- term:
+    id: GO:0042626
+    label: ATPase-coupled transmembrane transporter activity
+  evidence_type: NAS
+  original_reference_id: PMID:9266848
+  qualifier: enables
+  review:
+    summary: Author-stated ABC (ATPase-coupled) transporter activity from the original
+      cloning paper. Correct at the family level but more general than the demonstrated
+      cobalamin-specific activity.
+    action: MODIFY
+    reason: The essence (ATP-driven transmembrane transport) is correct, but the specific
+      ABC-type vitamin B12 transporter activity is now experimentally established and
+      should be used.
+    proposed_replacement_terms:
+    - id: GO:0015420
+      label: ABC-type vitamin B12 transporter activity
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 transports cobalamin from the inside to the outside of liposomes
+        in a manner that is dependent on ATPase activity
+- term:
+    id: GO:0043190
+    label: ATP-binding cassette (ABC) transporter complex
+  evidence_type: NAS
+  original_reference_id: PMID:9266848
+  qualifier: part_of
+  review:
+    summary: Author statement that ABCD4 is part of an ABC transporter complex. ABCD4 is
+      a half-transporter that functions as a homodimer (and associates with LMBD1), so
+      it is part of an ABC transporter complex.
+    action: ACCEPT
+    reason: As a half-size ABC transporter, ABCD4 assembles into a homodimeric functional
+      complex, consistent with this cellular-component annotation.
+    supported_by:
+    - reference_id: PMID:9266848
+      supporting_text: &#34;ABC-half-transporter to constitute a functional complex, either as a homodimer&#34;
+- term:
+    id: GO:0055085
+    label: transmembrane transport
+  evidence_type: NAS
+  original_reference_id: PMID:9266848
+  qualifier: involved_in
+  review:
+    summary: Author statement of transmembrane transport involvement. Correct but far
+      more general than the specific cobalamin transport process.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ABCD4 mediates transmembrane transport, but this high-level parent is
+      subsumed by the specific and better-supported cobalamin transport annotation.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: ABCD4 transports cobalamin from the inside to the outside of liposomes
+        in a manner that is dependent on ATPase activity
+core_functions:
+- description: ATP-dependent lysosomal cobalamin (vitamin B12) exporter that hydrolyzes
+    ATP to translocate cobalamin from the lysosomal lumen to the cytosol, functioning as
+    a homodimer at the lysosomal membrane.
+  molecular_function:
+    id: GO:0015420
+    label: ABC-type vitamin B12 transporter activity
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  - id: GO:0009235
+    label: cobalamin metabolic process
+  locations:
+  - id: GO:0005765
+    label: lysosomal membrane
+  supported_by:
+  - reference_id: PMID:33845046
+    supporting_text: ABCD4 transports cobalamin from the inside to the outside of liposomes
+      in a manner that is dependent on ATPase activity
+  - reference_id: file:human/ABCD4/ABCD4-uniprot.txt
+    supporting_text: from the lysosomal lumen to the cytosol in an ATP-dependent manner
+- description: Intrinsic ATPase / nucleotide-binding activity of the ABC transporter
+    nucleotide-binding domain that energizes cobalamin transport; ATP binding and
+    hydrolysis are coupled to substrate translocation (Walker A K427 is essential).
+  molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0005765
+    label: lysosomal membrane
+  supported_by:
+  - reference_id: PMID:33845046
+    supporting_text: the cobalamin inside liposomes is recognized by ABCD4 as substrate
+      and stimulates the ATP hydrolysis of ABCD4
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000003
+  title: Gene Ontology annotation based on Enzyme Commission mapping
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:14533738
+  title: Targeting of the human adrenoleukodystrophy protein to the peroxisomal membrane
+    by an internal region containing a highly conserved motif.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: MISCITED
+    review_notes: Study is about ALDP (ABCD1) peroxisomal targeting; cited to support a
+      peroxisomal localization of ABCD4/PMP69 that is now superseded. Does not support
+      full-length ABCD4 being peroxisomal.
+- id: PMID:19010322
+  title: 70-kDa peroxisomal membrane protein related protein (P70R/ABCD4) localizes
+    to endoplasmic reticulum not peroxisomes, and NH2-terminal hydrophobic property
+    determines the subcellular localization of ABC subfamily D proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Establishes that ABCD4 (P70R) localizes to the ER, not peroxisomes,
+      and that it lacks the N-terminal signal used for peroxisomal targeting.
+- id: PMID:22922874
+  title: Mutations in ABCD4 cause a new inborn error of vitamin B12 metabolism.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Foundational disease paper (cblJ); shows ABCD4 colocalizes with LAMP1
+      and LMBD1 and that ATPase-domain mutations impair function. Abstract-only in cache.
+- id: PMID:25535791
+  title: &#39;Purification and interaction analyses of two human lysosomal vitamin B12
+    transporters: LMBD1 and ABCD4.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Purified ABCD4 and LMBD1 form homodimers and interact with low
+      nanomolar affinity; MMACHC also interacts, supporting a vectorial delivery model.
+- id: PMID:27456980
+  title: Translocation of the ABC transporter ABCD4 from the endoplasmic reticulum
+    to lysosomes requires the escort protein LMBD1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Establishes LMBD1-dependent ER-to-lysosome translocation of ABCD4 and
+      that ABCD4 is not peroxisomal; endogenous ABCD4 splits between ER and lysosome.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Proteome-scale (BioPlex) interactome; source of a bare protein-binding
+      IPI (FAM234B). No specific ABCD4 function established.
+- id: PMID:28572511
+  title: Clinical or ATPase domain mutations in ABCD4 disrupt the interaction between
+    the vitamin B(12)-trafficking proteins ABCD4 and LMBD1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: FRET assay shows selective ABCD4-LMBD1 interaction disrupted by clinical
+      or ATPase-domain mutations; lysosomal targeting depends on LMBD1 interaction.
+- id: PMID:33845046
+  title: The lysosomal protein ABCD4 can transport vitamin B(12) across liposomal
+    membranes in vitro.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Definitive functional paper - reconstituted ABCD4 transports cobalamin
+      ATP-dependently (Km 426 uM); Walker A K427A abolishes ATPase and transport.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Proteome-scale (BioPlex 3.0) interactome; source of a bare
+      protein-binding IPI (FAM234B). No specific ABCD4 function established.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Multimodal interactome/cell-mapping study; source of an identical
+      protein binding (self/homodimer) IPI. No specific ABCD4 function beyond assembly.
+- id: PMID:9266848
+  title: Primary structure of human PMP69, a putative peroxisomal ABC-transporter.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Original cloning of ABCD4 (PMP69) as a putative peroxisomal
+      ABC-half-transporter; the peroxisomal assignment was later superseded.
+- id: PMID:9302272
+  title: Identification of a fourth half ABC transporter in the human peroxisomal
+    membrane.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: DISPUTED
+    review_notes: Original identification of ABCD4 (P70R) as a peroxisomal half ABC
+      transporter; the peroxisomal-membrane localization was overturned by later work.
+- id: Reactome:R-HSA-5223313
+  title: ABCD4:LMBRD1 transports RCbl from lysosomal lumen to cytosol (gut mucosal
+    cells)
+  findings: []
+- id: Reactome:R-HSA-5683325
+  title: Defective ABCD4:LMBRD1 does not transport Cbl from lysosomal lumen to cytosol
+  findings: []
+- id: Reactome:R-HSA-9758881
+  title: Uptake of dietary cobalamins into enterocytes
+  findings: []
+- id: Reactome:R-HSA-9758890
+  title: Transport of RCbl within the body
+  findings: []
+- id: Reactome:R-HSA-9759206
+  title: ABCD4:LMBRD1 transports RCbl from lysosomal lumen to cytosol
+  findings: []
+- id: file:human/ABCD4/ABCD4-uniprot.txt
+  title: ABCD4 UniProtKB record (O14678)
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/AMN/AMN-ai-review.html
+++ b/genes/human/AMN/AMN-ai-review.html
@@ -1,0 +1,5979 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AMN - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>AMN</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9BXJ7" target="_blank" class="term-link">
+                        Q9BXJ7
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "AMN";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9BXJ7" data-a="DESCRIPTION: AMN (amnionless) is a single-pass type I transmemb..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>AMN (amnionless) is a single-pass type I transmembrane glycoprotein that partners cubilin (CUBN) to form the cubam endocytic receptor. Cubilin carries the ligand-binding CUB domains but lacks a transmembrane segment and cytoplasmic endocytosis signals; AMN supplies both, acting as the membrane-anchoring/endocytic co-receptor subunit. AMN is required for the correct N-glycosylation, apical cell-surface targeting and clathrin-mediated internalization of cubilin together with its bound ligands. It is non-enzymatic: its extracellular region docks the amino-terminal region of cubilin (a single AMN chain binding three cubilin subunits), its transmembrane helix anchors the complex, and its cytoplasmic tail contains two redundant FXNPXF internalization motifs that engage the clathrin adaptors ARH (LDLRAP1) and Dab2. Cubam operates at the apical/microvillus (brush border) membrane of ileal enterocytes, where it mediates uptake of dietary vitamin B12 (cobalamin) complexed with intrinsic factor, and of renal proximal tubule cells, where it reabsorbs filtered low-molecular-weight proteins (e.g. albumin, transferrin, apolipoprotein A-I, vitamin D-binding protein). Loss-of-function variants in AMN cause Imerslund-Grasbeck syndrome 2 (megaloblastic anemia 1 with proteinuria), the same selective B12-malabsorption disorder produced by CUBN mutations.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0016324" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cubam (AMN+cubilin) is active at the apical plasma membrane of ileal enterocytes and renal proximal tubule cells; AMN provides the membrane anchor. This is a well-supported core localization consistent with experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IBA localization at the apical plasma membrane is corroborated by direct experimental evidence in the same gene (PMID:14576052 apical cell membrane; PMID:29402915 cell-surface targeting). This is the physiological site of cubam action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                                    GO:0038024
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0038024" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN is the membrane-anchoring/endocytic subunit of the cubam cargo receptor: it anchors the ligand-binding cubilin subunits to the membrane and directs their endocytosis. Cargo receptor activity is the correct molecular-function abstraction for this co-receptor role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cargo receptor activity is the core molecular function. AMN binds the ligand-binding cubilin subunits, anchors them via its transmembrane helix, and internalizes bound cargo (IF-B12, filtered proteins) via clathrin-coated pits. Supported by IBA and by direct experimental annotation from the same paper.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20088845" target="_blank" class="term-link">
+                                        PMID:20088845
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin contains no transmembrane segment and therefore needs the transmembrane region of AMN to be anchored in the plasma membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043235" target="_blank" class="term-link">
+                                    GO:0043235
+                                </a>
+                            </span>
+                            <span class="term-label">signaling receptor complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0043235" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN is part of a receptor complex (cubam), but cubam is a nutrient/cargo endocytic receptor, not a signaling receptor. The &#34;signaling&#34; framing is an over-interpretation; the informative, accurate content is captured by cargo receptor activity and receptor-mediated endocytosis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubam mediates ligand binding and endocytosis (uptake), not signal transduction. There is no evidence AMN participates in a signaling receptor complex; the endocytic-receptor role is the correct one. Marking as over-annotated rather than removing an IBA that reflects a generic &#34;receptor complex&#34; tree assignment.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">ROLE CONFLATION</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001029969</span>
+
+                                    &middot; AMN family node
+
+
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">UniProtKB:Q9BXJ7</span>
+
+                                    &middot; AMN (human)
+
+
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20088845" target="_blank" class="term-link">
+                                        PMID:20088845
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cubam is a multi-ligand receptor involved in dietary uptake of intrinsic factor-vitamin</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Membrane-bound component of the endocytic receptor formed by</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097017" target="_blank" class="term-link">
+                                    GO:0097017
+                                </a>
+                            </span>
+                            <span class="term-label">renal protein absorption</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0097017" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> In the renal proximal tubule, cubam reabsorbs filtered low-molecular-weight proteins (albumin, transferrin, apoA-I, vitamin D-binding protein). AMN is required for this CUBN-mediated renal protein reabsorption; the mild proteinuria in IGS2 reflects its loss.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported physiological role. IBA plus literature: cubam reabsorbs proteins from the glomerular ultrafiltrate, and AMN is required for cubilin&#39;s renal protein transport.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20088845" target="_blank" class="term-link">
+                                        PMID:20088845
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubam is involved in reabsorption of various proteins from the glomerular ultrafiltrate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006898" target="_blank" class="term-link">
+                                    GO:0006898
+                                </a>
+                            </span>
+                            <span class="term-label">receptor-mediated endocytosis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0006898" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN directs clathrin/receptor-mediated endocytosis of the cubam receptor and its ligands via two redundant FXNPXF motifs that engage ARH and Dab2. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimentally: the AMN cytoplasmic FXNPXF signals mediate internalization of cubam through ARH/Dab2 and clathrin-coated pits. IBA is corroborated by IDA/IMP.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20088845" target="_blank" class="term-link">
+                                        PMID:20088845
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both are able to mediate endocytosis of cubam through interaction with Dab2 and ARH</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008104" target="_blank" class="term-link">
+                                    GO:0008104
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein localization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0008104" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN directs the subcellular localization of cubilin: it is required to move cubilin out of early biosynthetic compartments to the cell surface and endosomes. Reflects AMN&#39;s chaperone/ trafficking role for its partner.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by experimental data: without AMN, cubilin accumulates in early biosynthetic compartments; with AMN, cubilin traffics to the surface and endosomes. AMN thus governs intracellular localization of the complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AMN binds to the amino-terminal third of cubilin and directs subcellular localization and endocytosis of cubilin with its ligand</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030139" target="_blank" class="term-link">
+                                    GO:0030139
+                                </a>
+                            </span>
+                            <span class="term-label">endocytic vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0030139" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cubam is internalized into and cycles through endocytic vesicles; AMN is active there during cargo internalization and receptor recycling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the receptor-mediated endocytosis role and corroborated by IDA localization to endocytic vesicle from the same gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005576" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A soluble form of AMN arises by proteolytic removal of the membrane anchor and is secreted; this justifies an extracellular-region localization for that shed form. Peripheral, not the core membrane-bound function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> SubCell mapping is consistent with the documented secreted soluble AMN form, but the biologically central form is the membrane-anchored co-receptor. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">A soluble form arises by proteolytic removal of the membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005886" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN is a single-pass type I plasma-membrane protein. Correct, though the more informative apical plasma membrane term better captures its polarized epithelial localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with EXP/TAS/IDA plasma-membrane annotations and UniProt SubCell Cell membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Single-pass type I membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010008" target="_blank" class="term-link">
+                                    GO:0010008
+                                </a>
+                            </span>
+                            <span class="term-label">endosome membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0010008" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> During receptor-mediated endocytosis AMN resides on the endosome membrane as cubam is internalized and recycled. Consistent with the endocytic itinerary.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by UniProt SubCell (Endosome membrane) and the endocytic role; a transit/recycling localization rather than the primary functional site.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endosome membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic membrane localization; correct but uninformative relative to the specific apical/microvillus plasma-membrane terms.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> True but too general; the specific apical plasma membrane / microvillus membrane annotations carry the informative content.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Single-pass type I membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0016324" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Apical plasma membrane localization of AMN, from SubCell mapping. Matches the experimentally determined apical cell membrane localization; core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Corroborated by IDA/NAS apical plasma membrane annotations and UniProt Apical cell membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30523278
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural assembly of the megadalton-sized receptor for int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005515" data-r="PMID:30523278" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IPI records the AMN-CUBN interaction (with UniProtKB:O60494 = CUBN). &#34;protein binding&#34; is an uninformative bare term; the biologically meaningful content of this interaction is captured by AMN&#39;s cargo receptor activity (anchoring the cubilin subunits) rather than generic binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, bare protein binding is uninformative. The interaction it documents (AMN binding cubilin, structurally resolved) is real and central, but its functional meaning is already represented by cargo receptor activity and by the cubam complex membership. Retained as over-annotated rather than removed (experimental IPI).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we present the crystal structure of AMN in complex with the amino-terminal region of cubilin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030139" target="_blank" class="term-link">
+                                    GO:0030139
+                                </a>
+                            </span>
+                            <span class="term-label">endocytic vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0030139" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Endocytic vesicle localization transferred from rat ortholog; consistent with AMN&#39;s endocytic role and with the IDA/IBA endocytic vesicle annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transferred localization agrees with experimental human annotations for the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031526" target="_blank" class="term-link">
+                                    GO:0031526
+                                </a>
+                            </span>
+                            <span class="term-label">brush border membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0031526" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Brush border (microvillus) membrane localization, consistent with cubam&#39;s site of action on the apical surface of ileal enterocytes and proximal tubule cells; matches the IDA microvillus membrane annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ortholog-transferred localization consistent with the experimentally determined microvillus membrane localization (PMID:14576052) and the apical epithelial role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                                    GO:0032991
+                                </a>
+                            </span>
+                            <span class="term-label">protein-containing complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0032991" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN is part of the cubam protein complex (one AMN + three cubilin chains). Correct but generic; the specific cubam receptor complex is the informative description.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> True (cubam is a defined protein complex, ComplexPortal CPX-5774) but the generic term is subsumed by the more specific complex membership; keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we present the crystal structure of AMN in complex with the amino-terminal region of cubilin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0015889" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cubam (AMN+cubilin) is the functional IF-cobalamin receptor: cells cotransfected with AMN and cubilin acquire IF-cobalamin endocytosis and lysosomal delivery. Core biological process for AMN.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly demonstrated: AMN is required to reconstitute IF-cobalamin uptake and degradation. This is a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0016020" data-r="PMID:14576052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic membrane localization; correct but uninformative relative to the specific apical/ microvillus plasma-membrane terms.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> True but too general; superseded by the specific membrane subcompartment annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Single-pass type I membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0016324" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Apical plasma membrane localization (author statement). Consistent with the experimentally determined apical/microvillus localization; core site of action.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with IDA apical plasma membrane and UniProt Apical cell membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030139" target="_blank" class="term-link">
+                                    GO:0030139
+                                </a>
+                            </span>
+                            <span class="term-label">endocytic vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0030139" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN localizes to endocytic vesicles as cubam internalizes ligand; documented colocalization in the endocytic apparatus of polarized epithelial cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly observed colocalization of AMN with cubilin in the endocytic apparatus.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043235" target="_blank" class="term-link">
+                                    GO:0043235
+                                </a>
+                            </span>
+                            <span class="term-label">signaling receptor complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30523278
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural assembly of the megadalton-sized receptor for int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0043235" data-r="PMID:30523278" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Records AMN&#39;s membership in the cubam receptor complex via its structurally resolved interaction with cubilin. However, cubam is an endocytic/cargo receptor, not a signaling receptor; the &#34;signaling&#34; qualifier is an over-annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The complex is real and central, but it is a nutrient-uptake endocytic receptor, not a signaling receptor complex. The accurate content is captured by cargo receptor activity and by cubam complex membership. Over-annotated rather than removed (experimental IPI documenting a genuine interaction).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we present the crystal structure of AMN in complex with the amino-terminal region of cubilin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005886" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally determined plasma-membrane localization of AMN. Core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence; AMN is a plasma-membrane co-receptor subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29402915" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29402915
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Amnionless-mediated glycosylation is crucial for cell surfac...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005886" data-r="PMID:29402915" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally determined plasma-membrane localization; AMN is required for cubilin&#39;s own plasma-membrane expression, and AMN itself resides at the surface.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for surface localization of the AMN/cubilin complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29402915" target="_blank" class="term-link">
+                                        PMID:29402915
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">amnionless-dependent membrane expression of cubilin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30523278
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural assembly of the megadalton-sized receptor for int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005886" data-r="PMID:30523278" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Plasma-membrane localization consistent with AMN being the transmembrane anchor of cubam (single-pass type I membrane protein).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structural/biochemical study confirms AMN as the transmembrane subunit anchoring cubam to the membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">anchors three ligand-binding cubilin subunits to the transmembrane AMN</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0009235" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN, as part of cubam, is required for intestinal absorption of vitamin B12, acting upstream of cobalamin metabolism. Reflects its role in supplying cobalamin to the body.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> AMN loss causes B12 deficiency (IGS2); cubam-mediated uptake is the entry step for dietary cobalamin. Upstream-of relationship to cobalamin metabolism is appropriate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031528" target="_blank" class="term-link">
+                                    GO:0031528
+                                </a>
+                            </span>
+                            <span class="term-label">microvillus membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0031528" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN localizes to the microvillus (brush border) membrane of polarized epithelia, the apical site where cubam captures its ligands.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with apical/brush-border localization of the cubam receptor in enterocytes and proximal tubule cells.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                                    GO:0038024
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0038024" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental support for AMN&#39;s cargo receptor activity: reconstitution of AMN with the cubilin ligand-binding construct confers ligand endocytosis that neither protein alone provides. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Neither AMN nor a truncated cubilin construct alone confers endocytosis; together they form the functional cargo receptor. This directly establishes AMN&#39;s cargo-receptor (co-receptor) function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">neither protein alone conferred ligand endocytosis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031528" target="_blank" class="term-link">
+                                    GO:0031528
+                                </a>
+                            </span>
+                            <span class="term-label">microvillus membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0031528" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN is active at the microvillus (brush border) membrane, the apical site of cubam-mediated ligand capture and internalization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the apical/brush-border localization and function of cubam.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0009235" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN participates in cobalamin metabolism through cubam-mediated intestinal B12 uptake. Duplicate of the acts_upstream_of_or_within annotation with the same evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Same experimental basis as the other cobalamin metabolic process annotation; AMN is required for cellular acquisition of vitamin B12.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006898" target="_blank" class="term-link">
+                                    GO:0006898
+                                </a>
+                            </span>
+                            <span class="term-label">receptor-mediated endocytosis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20088845" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20088845
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    AMN directs endocytosis of the intrinsic factor-vitamin B(12...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0006898" data-r="PMID:20088845" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutational analysis of AMN&#39;s two cytoplasmic FXNPXF signals shows they are required for internalization of cubam; simultaneous loss of both arrests ligand at the cell surface. Direct genetic (mutagenesis) support for receptor-mediated endocytosis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IMP from FXNPXF signal mutants: both signals possess endocytic capability and are needed for cubam internalization via ARH/Dab2/clathrin. Core process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20088845" target="_blank" class="term-link">
+                                        PMID:20088845
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">both FXNPXF signals in the cytosolic domain of AMN possess endocytic capabilities and that one signal is sufficient for uptake of labeled ligand via the cubam complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19056867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Large-scale proteomics and phosphoproteomics of urinary exos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0070062" data-r="PMID:19056867" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN was detected by high-throughput proteomics of human urinary exosomes. This reflects shedding of the apical membrane protein into urinary exosomes from renal epithelia, not a functional site of action.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proteomic detection in urinary exosomes is consistent with AMN&#39;s apical renal-epithelial expression but is a peripheral/incidental localization, not its functional site.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                                        PMID:19056867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we used LC-MS/MS to profile the proteome of human urinary exosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005102" target="_blank" class="term-link">
+                                    GO:0005102
+                                </a>
+                            </span>
+                            <span class="term-label">signaling receptor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005102" data-r="PMID:14576052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IPI (with CUBN, UniProtKB:O60494) records the AMN-cubilin interaction. Cubilin is a cargo receptor, not a signaling receptor, so &#34;signaling receptor binding&#34; mischaracterizes the interaction; the accurate description is co-receptor/cargo receptor assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The interaction with cubilin is genuine and central, but neither partner is a signaling receptor; the &#34;signaling&#34; framing is an over-annotation. The informative content is AMN&#39;s cargo receptor activity and cubam membership. Over-annotated rather than removed (experimental IPI documenting a real, structurally confirmed interaction).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN are subunits of a novel cubilin/AMN (cubam) complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005576" data-r="PMID:14576052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A soluble form of AMN is secreted following proteolytic removal of the membrane anchor, accounting for extracellular-region localization. Peripheral relative to the membrane-bound co-receptor form.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by the documented soluble/secreted AMN form; the biologically central form is the membrane-anchored co-receptor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">A soluble form arises by proteolytic removal of the membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006898" target="_blank" class="term-link">
+                                    GO:0006898
+                                </a>
+                            </span>
+                            <span class="term-label">receptor-mediated endocytosis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0006898" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reconstitution of AMN with cubilin confers IF-cobalamin endocytosis and lysosomal degradation, directly demonstrating AMN&#39;s role in receptor-mediated endocytosis. Core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental demonstration that AMN is required for cubam-mediated ligand endocytosis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0016324" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Directly observed apical plasma membrane localization of AMN in polarized epithelial cells. Core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for apical localization; consistent with UniProt Apical cell membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/AMN/AMN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043001" target="_blank" class="term-link">
+                                    GO:0043001
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi to plasma membrane protein transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0043001" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> AMN is required to move cubilin from early biosynthetic compartments (ER/Golgi) to the cell surface; without AMN, cubilin accumulates intracellularly. This trafficking/chaperone role for its partner supports involvement in Golgi-to-plasma-membrane protein transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported: cubilin reaches the surface only when co-expressed with AMN, otherwise it is retained in early biosynthetic compartments. AMN thus enables secretory transport of the complex to the plasma membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in cells cotransfected with AMN and the cubilin construct, cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3296477
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005886" data-r="Reactome:R-HSA-3296477" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable localization of AMN at the plasma membrane in the context of cubam-mediated GIF:Cbl uptake (and its defect). Consistent with experimental localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with EXP/IDA plasma-membrane localization; Reactome models AMN as a plasma-membrane cubam subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-264834
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005886" data-r="Reactome:R-HSA-264834" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome localization of AMN at the plasma membrane in the apoA-I endocytosis/degradation pathway (renal cubam reabsorption). Consistent with experimental localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with the experimentally supported plasma-membrane localization of the cubam subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-264848
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005886" data-r="Reactome:R-HSA-264848" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome localization of AMN at the plasma membrane in the apoA-I binding step of cubam-mediated renal reabsorption. Consistent with experimental localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with experimental plasma-membrane localization; cubam acts on apical surfaces.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000103
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005886" data-r="Reactome:R-HSA-3000103" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome localization of AMN at the plasma membrane where CUBN:AMN binds CBLIF:RCbl in the ileum. Consistent with experimental localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with experimental plasma-membrane localization of cubam.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000137
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005886" data-r="Reactome:R-HSA-3000137" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome localization of AMN at the plasma membrane in CUBN:AMN-mediated CBLIF:RCbl uptake and lysosomal delivery. Consistent with experimental localization and endocytic recycling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with experimental plasma-membrane localization; cubam returns to the plasma membrane after ligand delivery.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3296462
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BXJ7" data-a="GO:0005886" data-r="Reactome:R-HSA-3296462" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome localization of AMN at the plasma membrane in the defective-CUBN pathway (failed GIF:Cbl transport). Consistent with experimental localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with experimental plasma-membrane localization of the cubam subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Membrane-anchoring/endocytic co-receptor subunit of the cubam receptor: AMN provides the transmembrane anchor and cytoplasmic endocytosis signals that ligand-binding cubilin lacks, functioning as a cargo receptor that internalizes cubilin-bound ligands.</h3>
+                <span class="vote-buttons" data-g="Q9BXJ7" data-a="FUNCTION: Membrane-anchoring/endocytic co-receptor subunit o..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                            cargo receptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006898" target="_blank" class="term-link">
+                                receptor-mediated endocytosis
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                apical plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043235" target="_blank" class="term-link">
+                            receptor complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                PMID:14576052
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">neither protein alone conferred ligand endocytosis</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20088845" target="_blank" class="term-link">
+                                PMID:20088845
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">both are able to mediate endocytosis of cubam through interaction with Dab2 and ARH</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As part of cubam at the apical/microvillus membrane of ileal enterocytes, AMN mediates uptake of dietary vitamin B12 (cobalamin) complexed with intrinsic factor, and reabsorption of filtered proteins in the renal proximal tubule.</h3>
+                <span class="vote-buttons" data-g="Q9BXJ7" data-a="FUNCTION: As part of cubam at the apical/microvillus membran..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                            cargo receptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                apical plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                PMID:14576052
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                            PMID:14576052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The functional cobalamin (vitamin B12)-intrinsic factor receptor is a novel complex of cubilin and amnionless.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Cubilin and AMN form the cubam complex; AMN binds the amino-terminal third of cubilin and directs the subcellular localization and endocytosis of cubilin with its ligand. Neither protein alone confers ligand endocytosis; together they reconstitute IF-cobalamin uptake and lysosomal degradation.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                            PMID:19056867
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Proteomic profiling of human urinary exosomes; AMN is among detected proteins, consistent with shedding of apical renal-epithelial membrane proteins.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20088845" target="_blank" class="term-link">
+                            PMID:20088845
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">AMN directs endocytosis of the intrinsic factor-vitamin B(12) receptor cubam by engaging ARH or Dab2.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">AMN provides membrane anchorage and endocytic capacity via two redundant FXNPXF cytoplasmic signals that engage the clathrin adaptors ARH and Dab2 to internalize cubam and its ligands.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29402915" target="_blank" class="term-link">
+                            PMID:29402915
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Amnionless-mediated glycosylation is crucial for cell surface targeting of cubilin in renal and intestinal cells.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">AMN-dependent glycosylation and trafficking are required for cell-surface expression of cubilin; IGS-causing AMN missense mutations cause ER retention and abolish surface expression of cubilin.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                            PMID:30523278
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural assembly of the megadalton-sized receptor for intestinal vitamin B(12) uptake and kidney protein reabsorption.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Crystal structure of AMN with the amino-terminal region of cubilin shows a single AMN chain anchoring three ligand-binding cubilin subunits to the membrane via a beta-helix-beta-helix docking.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/AMN/AMN-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB Q9BXJ7 (AMNLS_HUMAN) entry</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">AMN is a single-pass type I membrane glycoprotein localized to the apical cell membrane; it is the membrane-bound component of the AMN+CUBN endocytic receptor. A soluble form arises by proteolytic removal of the membrane anchor.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-264834
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Endocytosis and degradation of apoA-I</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-264848
+
+                    </span>
+                </div>
+
+                <div class="reference-title">apoA-I binds to CUBN:AMN</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000103
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CUBN:AMN binds CBLIF:RCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000137
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CUBN:AMN-mediated CBLIF:RCbl uptake and delivery to lysosome</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3296462
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective CUBN does not transport GIF:Cbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3296477
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective AMN does not transport GIF:Cbl</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(AMN-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9BXJ7" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="amn-amnionless-review-notes">AMN (amnionless) — review notes</h1>
+<p>UniProt: Q9BXJ7 (AMNLS_HUMAN), 453 aa, single-pass type I transmembrane glycoprotein.<br />
+Gene HGNC:14604, chromosome 14. HPA: group enriched in intestine, kidney, liver.</p>
+<h2 id="core-biology">Core biology</h2>
+<p>AMN is the membrane-anchoring / endocytic co-receptor subunit of the <strong>cubam</strong><br />
+endocytic receptor, formed together with cubilin (CUBN). Cubilin is a ~460-kDa<br />
+peripheral protein with the ligand-binding CUB domains but <strong>no transmembrane<br />
+segment and no endocytosis signals</strong>; AMN supplies both.</p>
+<ul>
+<li><strong>Membrane anchorage</strong>: AMN is a type I TM protein (TM 358–378 per UniProt FT);<br />
+  the crystal structure (PDB 6GJE) shows a three-faced β-helix domain in AMN docking<br />
+  a three-subunit cubilin β-helix, anchoring three ligand-binding cubilin chains to<br />
+  the membrane <a href="https://pubmed.ncbi.nlm.nih.gov/30523278">PMID:30523278</a>.</li>
+<li><strong>Trafficking / glycosylation</strong>: AMN is required for correct N-glycosylation and<br />
+  cell-surface (apical) targeting of cubilin; without AMN, cubilin is retained in the<br />
+  ER/Golgi. IGS-causing AMN mutations (T41I, M69K, C234F) cause ER retention and loss<br />
+  of cubilin surface expression [PMID:14576052; PMID:29402915].</li>
+<li><strong>Endocytosis signals</strong>: the AMN cytoplasmic tail carries two redundant FXNPXF<br />
+  internalization motifs (residues ~406–411 and ~441–446) that engage the<br />
+  clathrin-associated sorting adaptors ARH (LDLRAP1) and Dab2 to internalize cubam<br />
+  and its ligands via clathrin-coated pits <a href="https://pubmed.ncbi.nlm.nih.gov/20088845">PMID:20088845</a>.</li>
+</ul>
+<h2 id="function-localization">Function / localization</h2>
+<ul>
+<li>Non-enzymatic. Molecular function is a <strong>cargo receptor / membrane co-receptor</strong><br />
+  role (GO:0038024 cargo receptor activity), providing anchorage + endocytic signals.</li>
+<li>Localizes to <strong>apical plasma membrane / microvillus (brush border) membrane</strong> of<br />
+  ileal enterocytes and renal proximal tubule cells; cycles through endocytic<br />
+  vesicles / coated pits; endosome membrane. A soluble form is shed (secreted).</li>
+<li>BP: <strong>cobalamin transport</strong> (GO:0015889), <strong>receptor-mediated endocytosis</strong><br />
+  (GO:0006898), renal protein absorption (kidney reabsorption of albumin, transferrin,<br />
+  apoA-I, vitamin D-binding protein via cubam).</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<p>Imerslund-Gräsbeck syndrome 2 / megaloblastic anemia 1 (IGS2, MIM:618882): selective<br />
+intestinal B12 malabsorption + mild proteinuria; same disorder as CUBN mutations<br />
+(both cubam subunits) [PMID:14576052; PMID:29402915; PMID:26040326].</p>
+<h2 id="key-references-all-cached">Key references (all cached)</h2>
+<ul>
+<li>PMID:14576052 (Blood 2004, abstract-only cache) — cubam = CUBN+AMN; AMN directs<br />
+  subcellular localization and endocytosis of cubilin+ligand; N-glycosylation; soluble form.</li>
+<li>PMID:20088845 (Traffic 2010, full text) — FXNPXF signals → ARH/Dab2 → clathrin endocytosis.</li>
+<li>PMID:29402915 (Sci Rep 2018, full text) — AMN glycosylation/trafficking required for<br />
+  cubilin surface targeting; IGS mutants ER-retained.</li>
+<li>PMID:30523278 (Nat Commun 2018, full text) — cubam crystal structure; 1 AMN : 3 CUBN.</li>
+<li>PMID:19056867 — urinary exosome proteomics (AMN detected; HDA extracellular exosome).</li>
+</ul>
+<h2 id="annotation-review-decisions-summary">Annotation review decisions (summary)</h2>
+<ul>
+<li>ACCEPT core: cargo receptor activity (IBA+IDA); cobalamin transport (IDA); receptor-mediated<br />
+  endocytosis (IDA/IMP/IBA); apical plasma membrane / microvillus membrane / endocytic vesicle;<br />
+  plasma membrane (EXP/TAS/IEA); renal protein absorption (IBA); intracellular protein<br />
+  localization (IBA); Golgi to plasma membrane protein transport (IDA); cobalamin metabolic process.</li>
+<li>MARK_AS_OVER_ANNOTATED: signaling receptor complex (GO:0043235) and signaling receptor binding<br />
+  (GO:0005102) — cubam is a nutrient/cargo endocytic receptor, not a signaling receptor; these are<br />
+  IBA/IPI over-annotations toward a "signaling" framing. protein binding (GO:0005515, IPI) —<br />
+  uninformative bare term (the informative content is the CUBN interaction = cargo receptor/anchor).</li>
+<li>ACCEPT with KEEP_AS_NON_CORE: extracellular region / extracellular exosome / endosome membrane /<br />
+  membrane / protein-containing complex — peripheral/secreted-form/proteomic localizations.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9BXJ7
+gene_symbol: AMN
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  AMN (amnionless) is a single-pass type I transmembrane glycoprotein that partners
+  cubilin (CUBN) to form the cubam endocytic receptor. Cubilin carries the ligand-binding
+  CUB domains but lacks a transmembrane segment and cytoplasmic endocytosis signals; AMN
+  supplies both, acting as the membrane-anchoring/endocytic co-receptor subunit. AMN is
+  required for the correct N-glycosylation, apical cell-surface targeting and clathrin-mediated
+  internalization of cubilin together with its bound ligands. It is non-enzymatic: its
+  extracellular region docks the amino-terminal region of cubilin (a single AMN chain binding
+  three cubilin subunits), its transmembrane helix anchors the complex, and its cytoplasmic tail
+  contains two redundant FXNPXF internalization motifs that engage the clathrin adaptors ARH
+  (LDLRAP1) and Dab2. Cubam operates at the apical/microvillus (brush border) membrane of ileal
+  enterocytes, where it mediates uptake of dietary vitamin B12 (cobalamin) complexed with intrinsic
+  factor, and of renal proximal tubule cells, where it reabsorbs filtered low-molecular-weight
+  proteins (e.g. albumin, transferrin, apolipoprotein A-I, vitamin D-binding protein). Loss-of-function
+  variants in AMN cause Imerslund-Grasbeck syndrome 2 (megaloblastic anemia 1 with proteinuria),
+  the same selective B12-malabsorption disorder produced by CUBN mutations.
+existing_annotations:
+- term:
+    id: GO:0016324
+    label: apical plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Cubam (AMN+cubilin) is active at the apical plasma membrane of ileal enterocytes and
+      renal proximal tubule cells; AMN provides the membrane anchor. This is a well-supported
+      core localization consistent with experimental data.
+    action: ACCEPT
+    reason: &gt;-
+      IBA localization at the apical plasma membrane is corroborated by direct experimental
+      evidence in the same gene (PMID:14576052 apical cell membrane; PMID:29402915 cell-surface
+      targeting). This is the physiological site of cubam action.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0038024
+    label: cargo receptor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      AMN is the membrane-anchoring/endocytic subunit of the cubam cargo receptor: it anchors
+      the ligand-binding cubilin subunits to the membrane and directs their endocytosis. Cargo
+      receptor activity is the correct molecular-function abstraction for this co-receptor role.
+    action: ACCEPT
+    reason: &gt;-
+      Cargo receptor activity is the core molecular function. AMN binds the ligand-binding cubilin
+      subunits, anchors them via its transmembrane helix, and internalizes bound cargo (IF-B12,
+      filtered proteins) via clathrin-coated pits. Supported by IBA and by direct experimental
+      annotation from the same paper.
+    supported_by:
+    - reference_id: PMID:20088845
+      supporting_text: &gt;-
+        cubilin contains no transmembrane segment and therefore needs the transmembrane region
+        of AMN to be anchored in the plasma membrane
+- term:
+    id: GO:0043235
+    label: signaling receptor complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      AMN is part of a receptor complex (cubam), but cubam is a nutrient/cargo endocytic receptor,
+      not a signaling receptor. The &#34;signaling&#34; framing is an over-interpretation; the informative,
+      accurate content is captured by cargo receptor activity and receptor-mediated endocytosis.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Cubam mediates ligand binding and endocytosis (uptake), not signal transduction. There is no
+      evidence AMN participates in a signaling receptor complex; the endocytic-receptor role is the
+      correct one. Marking as over-annotated rather than removing an IBA that reflects a generic
+      &#34;receptor complex&#34; tree assignment.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - ROLE_CONFLATION
+      source_entities:
+      - source_id: PANTHER:PTN001029969
+        source_label: AMN family node
+      - source_id: UniProtKB:Q9BXJ7
+        source_label: AMN (human)
+    supported_by:
+    - reference_id: PMID:20088845
+      supporting_text: &gt;-
+        Cubam is a multi-ligand receptor involved in dietary uptake of intrinsic factor-vitamin
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: &gt;-
+        Membrane-bound component of the endocytic receptor formed by
+- term:
+    id: GO:0097017
+    label: renal protein absorption
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      In the renal proximal tubule, cubam reabsorbs filtered low-molecular-weight proteins
+      (albumin, transferrin, apoA-I, vitamin D-binding protein). AMN is required for this
+      CUBN-mediated renal protein reabsorption; the mild proteinuria in IGS2 reflects its loss.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported physiological role. IBA plus literature: cubam reabsorbs proteins from the
+      glomerular ultrafiltrate, and AMN is required for cubilin&#39;s renal protein transport.
+    supported_by:
+    - reference_id: PMID:20088845
+      supporting_text: &gt;-
+        cubam is involved in reabsorption of various proteins from the glomerular ultrafiltrate
+- term:
+    id: GO:0006898
+    label: receptor-mediated endocytosis
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      AMN directs clathrin/receptor-mediated endocytosis of the cubam receptor and its ligands via
+      two redundant FXNPXF motifs that engage ARH and Dab2. Core biological process.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported experimentally: the AMN cytoplasmic FXNPXF signals mediate internalization
+      of cubam through ARH/Dab2 and clathrin-coated pits. IBA is corroborated by IDA/IMP.
+    supported_by:
+    - reference_id: PMID:20088845
+      supporting_text: &gt;-
+        both are able to mediate endocytosis of cubam through interaction with Dab2 and ARH
+- term:
+    id: GO:0008104
+    label: intracellular protein localization
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      AMN directs the subcellular localization of cubilin: it is required to move cubilin out of
+      early biosynthetic compartments to the cell surface and endosomes. Reflects AMN&#39;s chaperone/
+      trafficking role for its partner.
+    action: ACCEPT
+    reason: &gt;-
+      Supported by experimental data: without AMN, cubilin accumulates in early biosynthetic
+      compartments; with AMN, cubilin traffics to the surface and endosomes. AMN thus governs
+      intracellular localization of the complex.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        AMN binds to the amino-terminal third of cubilin and directs subcellular localization and
+        endocytosis of cubilin with its ligand
+- term:
+    id: GO:0030139
+    label: endocytic vesicle
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Cubam is internalized into and cycles through endocytic vesicles; AMN is active there during
+      cargo internalization and receptor recycling.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the receptor-mediated endocytosis role and corroborated by IDA localization to
+      endocytic vesicle from the same gene.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      A soluble form of AMN arises by proteolytic removal of the membrane anchor and is secreted;
+      this justifies an extracellular-region localization for that shed form. Peripheral, not the
+      core membrane-bound function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      SubCell mapping is consistent with the documented secreted soluble AMN form, but the biologically
+      central form is the membrane-anchored co-receptor. Keep as non-core.
+    supported_by:
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: &gt;-
+        A soluble form arises by proteolytic removal of the membrane
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      AMN is a single-pass type I plasma-membrane protein. Correct, though the more informative apical
+      plasma membrane term better captures its polarized epithelial localization.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with EXP/TAS/IDA plasma-membrane annotations and UniProt SubCell Cell membrane.
+    supported_by:
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: Single-pass type I membrane protein
+- term:
+    id: GO:0010008
+    label: endosome membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      During receptor-mediated endocytosis AMN resides on the endosome membrane as cubam is
+      internalized and recycled. Consistent with the endocytic itinerary.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Supported by UniProt SubCell (Endosome membrane) and the endocytic role; a transit/recycling
+      localization rather than the primary functional site.
+    supported_by:
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: Endosome membrane
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Generic membrane localization; correct but uninformative relative to the specific
+      apical/microvillus plasma-membrane terms.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      True but too general; the specific apical plasma membrane / microvillus membrane annotations
+      carry the informative content.
+    supported_by:
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: Single-pass type I membrane protein
+- term:
+    id: GO:0016324
+    label: apical plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Apical plasma membrane localization of AMN, from SubCell mapping. Matches the experimentally
+      determined apical cell membrane localization; core localization.
+    action: ACCEPT
+    reason: &gt;-
+      Corroborated by IDA/NAS apical plasma membrane annotations and UniProt Apical cell membrane.
+    supported_by:
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:30523278
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This IPI records the AMN-CUBN interaction (with UniProtKB:O60494 = CUBN). &#34;protein binding&#34; is
+      an uninformative bare term; the biologically meaningful content of this interaction is captured
+      by AMN&#39;s cargo receptor activity (anchoring the cubilin subunits) rather than generic binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation guidelines, bare protein binding is uninformative. The interaction it documents
+      (AMN binding cubilin, structurally resolved) is real and central, but its functional meaning is
+      already represented by cargo receptor activity and by the cubam complex membership. Retained as
+      over-annotated rather than removed (experimental IPI).
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: &gt;-
+        we present the crystal structure of AMN in complex with the amino-terminal region of cubilin
+- term:
+    id: GO:0030139
+    label: endocytic vesicle
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Endocytic vesicle localization transferred from rat ortholog; consistent with AMN&#39;s endocytic
+      role and with the IDA/IBA endocytic vesicle annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Ortholog-transferred localization agrees with experimental human annotations for the same term.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells
+- term:
+    id: GO:0031526
+    label: brush border membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Brush border (microvillus) membrane localization, consistent with cubam&#39;s site of action on the
+      apical surface of ileal enterocytes and proximal tubule cells; matches the IDA microvillus
+      membrane annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Ortholog-transferred localization consistent with the experimentally determined microvillus
+      membrane localization (PMID:14576052) and the apical epithelial role.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells
+- term:
+    id: GO:0032991
+    label: protein-containing complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      AMN is part of the cubam protein complex (one AMN + three cubilin chains). Correct but generic;
+      the specific cubam receptor complex is the informative description.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      True (cubam is a defined protein complex, ComplexPortal CPX-5774) but the generic term is
+      subsumed by the more specific complex membership; keep as non-core.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: &gt;-
+        we present the crystal structure of AMN in complex with the amino-terminal region of cubilin
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Cubam (AMN+cubilin) is the functional IF-cobalamin receptor: cells cotransfected with AMN and
+      cubilin acquire IF-cobalamin endocytosis and lysosomal delivery. Core biological process for AMN.
+    action: ACCEPT
+    reason: &gt;-
+      Directly demonstrated: AMN is required to reconstitute IF-cobalamin uptake and degradation.
+      This is a core function.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Generic membrane localization; correct but uninformative relative to the specific apical/
+      microvillus plasma-membrane terms.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      True but too general; superseded by the specific membrane subcompartment annotations.
+    supported_by:
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: Single-pass type I membrane protein
+- term:
+    id: GO:0016324
+    label: apical plasma membrane
+  evidence_type: NAS
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Apical plasma membrane localization (author statement). Consistent with the experimentally
+      determined apical/microvillus localization; core site of action.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with IDA apical plasma membrane and UniProt Apical cell membrane.
+    supported_by:
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0030139
+    label: endocytic vesicle
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      AMN localizes to endocytic vesicles as cubam internalizes ligand; documented colocalization in
+      the endocytic apparatus of polarized epithelial cells.
+    action: ACCEPT
+    reason: &gt;-
+      Directly observed colocalization of AMN with cubilin in the endocytic apparatus.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells
+- term:
+    id: GO:0043235
+    label: signaling receptor complex
+  evidence_type: IPI
+  original_reference_id: PMID:30523278
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Records AMN&#39;s membership in the cubam receptor complex via its structurally resolved interaction
+      with cubilin. However, cubam is an endocytic/cargo receptor, not a signaling receptor; the
+      &#34;signaling&#34; qualifier is an over-annotation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The complex is real and central, but it is a nutrient-uptake endocytic receptor, not a signaling
+      receptor complex. The accurate content is captured by cargo receptor activity and by cubam
+      complex membership. Over-annotated rather than removed (experimental IPI documenting a genuine
+      interaction).
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: &gt;-
+        we present the crystal structure of AMN in complex with the amino-terminal region of cubilin
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: EXP
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimentally determined plasma-membrane localization of AMN. Core localization.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental evidence; AMN is a plasma-membrane co-receptor subunit.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: EXP
+  original_reference_id: PMID:29402915
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimentally determined plasma-membrane localization; AMN is required for cubilin&#39;s own
+      plasma-membrane expression, and AMN itself resides at the surface.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental support for surface localization of the AMN/cubilin complex.
+    supported_by:
+    - reference_id: PMID:29402915
+      supporting_text: amnionless-dependent membrane expression of cubilin
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: EXP
+  original_reference_id: PMID:30523278
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Plasma-membrane localization consistent with AMN being the transmembrane anchor of cubam
+      (single-pass type I membrane protein).
+    action: ACCEPT
+    reason: &gt;-
+      Structural/biochemical study confirms AMN as the transmembrane subunit anchoring cubam to the
+      membrane.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: &gt;-
+        anchors three ligand-binding cubilin subunits to the transmembrane AMN
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: &gt;-
+      AMN, as part of cubam, is required for intestinal absorption of vitamin B12, acting upstream of
+      cobalamin metabolism. Reflects its role in supplying cobalamin to the body.
+    action: ACCEPT
+    reason: &gt;-
+      AMN loss causes B12 deficiency (IGS2); cubam-mediated uptake is the entry step for dietary
+      cobalamin. Upstream-of relationship to cobalamin metabolism is appropriate.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF
+- term:
+    id: GO:0031528
+    label: microvillus membrane
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      AMN localizes to the microvillus (brush border) membrane of polarized epithelia, the apical
+      site where cubam captures its ligands.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with apical/brush-border localization of the cubam receptor in enterocytes and
+      proximal tubule cells.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells
+- term:
+    id: GO:0038024
+    label: cargo receptor activity
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental support for AMN&#39;s cargo receptor activity: reconstitution of AMN with the
+      cubilin ligand-binding construct confers ligand endocytosis that neither protein alone provides.
+      Core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Neither AMN nor a truncated cubilin construct alone confers endocytosis; together they form the
+      functional cargo receptor. This directly establishes AMN&#39;s cargo-receptor (co-receptor) function.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        neither protein alone conferred ligand endocytosis
+- term:
+    id: GO:0031528
+    label: microvillus membrane
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      AMN is active at the microvillus (brush border) membrane, the apical site of cubam-mediated
+      ligand capture and internalization.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the apical/brush-border localization and function of cubam.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      AMN participates in cobalamin metabolism through cubam-mediated intestinal B12 uptake. Duplicate
+      of the acts_upstream_of_or_within annotation with the same evidence.
+    action: ACCEPT
+    reason: &gt;-
+      Same experimental basis as the other cobalamin metabolic process annotation; AMN is required for
+      cellular acquisition of vitamin B12.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF
+- term:
+    id: GO:0006898
+    label: receptor-mediated endocytosis
+  evidence_type: IMP
+  original_reference_id: PMID:20088845
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mutational analysis of AMN&#39;s two cytoplasmic FXNPXF signals shows they are required for
+      internalization of cubam; simultaneous loss of both arrests ligand at the cell surface.
+      Direct genetic (mutagenesis) support for receptor-mediated endocytosis.
+    action: ACCEPT
+    reason: &gt;-
+      IMP from FXNPXF signal mutants: both signals possess endocytic capability and are needed for
+      cubam internalization via ARH/Dab2/clathrin. Core process.
+    supported_by:
+    - reference_id: PMID:20088845
+      supporting_text: &gt;-
+        both FXNPXF signals in the cytosolic domain of AMN possess endocytic capabilities and that one
+        signal is sufficient for uptake of labeled ligand via the cubam complex
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      AMN was detected by high-throughput proteomics of human urinary exosomes. This reflects shedding
+      of the apical membrane protein into urinary exosomes from renal epithelia, not a functional
+      site of action.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Proteomic detection in urinary exosomes is consistent with AMN&#39;s apical renal-epithelial
+      expression but is a peripheral/incidental localization, not its functional site.
+    supported_by:
+    - reference_id: PMID:19056867
+      supporting_text: &gt;-
+        we used LC-MS/MS to profile the proteome of human urinary exosomes
+- term:
+    id: GO:0005102
+    label: signaling receptor binding
+  evidence_type: IPI
+  original_reference_id: PMID:14576052
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This IPI (with CUBN, UniProtKB:O60494) records the AMN-cubilin interaction. Cubilin is a cargo
+      receptor, not a signaling receptor, so &#34;signaling receptor binding&#34; mischaracterizes the
+      interaction; the accurate description is co-receptor/cargo receptor assembly.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The interaction with cubilin is genuine and central, but neither partner is a signaling receptor;
+      the &#34;signaling&#34; framing is an over-annotation. The informative content is AMN&#39;s cargo receptor
+      activity and cubam membership. Over-annotated rather than removed (experimental IPI documenting a
+      real, structurally confirmed interaction).
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin and AMN are subunits of a novel cubilin/AMN (cubam) complex
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      A soluble form of AMN is secreted following proteolytic removal of the membrane anchor,
+      accounting for extracellular-region localization. Peripheral relative to the membrane-bound
+      co-receptor form.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Supported by the documented soluble/secreted AMN form; the biologically central form is the
+      membrane-anchored co-receptor.
+    supported_by:
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: &gt;-
+        A soluble form arises by proteolytic removal of the membrane
+- term:
+    id: GO:0006898
+    label: receptor-mediated endocytosis
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reconstitution of AMN with cubilin confers IF-cobalamin endocytosis and lysosomal degradation,
+      directly demonstrating AMN&#39;s role in receptor-mediated endocytosis. Core process.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental demonstration that AMN is required for cubam-mediated ligand endocytosis.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF
+- term:
+    id: GO:0016324
+    label: apical plasma membrane
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Directly observed apical plasma membrane localization of AMN in polarized epithelial cells.
+      Core localization.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental evidence for apical localization; consistent with UniProt Apical cell
+      membrane.
+    supported_by:
+    - reference_id: file:human/AMN/AMN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0043001
+    label: Golgi to plasma membrane protein transport
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      AMN is required to move cubilin from early biosynthetic compartments (ER/Golgi) to the cell
+      surface; without AMN, cubilin accumulates intracellularly. This trafficking/chaperone role for
+      its partner supports involvement in Golgi-to-plasma-membrane protein transport.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported: cubilin reaches the surface only when co-expressed with AMN, otherwise
+      it is retained in early biosynthetic compartments. AMN thus enables secretory transport of the
+      complex to the plasma membrane.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        in cells cotransfected with AMN and the cubilin construct, cubilin trafficked to the cell
+        surface and endosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3296477
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome traceable localization of AMN at the plasma membrane in the context of cubam-mediated
+      GIF:Cbl uptake (and its defect). Consistent with experimental localization.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with EXP/IDA plasma-membrane localization; Reactome models AMN as a plasma-membrane
+      cubam subunit.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-264834
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome localization of AMN at the plasma membrane in the apoA-I endocytosis/degradation
+      pathway (renal cubam reabsorption). Consistent with experimental localization.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with the experimentally supported plasma-membrane localization of the cubam subunit.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-264848
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome localization of AMN at the plasma membrane in the apoA-I binding step of cubam-mediated
+      renal reabsorption. Consistent with experimental localization.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with experimental plasma-membrane localization; cubam acts on apical surfaces.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000103
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome localization of AMN at the plasma membrane where CUBN:AMN binds CBLIF:RCbl in the
+      ileum. Consistent with experimental localization.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with experimental plasma-membrane localization of cubam.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000137
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome localization of AMN at the plasma membrane in CUBN:AMN-mediated CBLIF:RCbl uptake and
+      lysosomal delivery. Consistent with experimental localization and endocytic recycling.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with experimental plasma-membrane localization; cubam returns to the plasma membrane
+      after ligand delivery.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3296462
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome localization of AMN at the plasma membrane in the defective-CUBN pathway (failed
+      GIF:Cbl transport). Consistent with experimental localization.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with experimental plasma-membrane localization of the cubam subunit.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: &gt;-
+        cubilin trafficked to the cell surface and endosomes
+core_functions:
+- description: &gt;-
+    Membrane-anchoring/endocytic co-receptor subunit of the cubam receptor: AMN provides the
+    transmembrane anchor and cytoplasmic endocytosis signals that ligand-binding cubilin lacks,
+    functioning as a cargo receptor that internalizes cubilin-bound ligands.
+  molecular_function:
+    id: GO:0038024
+    label: cargo receptor activity
+  directly_involved_in:
+  - id: GO:0006898
+    label: receptor-mediated endocytosis
+  supported_by:
+  - reference_id: PMID:14576052
+    supporting_text: &gt;-
+      neither protein alone conferred ligand endocytosis
+  - reference_id: PMID:20088845
+    supporting_text: &gt;-
+      both are able to mediate endocytosis of cubam through interaction with Dab2 and ARH
+  locations:
+  - id: GO:0016324
+    label: apical plasma membrane
+  in_complex:
+    id: GO:0043235
+    label: receptor complex
+- description: &gt;-
+    As part of cubam at the apical/microvillus membrane of ileal enterocytes, AMN mediates uptake of
+    dietary vitamin B12 (cobalamin) complexed with intrinsic factor, and reabsorption of filtered
+    proteins in the renal proximal tubule.
+  molecular_function:
+    id: GO:0038024
+    label: cargo receptor activity
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  supported_by:
+  - reference_id: PMID:14576052
+    supporting_text: &gt;-
+      the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF
+  locations:
+  - id: GO:0016324
+    label: apical plasma membrane
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: PMID:14576052
+  title: The functional cobalamin (vitamin B12)-intrinsic factor receptor is a novel
+    complex of cubilin and amnionless.
+  findings:
+  - statement: &gt;-
+      Cubilin and AMN form the cubam complex; AMN binds the amino-terminal third of cubilin and
+      directs the subcellular localization and endocytosis of cubilin with its ligand. Neither
+      protein alone confers ligand endocytosis; together they reconstitute IF-cobalamin uptake and
+      lysosomal degradation.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Foundational paper defining cubam as CUBN+AMN and establishing AMN&#39;s role in localization and
+      endocytosis. Cache is abstract-only but the abstract directly supports the annotations.
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings:
+  - statement: &gt;-
+      Proteomic profiling of human urinary exosomes; AMN is among detected proteins, consistent with
+      shedding of apical renal-epithelial membrane proteins.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput proteomics source for the extracellular-exosome (HDA) localization; peripheral
+      to AMN&#39;s core function.
+- id: PMID:20088845
+  title: AMN directs endocytosis of the intrinsic factor-vitamin B(12) receptor cubam
+    by engaging ARH or Dab2.
+  findings:
+  - statement: &gt;-
+      AMN provides membrane anchorage and endocytic capacity via two redundant FXNPXF cytoplasmic
+      signals that engage the clathrin adaptors ARH and Dab2 to internalize cubam and its ligands.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full-text mechanistic study of AMN&#39;s endocytic signals; supports receptor-mediated endocytosis
+      and the membrane-anchor/cargo-receptor role.
+- id: PMID:29402915
+  title: Amnionless-mediated glycosylation is crucial for cell surface targeting of
+    cubilin in renal and intestinal cells.
+  findings:
+  - statement: &gt;-
+      AMN-dependent glycosylation and trafficking are required for cell-surface expression of cubilin;
+      IGS-causing AMN missense mutations cause ER retention and abolish surface expression of cubilin.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full-text study establishing AMN&#39;s requirement for cubilin surface targeting; supports the
+      trafficking/localization annotations and plasma-membrane localization.
+- id: PMID:30523278
+  title: Structural assembly of the megadalton-sized receptor for intestinal vitamin
+    B(12) uptake and kidney protein reabsorption.
+  findings:
+  - statement: &gt;-
+      Crystal structure of AMN with the amino-terminal region of cubilin shows a single AMN chain
+      anchoring three ligand-binding cubilin subunits to the membrane via a beta-helix-beta-helix
+      docking.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Structural basis of cubam assembly and of AMN&#39;s membrane-anchoring role (PDB 6GJE); source of
+      the AMN-CUBN IPI interaction.
+- id: file:human/AMN/AMN-uniprot.txt
+  title: UniProtKB Q9BXJ7 (AMNLS_HUMAN) entry
+  findings:
+  - statement: &gt;-
+      AMN is a single-pass type I membrane glycoprotein localized to the apical cell membrane; it is
+      the membrane-bound component of the AMN+CUBN endocytic receptor. A soluble form arises by
+      proteolytic removal of the membrane anchor.
+    reference_section_type: OTHER
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      UniProt record used for topology, subcellular location, and the secreted soluble-form
+      annotations.
+- id: Reactome:R-HSA-264834
+  title: Endocytosis and degradation of apoA-I
+  findings: []
+- id: Reactome:R-HSA-264848
+  title: apoA-I binds to CUBN:AMN
+  findings: []
+- id: Reactome:R-HSA-3000103
+  title: CUBN:AMN binds CBLIF:RCbl
+  findings: []
+- id: Reactome:R-HSA-3000137
+  title: CUBN:AMN-mediated CBLIF:RCbl uptake and delivery to lysosome
+  findings: []
+- id: Reactome:R-HSA-3296462
+  title: Defective CUBN does not transport GIF:Cbl
+  findings: []
+- id: Reactome:R-HSA-3296477
+  title: Defective AMN does not transport GIF:Cbl
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/CBLIF/CBLIF-ai-review.html
+++ b/genes/human/CBLIF/CBLIF-ai-review.html
@@ -1,0 +1,4264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CBLIF - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>CBLIF</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P27352" target="_blank" class="term-link">
+                        P27352
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "CBLIF";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P27352" data-a="DESCRIPTION: CBLIF (gastric intrinsic factor, GIF; also called ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>CBLIF (gastric intrinsic factor, GIF; also called intrinsic factor, IF) is a secreted cobalamin (vitamin B12)-binding glycoprotein produced by gastric parietal cells (and, at the margins of gastric anatomical regions, by some chief and enteroendocrine cells). Its principal role is the intestinal absorption of dietary cobalamin: after cobalamin is released from salivary/gastric haptocorrin in the proximal small intestine, CBLIF binds it tightly, and the resulting CBLIF-cobalamin complex is recognized in the distal ileum by the cubam receptor formed by cubilin (CUBN) and amnionless (AMN). Cubam mediates receptor-dependent endocytosis of the complex, which is then delivered to lysosomes where cobalamin is released for cellular use. Structurally CBLIF is a two-domain alpha6/alpha6 barrel protein that binds one cobalamin at the domain interface in a base-on conformation. It is not an enzyme; it functions as a cobalamin-binding carrier and as the ligand recognized by the cubam cargo receptor. Loss-of-function mutations cause hereditary intrinsic factor deficiency (congenital/juvenile pernicious anemia; MIM:261000), a form of megaloblastic anemia resulting from vitamin B12 malabsorption.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005576" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation placing CBLIF in the extracellular region. CBLIF is a secreted protein that acts extracellularly (in the gut lumen / on the intestinal apical surface) to bind and deliver cobalamin, so this is correct and part of the core biology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records the protein as secreted, and it functions extracellularly as a cobalamin carrier. The IBA call is consistent with experimental localization and the known biology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0015889" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to cobalamin transport. CBLIF is required for intestinal absorption of dietary cobalamin, binding it and mediating cubam(CUBN/AMN)-dependent uptake in the ileum. This is a core biological process for the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported experimentally by human loss-of-function disease (hereditary IF deficiency) and by the well-established IF-cobalamin/cubam absorption pathway. Correct and core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link">
+                                        PMID:20237569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This occurs by the combined action of the gastric intrinsic factor (IF) and the ileal endocytic cubam receptor formed by the 460-kilodalton (kDa) protein cubilin and the 45-kDa transmembrane protein amnionless.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Promotes absorption of the essential vitamin cobalamin (Cbl) in the ileum. After interaction with CUBN, the CBLIF-cobalamin complex is internalized via receptor-mediated endocytosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0031419" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to cobalamin binding, the defining molecular function of CBLIF. This is directly supported by the crystal structure of the human IF-cobalamin complex and by defined cobalamin-contacting residues in UniProt.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cobalamin binding is the core molecular function of intrinsic factor, confirmed by structural and biochemical evidence. The IBA call is at the correct level of specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" target="_blank" class="term-link">
+                                        PMID:17954916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the Cbl is bound at the interface of the domains in a base-on conformation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005576" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to extracellular region derived from the UniProt &#34;Secreted&#34; subcellular location keyword mapping. Consistent with the experimental and phylogenetic evidence for a secreted protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the IBA/IDA extracellular-region calls but correct; the SubCell mapping accurately reflects the secreted nature of the protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0015889" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation (IPR002157, cobalamin-binding protein) to cobalamin transport. Consistent with the experimentally supported transport role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro family mapping is biologically appropriate for CBLIF and matches the experimental IMP/IBA/TAS annotations to the same process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Promotes absorption of the essential vitamin cobalamin (Cbl) in the ileum.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0031419" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation (IPR002157) to cobalamin binding. Matches the structurally validated core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cobalamin-binding domain assignment is correct for CBLIF and the mapped MF term is the defining function, corroborated by crystallography (PMID:17954916).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" target="_blank" class="term-link">
+                                        PMID:17954916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The structure of intrinsic factor (IF) in complex with cobalamin (Cbl) was determined at 2.6-A resolution.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20237569
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for receptor recognition of vitamin-B(12)-i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005515" data-r="PMID:20237569" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI annotation to the generic term protein binding, capturing the interaction with cubilin (CUBN, IntAct O60494). This interaction is real and functionally central (the IF-Cbl complex is recognized by the CUBN/AMN cubam receptor for ileal uptake), and is structurally defined. However, the bare &#34;protein binding&#34; term is uninformative about the actual function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidance, the uninformative &#34;protein binding&#34; term should not be treated as a core function even though the underlying CUBN interaction is genuine. The functional content of this interaction is better represented by the cobalamin-transport process and the cargo receptor ligand activity annotations, and by the specific CUBN partner recorded in UniProt SUBUNIT.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link">
+                                        PMID:20237569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">how two distant CUB domains embrace the Cbl molecule by binding the two IF domains in a Ca(2+)-dependent manner</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interacts with CUBN (via CUB domains).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI annotation to protein binding from the HuRI high-throughput binary (yeast two-hybrid) interactome screen. The recorded partners (FFAR2, SLC13A4, SLC22A23, SLC7A1, SLC7A14, TMEM237) are membrane transporters/GPCRs with no established biological relationship to a secreted cobalamin-binding protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> These are uninformative large-scale screen hits and the bare &#34;protein binding&#34; term conveys no functional information; they are very unlikely to reflect physiological partners of a secreted extracellular Cbl carrier. Marked as over-annotated rather than removed, per policy for IPI protein-binding annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reference interactome map of human binary protein interactions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9758881
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0015889" data-r="Reactome:R-HSA-9758881" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to cobalamin transport, from the &#34;Uptake of dietary cobalamins into enterocytes&#34; pathway. CBLIF binds dietary cobalamin and delivers it to the ileal cubam receptor for absorption; this is the core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome&#39;s pathway representation accurately captures CBLIF&#39;s role in the intestinal cobalamin absorption pathway, consistent with experimental (IMP) and phylogenetic (IBA) annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Promotes absorption of the essential vitamin cobalamin (Cbl) in the ileum.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140355" target="_blank" class="term-link">
+                                    GO:0140355
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor ligand activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17954916
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of human intrinsic factor: cobalamin compl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0140355" data-r="PMID:17954916" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation to cargo receptor ligand activity. The cobalamin-loaded CBLIF complex is the ligand recognized by the cubam (CUBN/AMN) cargo receptor, which then internalizes it by endocytosis in the ileum. This captures the receptor-recognition facet of CBLIF&#39;s transport function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structural work shows CUBN recognizes the Cbl-saturated IF complex, and the complex is taken up by receptor-mediated endocytosis; &#34;cargo receptor ligand activity&#34; is the appropriate MF for a secreted carrier ligand that engages an endocytic receptor. This is an informative, core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" target="_blank" class="term-link">
+                                        PMID:17954916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CUB recognizes both the full-length Cbl-saturated IF complex and the Cbl-saturated cleaved IF complex but not the isolated</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">After interaction with CUBN, the CBLIF-cobalamin complex is internalized via receptor-mediated endocytosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000103
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005576" data-r="Reactome:R-HSA-3000103" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to extracellular region for the reaction in which the cubam (CUBN:AMN) receptor binds the secreted CBLIF:RCbl complex. Correct for a secreted protein acting on the intestinal luminal/apical surface.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the secreted subcellular location and with the other extracellular annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005576" data-r="Reactome:R-HSA-3000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to extracellular region for the reaction &#34;CBLIF binds RCbl&#34; (binding of free cobalamin by secreted intrinsic factor in the intestinal lumen). Correct for the secreted protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with other extracellular-region calls but accurate; the binding of cobalamin by CBLIF occurs extracellularly in the gut lumen.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000137
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005576" data-r="Reactome:R-HSA-3000137" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to extracellular region for the cubam-mediated uptake reaction. Correct for the secreted CBLIF:RCbl complex engaging the cell-surface receptor prior to internalization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the secreted nature of the protein and its extracellular site of action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3296462
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005576" data-r="Reactome:R-HSA-3296462" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to extracellular region for the disease reaction &#34;Defective CUBN does not transport GIF:Cbl&#34;. The extracellular localization of CBLIF is correct regardless of the disease context.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate secreted localization; redundant with the other extracellular annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3296477
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005576" data-r="Reactome:R-HSA-3296477" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to extracellular region for the disease reaction &#34;Defective AMN does not transport GIF:Cbl&#34;. The secreted CBLIF localization is correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate secreted localization; redundant with the other extracellular annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3315455
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005576" data-r="Reactome:R-HSA-3315455" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to extracellular region for the disease reaction &#34;Defective CBLIF does not bind Cbl&#34;. The secreted CBLIF localization is correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate secreted localization; redundant with the other extracellular annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043202" target="_blank" class="term-link">
+                                    GO:0043202
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000137
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0043202" data-r="Reactome:R-HSA-3000137" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to lysosomal lumen. After cubam-mediated endocytosis in the ileal enterocyte, the CBLIF:RCbl complex is delivered to lysosomes, where cobalamin is released and CBLIF is degraded. This is a genuine trafficking endpoint but not the protein&#39;s core (secreted, cobalamin-binding) function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The lysosomal-lumen localization reflects the fate of the internalized complex in the target enterocyte rather than where CBLIF performs its defining function; retain as a correct but non-core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">After interaction with CUBN, the CBLIF-cobalamin complex is internalized via receptor-mediated endocytosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043202" target="_blank" class="term-link">
+                                    GO:0043202
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000243
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0043202" data-r="Reactome:R-HSA-3000243" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS localization to lysosomal lumen for the reaction in which a lysosomal protease degrades CBLIF:RCbl to release cobalamin. Same non-core trafficking endpoint as R-HSA-3000137.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization of the internalized complex within the enterocyte lysosome, but peripheral to CBLIF&#39;s defining secreted cobalamin-binding function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CBLIF/CBLIF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">After interaction with CUBN, the CBLIF-cobalamin complex is internalized via receptor-mediated endocytosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14695536" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14695536
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A genetic polymorphism in the coding region of the gastric i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005576" data-r="PMID:14695536" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA localization to extracellular region. Recombinant CBLIF expressed in COS-7 cells was secreted with size, secretion rate, and pepsin sensitivity similar to native IF, supporting the secreted/extracellular localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for secretion of the protein; core extracellular localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14695536" target="_blank" class="term-link">
+                                        PMID:14695536
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The apparent size, secretion rate, and sensitivity to pepsin hydrolysis of the expressed IF were similar to native IF.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    GO:0005768
+                                </a>
+                            </span>
+                            <span class="term-label">endosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8886952" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8886952
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human gastric intrinsic factor expression is not restricted ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005768" data-r="PMID:8886952" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA localization to endosome, from immunoelectron microscopy of human gastric mucosa showing highest intrinsic factor antigen density on endocytic (and apical) membranes of parietal cells. Reflects the intracellular biosynthetic/secretory and endocytic compartments in the producing cell rather than the core secreted function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A real, experimentally observed localization within intrinsic-factor-producing cells, but peripheral to the protein&#39;s defining extracellular cobalamin-binding/transport role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8886952" target="_blank" class="term-link">
+                                        PMID:8886952
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Immunoelectron microscopy demonstrated the highest antigen density on endocytic and apical membranes of parietal cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005902" target="_blank" class="term-link">
+                                    GO:0005902
+                                </a>
+                            </span>
+                            <span class="term-label">microvillus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8886952" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8886952
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human gastric intrinsic factor expression is not restricted ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0005902" data-r="PMID:8886952" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA localization to microvillus, from the same immuno-localization study of intrinsic factor in gastric mucosa. Represents cell-surface/apical membrane localization in the producing parietal cell; non-core relative to the secreted function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally observed apical/microvillar membrane association in parietal cells; correct but peripheral to CBLIF&#39;s core secreted cobalamin-binding/transport function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8886952" target="_blank" class="term-link">
+                                        PMID:8886952
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Immunoelectron microscopy demonstrated the highest antigen density on endocytic and apical membranes of parietal cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15738392" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15738392
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Hereditary juvenile cobalamin deficiency caused by mutations...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0015889" data-r="PMID:15738392" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IMP annotation to cobalamin transport based on human genetics: biallelic nonsense and missense GIF (CBLIF) mutations cause hereditary intrinsic factor deficiency with juvenile megaloblastic anemia due to intestinal cobalamin malabsorption. This is the strongest experimental support for CBLIF&#39;s role in cobalamin transport/absorption.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Loss-of-function mutations abolishing intestinal cobalamin absorption directly demonstrate CBLIF&#39;s requirement for cobalamin transport; core process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15738392" target="_blank" class="term-link">
+                                        PMID:15738392
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">harbored homozygous nonsense and missense mutations in these four families and in three additional families. The disease in these cases therefore should be classified as hereditary IF deficiency.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8886952" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8886952
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human gastric intrinsic factor expression is not restricted ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0016324" data-r="PMID:8886952" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA localization to apical plasma membrane, from immunoelectron microscopy showing highest intrinsic factor antigen density on apical (and endocytic) membranes of gastric parietal cells. Reflects the apical secretory surface of the producing cell.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported apical membrane association in parietal cells; a correct but non-core localization relative to the secreted extracellular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8886952" target="_blank" class="term-link">
+                                        PMID:8886952
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Immunoelectron microscopy demonstrated the highest antigen density on endocytic and apical membranes of parietal cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14695536" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14695536
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A genetic polymorphism in the coding region of the gastric i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27352" data-a="GO:0031419" data-r="PMID:14695536" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to cobalamin binding, the defining molecular function of CBLIF, assessed for recombinant IF (studied in the context of the congenital IF deficiency-associated Q23R variant). Directly corroborated by the crystal structure of the IF-cobalamin complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cobalamin binding is CBLIF&#39;s core molecular function, supported here by direct assay of the recombinant protein and by structural evidence (PMID:17954916).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14695536" target="_blank" class="term-link">
+                                        PMID:14695536
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The apparent size, secretion rate, and sensitivity to pepsin hydrolysis of the expressed IF were similar to native IF.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" target="_blank" class="term-link">
+                                        PMID:17954916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the Cbl is bound at the interface of the domains in a base-on conformation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Binds dietary cobalamin (vitamin B12) as a secreted carrier and functions as the ligand recognized by the ileal cubam (CUBN/AMN) cargo receptor, thereby mediating receptor-dependent intestinal absorption of cobalamin.</h3>
+                <span class="vote-buttons" data-g="P27352" data-a="FUNCTION: Binds dietary cobalamin (vitamin B12) as a secrete..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                            cobalamin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" target="_blank" class="term-link">
+                                PMID:17954916
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the Cbl is bound at the interface of the domains in a base-on conformation</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15738392" target="_blank" class="term-link">
+                                PMID:15738392
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">harbored homozygous nonsense and missense mutations in these four families and in three additional families. The disease in these cases therefore should be classified as hereditary IF deficiency.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/CBLIF/CBLIF-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Promotes absorption of the essential vitamin cobalamin (Cbl) in the ileum. After interaction with CUBN, the CBLIF-cobalamin complex is internalized via receptor-mediated endocytosis.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Acts as the cargo ligand for the ileal endocytic cubam receptor: the cobalamin-loaded CBLIF complex is recognized by CUBN/AMN and internalized by receptor-mediated endocytosis, coupling cobalamin binding to its cellular uptake.</h3>
+                <span class="vote-buttons" data-g="P27352" data-a="FUNCTION: Acts as the cargo ligand for the ileal endocytic c..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140355" target="_blank" class="term-link">
+                            cargo receptor ligand activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link">
+                                PMID:20237569
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">This occurs by the combined action of the gastric intrinsic factor (IF) and the ileal endocytic cubam receptor formed by the 460-kilodalton (kDa) protein cubilin and the 45-kDa transmembrane protein amnionless.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" target="_blank" class="term-link">
+                                PMID:17954916
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">CUB recognizes both the full-length Cbl-saturated IF complex and the Cbl-saturated cleaved IF complex but not the isolated</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14695536" target="_blank" class="term-link">
+                            PMID:14695536
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A genetic polymorphism in the coding region of the gastric intrinsic factor gene (GIF) is associated with congenital intrinsic factor deficiency.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15738392" target="_blank" class="term-link">
+                            PMID:15738392
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Hereditary juvenile cobalamin deficiency caused by mutations in the intrinsic factor gene.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" target="_blank" class="term-link">
+                            PMID:17954916
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Crystal structure of human intrinsic factor: cobalamin complex at 2.6-A resolution.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link">
+                            PMID:20237569
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for receptor recognition of vitamin-B(12)-intrinsic factor complexes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8886952" target="_blank" class="term-link">
+                            PMID:8886952
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human gastric intrinsic factor expression is not restricted to parietal cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/CBLIF/CBLIF-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry P27352 (IF_HUMAN), Cobalamin binding intrinsic factor</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000103
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CUBN:AMN binds CBLIF:RCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000120
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CBLIF binds RCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000137
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CUBN:AMN-mediated CBLIF:RCbl uptake and delivery to lysosome</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000243
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Unknown lysosomal protease degrades CBLIF:RCbl to release Cbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3296462
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective CUBN does not transport GIF:Cbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3296477
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective AMN does not transport GIF:Cbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3315455
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective CBLIF does not bind Cbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9758881
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Uptake of dietary cobalamins into enterocytes</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CBLIF-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P27352" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cblif-gastric-intrinsic-factor-gif-review-notes">CBLIF (Gastric intrinsic factor / GIF) — review notes</h1>
+<p>UniProtKB:P27352 (IF_HUMAN). HGNC:4268. Synonyms: GIF, IFMH. NCBITaxon:9606.</p>
+<h2 id="summary-of-function">Summary of function</h2>
+<p>CBLIF is the secreted <strong>cobalamin (vitamin B12)-binding glycoprotein</strong> produced by<br />
+gastric parietal cells (and, at anatomical margins, some chief/enteroendocrine cells).<br />
+Its core function is to <strong>bind dietary cobalamin</strong> in the small intestine and to <strong>mediate<br />
+its receptor-dependent absorption in the distal ileum</strong>. The IF–cobalamin complex is taken<br />
+up by the ileal <strong>cubam receptor</strong> (cubilin/CUBN + amnionless/AMN) via receptor-mediated<br />
+endocytosis; the complex is delivered to lysosomes where Cbl is released. CBLIF is NOT an<br />
+enzyme. Loss of function causes <strong>hereditary intrinsic factor deficiency (IFD, MIM:261000)</strong>,<br />
+a form of juvenile/congenital pernicious anemia presenting as megaloblastic anemia from B12<br />
+malabsorption.</p>
+<h2 id="key-provenance">Key provenance</h2>
+<ul>
+<li>FUNCTION: [file:human/CBLIF/CBLIF-uniprot.txt "Promotes absorption of the essential vitamin cobalamin (Cbl) in the ileum. After interaction with CUBN, the CBLIF-cobalamin complex is internalized via receptor-mediated endocytosis."]</li>
+<li>SUBUNIT: [file:human/CBLIF/CBLIF-uniprot.txt "Interacts with CUBN (via CUB domains)."]</li>
+<li>SUBCELLULAR LOCATION: Secreted [file:human/CBLIF/CBLIF-uniprot.txt "SUBCELLULAR LOCATION: Secreted."]</li>
+<li>TISSUE SPECIFICITY: Gastric mucosa [file:human/CBLIF/CBLIF-uniprot.txt "TISSUE SPECIFICITY: Gastric mucosa."]</li>
+<li>DISEASE IFD: megaloblastic anemia [file:human/CBLIF/CBLIF-uniprot.txt "Autosomal recessive disorder characterized by megaloblastic anemia."]</li>
+<li>SIMILARITY: eukaryotic cobalamin transport proteins family (with TCN1 haptocorrin / TCN2 transcobalamin).</li>
+<li>Cbl-binding residues (BINDING features): 171, 222, 270, 365-370, 386-395; C-terminal beta-domain essential for retention.</li>
+</ul>
+<h2 id="literature">Literature</h2>
+<ul>
+<li>
+<p><strong>PMID:17954916</strong> (Mathews et al. 2007, PNAS) — crystal structure of human IF:Cbl at 2.6 Å; alpha6/alpha6 barrel two-domain protein; Cbl bound base-on at domain interface. Basis of Reactome's EXP <code>cargo receptor ligand activity</code> and <code>cobalamin binding</code> calls. <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" title="The structure of intrinsic factor (IF) in complex with cobalamin (Cbl) was determined at 2.6-A resolution.">PMID:17954916</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" title="the Cbl is bound at the interface of the domains in a base-on conformation">PMID:17954916</a>. Also describes the CUB(N) receptor recognition: <a href="https://pubmed.ncbi.nlm.nih.gov/17954916" title="CUB recognizes both the full-length Cbl-saturated IF complex and the Cbl-saturated cleaved IF complex but not the isolated α- or β-domains, even if they are saturated with Cbl">PMID:17954916</a>.</p>
+</li>
+<li>
+<p><strong>PMID:20237569</strong> (Andersen et al. 2010, Nature) — crystal structure of IF:Cbl bound to cubilin CUB(5-8); defines how the cubam receptor recognizes the IF-Cbl complex. Source of the CUBN IPI (IntAct O60494). Abstract-only in cache. Abstract: <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" title="This occurs by the combined action of the gastric intrinsic factor (IF) and the ileal endocytic cubam receptor formed by the 460-kilodalton (kDa) protein cubilin and the 45-kDa transmembrane protein amnionless.">PMID:20237569</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" title="how two distant CUB domains embrace the Cbl molecule by binding the two IF domains in a Ca(2+)-dependent manner">PMID:20237569</a>.</p>
+</li>
+<li>
+<p><strong>PMID:15738392</strong> (Tanner et al. 2005, PNAS) — biallelic GIF mutations (nonsense/missense) cause hereditary IF deficiency; distinct from Imerslund-Grasbeck (CUBN/AMN). IMP evidence for role in cobalamin transport/absorption. <a href="https://pubmed.ncbi.nlm.nih.gov/15738392" title="The gastric IF (GIF) gene located in this region harbored homozygous nonsense and missense mutations in these four families and in three additional families. The disease in these cases therefore should be classified as hereditary IF deficiency.">PMID:15738392</a></p>
+</li>
+<li>
+<p><strong>PMID:14695536</strong> (Gordon et al. 2004, Hum Mutat) — Gln5→Arg (mature Q23R) coding polymorphism associated with congenital IF deficiency; recombinant IF expressed/secreted from COS-7 with native size, secretion rate, pepsin sensitivity. Supports secreted localization and Cbl binding of the expressed protein. <a href="https://pubmed.ncbi.nlm.nih.gov/14695536" title="The apparent size, secretion rate, and sensitivity to pepsin hydrolysis of the expressed IF were similar to native IF.">PMID:14695536</a></p>
+</li>
+<li>
+<p><strong>PMID:8886952</strong> (Howard et al. 1996, J Anat) — immuno-localization of human IF; parietal cells are the main source but expression is not restricted to them. Immunoelectron microscopy: highest antigen density on endocytic and apical membranes of parietal cells; also secretory granules. IDA support for endosome / microvillus / apical plasma membrane localization in the producing cell. <a href="https://pubmed.ncbi.nlm.nih.gov/8886952" title="Immunoelectron microscopy demonstrated the highest antigen density on endocytic and apical membranes of parietal cells.">PMID:8886952</a></p>
+</li>
+<li>
+<p><strong>PMID:32296183</strong> (Luck et al. 2020, Nature) — HuRI high-throughput binary (Y2H) interactome. Source of several IPI <code>protein binding</code> calls (FFAR2, SLC13A4, SLC22A23, SLC7A1, SLC7A14, TMEM237). These are large-scale screen hits with no established biological role for a secreted Cbl-binding protein; treat as uninformative <code>protein binding</code> over-annotations, not true partners.</p>
+</li>
+</ul>
+<h2 id="curation-decisions-high-level">Curation decisions (high level)</h2>
+<ul>
+<li>MF cobalamin binding (GO:0031419): CORE. Multiple lines (IDA/IBA/IEA, crystal structures). ACCEPT.</li>
+<li>BP cobalamin transport (GO:0015889): CORE. IMP (disease), IBA, TAS(Reactome), IEA. ACCEPT.</li>
+<li>CC extracellular region (GO:0005576): CORE (secreted). ACCEPT IBA/IDA; IEA/TAS ACCEPT.</li>
+<li>MF cargo receptor ligand activity (GO:0140355) EXP/Reactome: the IF-Cbl complex is the ligand recognized by the cubam cargo receptor — biologically apt; ACCEPT (this is essentially the receptor-recognition facet of its transport role).</li>
+<li>CC endosome / microvillus / apical plasma membrane (IDA, PMID:8886952): localizations in the producing parietal cell / uptake compartments; not the core secreted function but real. KEEP_AS_NON_CORE.</li>
+<li>CC lysosomal lumen (TAS Reactome): the IF-Cbl complex is delivered to lysosomes in the enterocyte for degradation/Cbl release; real trafficking endpoint, non-core. KEEP_AS_NON_CORE.</li>
+<li>MF protein binding (GO:0005515) IPI: CUBN (PMID:20237569) is the real, functionally central partner but the bare <code>protein binding</code> term is uninformative → MARK_AS_OVER_ANNOTATED (per policy, not REMOVE). HuRI hits (PMID:32296183) → MARK_AS_OVER_ANNOTATED (uninformative screen hits).<br />
+</content></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P27352
+gene_symbol: CBLIF
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  CBLIF (gastric intrinsic factor, GIF; also called intrinsic factor, IF) is a secreted
+  cobalamin (vitamin B12)-binding glycoprotein produced by gastric parietal cells (and,
+  at the margins of gastric anatomical regions, by some chief and enteroendocrine cells).
+  Its principal role is the intestinal absorption of dietary cobalamin: after cobalamin is
+  released from salivary/gastric haptocorrin in the proximal small intestine, CBLIF binds
+  it tightly, and the resulting CBLIF-cobalamin complex is recognized in the distal ileum
+  by the cubam receptor formed by cubilin (CUBN) and amnionless (AMN). Cubam mediates
+  receptor-dependent endocytosis of the complex, which is then delivered to lysosomes where
+  cobalamin is released for cellular use. Structurally CBLIF is a two-domain alpha6/alpha6
+  barrel protein that binds one cobalamin at the domain interface in a base-on conformation.
+  It is not an enzyme; it functions as a cobalamin-binding carrier and as the ligand
+  recognized by the cubam cargo receptor. Loss-of-function mutations cause hereditary
+  intrinsic factor deficiency (congenital/juvenile pernicious anemia; MIM:261000), a form of
+  megaloblastic anemia resulting from vitamin B12 malabsorption.
+alternative_products:
+- name: &#39;1&#39;
+  id: P27352-1
+- name: &#39;2&#39;
+  id: P27352-2
+  sequence_note: VSP_041585
+existing_annotations:
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation placing CBLIF in the extracellular region. CBLIF is a
+      secreted protein that acts extracellularly (in the gut lumen / on the intestinal
+      apical surface) to bind and deliver cobalamin, so this is correct and part of the
+      core biology.
+    action: ACCEPT
+    reason: &gt;-
+      UniProt records the protein as secreted, and it functions extracellularly as a
+      cobalamin carrier. The IBA call is consistent with experimental localization and the
+      known biology.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation to cobalamin transport. CBLIF is required for intestinal
+      absorption of dietary cobalamin, binding it and mediating cubam(CUBN/AMN)-dependent
+      uptake in the ileum. This is a core biological process for the gene.
+    action: ACCEPT
+    reason: &gt;-
+      Supported experimentally by human loss-of-function disease (hereditary IF deficiency)
+      and by the well-established IF-cobalamin/cubam absorption pathway. Correct and core.
+    supported_by:
+    - reference_id: PMID:20237569
+      supporting_text: &gt;-
+        This occurs by the combined action of the gastric intrinsic factor (IF) and the
+        ileal endocytic cubam receptor formed by the 460-kilodalton (kDa) protein cubilin
+        and the 45-kDa transmembrane protein amnionless.
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &gt;-
+        Promotes absorption of the essential vitamin cobalamin (Cbl) in the ileum. After
+        interaction with CUBN, the CBLIF-cobalamin complex is internalized via
+        receptor-mediated endocytosis.
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation to cobalamin binding, the defining molecular function of
+      CBLIF. This is directly supported by the crystal structure of the human IF-cobalamin
+      complex and by defined cobalamin-contacting residues in UniProt.
+    action: ACCEPT
+    reason: &gt;-
+      Cobalamin binding is the core molecular function of intrinsic factor, confirmed by
+      structural and biochemical evidence. The IBA call is at the correct level of
+      specificity.
+    supported_by:
+    - reference_id: PMID:17954916
+      supporting_text: &gt;-
+        the Cbl is bound at the interface of the domains in a base-on conformation
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation to extracellular region derived from the UniProt &#34;Secreted&#34;
+      subcellular location keyword mapping. Consistent with the experimental and
+      phylogenetic evidence for a secreted protein.
+    action: ACCEPT
+    reason: &gt;-
+      Redundant with the IBA/IDA extracellular-region calls but correct; the SubCell mapping
+      accurately reflects the secreted nature of the protein.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation (IPR002157, cobalamin-binding protein) to cobalamin
+      transport. Consistent with the experimentally supported transport role.
+    action: ACCEPT
+    reason: &gt;-
+      The InterPro family mapping is biologically appropriate for CBLIF and matches the
+      experimental IMP/IBA/TAS annotations to the same process.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &gt;-
+        Promotes absorption of the essential vitamin cobalamin (Cbl) in the ileum.
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation (IPR002157) to cobalamin binding. Matches the
+      structurally validated core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      The cobalamin-binding domain assignment is correct for CBLIF and the mapped MF term is
+      the defining function, corroborated by crystallography (PMID:17954916).
+    supported_by:
+    - reference_id: PMID:17954916
+      supporting_text: &gt;-
+        The structure of intrinsic factor (IF) in complex with cobalamin (Cbl) was
+        determined at 2.6-A resolution.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20237569
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI annotation to the generic term protein binding, capturing the interaction with
+      cubilin (CUBN, IntAct O60494). This interaction is real and functionally central (the
+      IF-Cbl complex is recognized by the CUBN/AMN cubam receptor for ileal uptake), and is
+      structurally defined. However, the bare &#34;protein binding&#34; term is uninformative about
+      the actual function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation guidance, the uninformative &#34;protein binding&#34; term should not be treated
+      as a core function even though the underlying CUBN interaction is genuine. The
+      functional content of this interaction is better represented by the
+      cobalamin-transport process and the cargo receptor ligand activity annotations, and by
+      the specific CUBN partner recorded in UniProt SUBUNIT.
+    supported_by:
+    - reference_id: PMID:20237569
+      supporting_text: &gt;-
+        how two distant CUB domains embrace the Cbl molecule by binding the two IF domains
+        in a Ca(2+)-dependent manner
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &#34;Interacts with CUBN (via CUB domains).&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI annotation to protein binding from the HuRI high-throughput binary (yeast
+      two-hybrid) interactome screen. The recorded partners (FFAR2, SLC13A4, SLC22A23,
+      SLC7A1, SLC7A14, TMEM237) are membrane transporters/GPCRs with no established
+      biological relationship to a secreted cobalamin-binding protein.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These are uninformative large-scale screen hits and the bare &#34;protein binding&#34; term
+      conveys no functional information; they are very unlikely to reflect physiological
+      partners of a secreted extracellular Cbl carrier. Marked as over-annotated rather than
+      removed, per policy for IPI protein-binding annotations.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &gt;-
+        reference interactome map of human binary protein interactions
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9758881
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to cobalamin transport, from the &#34;Uptake of dietary cobalamins
+      into enterocytes&#34; pathway. CBLIF binds dietary cobalamin and delivers it to the ileal
+      cubam receptor for absorption; this is the core process.
+    action: ACCEPT
+    reason: &gt;-
+      Reactome&#39;s pathway representation accurately captures CBLIF&#39;s role in the intestinal
+      cobalamin absorption pathway, consistent with experimental (IMP) and phylogenetic
+      (IBA) annotations.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &gt;-
+        Promotes absorption of the essential vitamin cobalamin (Cbl) in the ileum.
+- term:
+    id: GO:0140355
+    label: cargo receptor ligand activity
+  evidence_type: EXP
+  original_reference_id: PMID:17954916
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental annotation to cargo receptor ligand activity. The cobalamin-loaded CBLIF
+      complex is the ligand recognized by the cubam (CUBN/AMN) cargo receptor, which then
+      internalizes it by endocytosis in the ileum. This captures the receptor-recognition
+      facet of CBLIF&#39;s transport function.
+    action: ACCEPT
+    reason: &gt;-
+      Structural work shows CUBN recognizes the Cbl-saturated IF complex, and the complex is
+      taken up by receptor-mediated endocytosis; &#34;cargo receptor ligand activity&#34; is the
+      appropriate MF for a secreted carrier ligand that engages an endocytic receptor. This
+      is an informative, core molecular function.
+    supported_by:
+    - reference_id: PMID:17954916
+      supporting_text: &gt;-
+        CUB recognizes both the full-length Cbl-saturated IF complex and the Cbl-saturated
+        cleaved IF complex but not the isolated
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &gt;-
+        After interaction with CUBN, the CBLIF-cobalamin complex is internalized via
+        receptor-mediated endocytosis.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000103
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to extracellular region for the reaction in which the cubam
+      (CUBN:AMN) receptor binds the secreted CBLIF:RCbl complex. Correct for a secreted
+      protein acting on the intestinal luminal/apical surface.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the secreted subcellular location and with the other extracellular
+      annotations.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to extracellular region for the reaction &#34;CBLIF binds RCbl&#34;
+      (binding of free cobalamin by secreted intrinsic factor in the intestinal lumen).
+      Correct for the secreted protein.
+    action: ACCEPT
+    reason: &gt;-
+      Redundant with other extracellular-region calls but accurate; the binding of cobalamin
+      by CBLIF occurs extracellularly in the gut lumen.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000137
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to extracellular region for the cubam-mediated uptake
+      reaction. Correct for the secreted CBLIF:RCbl complex engaging the cell-surface
+      receptor prior to internalization.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the secreted nature of the protein and its extracellular site of
+      action.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3296462
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to extracellular region for the disease reaction &#34;Defective
+      CUBN does not transport GIF:Cbl&#34;. The extracellular localization of CBLIF is correct
+      regardless of the disease context.
+    action: ACCEPT
+    reason: &gt;-
+      Accurate secreted localization; redundant with the other extracellular annotations.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3296477
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to extracellular region for the disease reaction &#34;Defective
+      AMN does not transport GIF:Cbl&#34;. The secreted CBLIF localization is correct.
+    action: ACCEPT
+    reason: &gt;-
+      Accurate secreted localization; redundant with the other extracellular annotations.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3315455
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to extracellular region for the disease reaction &#34;Defective
+      CBLIF does not bind Cbl&#34;. The secreted CBLIF localization is correct.
+    action: ACCEPT
+    reason: &gt;-
+      Accurate secreted localization; redundant with the other extracellular annotations.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0043202
+    label: lysosomal lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000137
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to lysosomal lumen. After cubam-mediated endocytosis in the
+      ileal enterocyte, the CBLIF:RCbl complex is delivered to lysosomes, where cobalamin is
+      released and CBLIF is degraded. This is a genuine trafficking endpoint but not the
+      protein&#39;s core (secreted, cobalamin-binding) function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The lysosomal-lumen localization reflects the fate of the internalized complex in the
+      target enterocyte rather than where CBLIF performs its defining function; retain as a
+      correct but non-core localization.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &gt;-
+        After interaction with CUBN, the CBLIF-cobalamin complex is internalized via
+        receptor-mediated endocytosis.
+- term:
+    id: GO:0043202
+    label: lysosomal lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000243
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS localization to lysosomal lumen for the reaction in which a lysosomal
+      protease degrades CBLIF:RCbl to release cobalamin. Same non-core trafficking endpoint
+      as R-HSA-3000137.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct localization of the internalized complex within the enterocyte lysosome, but
+      peripheral to CBLIF&#39;s defining secreted cobalamin-binding function.
+    supported_by:
+    - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+      supporting_text: &gt;-
+        After interaction with CUBN, the CBLIF-cobalamin complex is internalized via
+        receptor-mediated endocytosis.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IDA
+  original_reference_id: PMID:14695536
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      IDA localization to extracellular region. Recombinant CBLIF expressed in COS-7 cells
+      was secreted with size, secretion rate, and pepsin sensitivity similar to native IF,
+      supporting the secreted/extracellular localization.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental support for secretion of the protein; core extracellular
+      localization.
+    supported_by:
+    - reference_id: PMID:14695536
+      supporting_text: &gt;-
+        The apparent size, secretion rate, and sensitivity to pepsin hydrolysis of the
+        expressed IF were similar to native IF.
+- term:
+    id: GO:0005768
+    label: endosome
+  evidence_type: IDA
+  original_reference_id: PMID:8886952
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      IDA localization to endosome, from immunoelectron microscopy of human gastric mucosa
+      showing highest intrinsic factor antigen density on endocytic (and apical) membranes
+      of parietal cells. Reflects the intracellular biosynthetic/secretory and endocytic
+      compartments in the producing cell rather than the core secreted function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A real, experimentally observed localization within intrinsic-factor-producing cells,
+      but peripheral to the protein&#39;s defining extracellular cobalamin-binding/transport
+      role.
+    supported_by:
+    - reference_id: PMID:8886952
+      supporting_text: &gt;-
+        Immunoelectron microscopy demonstrated the highest antigen density on endocytic and
+        apical membranes of parietal cells.
+- term:
+    id: GO:0005902
+    label: microvillus
+  evidence_type: IDA
+  original_reference_id: PMID:8886952
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      IDA localization to microvillus, from the same immuno-localization study of intrinsic
+      factor in gastric mucosa. Represents cell-surface/apical membrane localization in the
+      producing parietal cell; non-core relative to the secreted function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally observed apical/microvillar membrane association in parietal cells;
+      correct but peripheral to CBLIF&#39;s core secreted cobalamin-binding/transport function.
+    supported_by:
+    - reference_id: PMID:8886952
+      supporting_text: &gt;-
+        Immunoelectron microscopy demonstrated the highest antigen density on endocytic and
+        apical membranes of parietal cells.
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IMP
+  original_reference_id: PMID:15738392
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IMP annotation to cobalamin transport based on human genetics: biallelic nonsense and
+      missense GIF (CBLIF) mutations cause hereditary intrinsic factor deficiency with
+      juvenile megaloblastic anemia due to intestinal cobalamin malabsorption. This is the
+      strongest experimental support for CBLIF&#39;s role in cobalamin transport/absorption.
+    action: ACCEPT
+    reason: &gt;-
+      Loss-of-function mutations abolishing intestinal cobalamin absorption directly
+      demonstrate CBLIF&#39;s requirement for cobalamin transport; core process.
+    supported_by:
+    - reference_id: PMID:15738392
+      supporting_text: &gt;-
+        harbored homozygous nonsense and missense mutations in these four families and in
+        three additional families. The disease in these cases therefore should be classified
+        as hereditary IF deficiency.
+- term:
+    id: GO:0016324
+    label: apical plasma membrane
+  evidence_type: IDA
+  original_reference_id: PMID:8886952
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      IDA localization to apical plasma membrane, from immunoelectron microscopy showing
+      highest intrinsic factor antigen density on apical (and endocytic) membranes of gastric
+      parietal cells. Reflects the apical secretory surface of the producing cell.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported apical membrane association in parietal cells; a correct but
+      non-core localization relative to the secreted extracellular function.
+    supported_by:
+    - reference_id: PMID:8886952
+      supporting_text: &gt;-
+        Immunoelectron microscopy demonstrated the highest antigen density on endocytic and
+        apical membranes of parietal cells.
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IDA
+  original_reference_id: PMID:14695536
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IDA annotation to cobalamin binding, the defining molecular function of CBLIF, assessed
+      for recombinant IF (studied in the context of the congenital IF deficiency-associated
+      Q23R variant). Directly corroborated by the crystal structure of the IF-cobalamin
+      complex.
+    action: ACCEPT
+    reason: &gt;-
+      Cobalamin binding is CBLIF&#39;s core molecular function, supported here by direct assay of
+      the recombinant protein and by structural evidence (PMID:17954916).
+    supported_by:
+    - reference_id: PMID:14695536
+      supporting_text: &gt;-
+        The apparent size, secretion rate, and sensitivity to pepsin hydrolysis of the
+        expressed IF were similar to native IF.
+    - reference_id: PMID:17954916
+      supporting_text: &gt;-
+        the Cbl is bound at the interface of the domains in a base-on conformation
+core_functions:
+- description: &gt;-
+    Binds dietary cobalamin (vitamin B12) as a secreted carrier and functions as the ligand
+    recognized by the ileal cubam (CUBN/AMN) cargo receptor, thereby mediating
+    receptor-dependent intestinal absorption of cobalamin.
+  molecular_function:
+    id: GO:0031419
+    label: cobalamin binding
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0005576
+    label: extracellular region
+  supported_by:
+  - reference_id: PMID:17954916
+    supporting_text: &gt;-
+      the Cbl is bound at the interface of the domains in a base-on conformation
+  - reference_id: PMID:15738392
+    supporting_text: &gt;-
+      harbored homozygous nonsense and missense mutations in these four families and in
+      three additional families. The disease in these cases therefore should be classified
+      as hereditary IF deficiency.
+  - reference_id: file:human/CBLIF/CBLIF-uniprot.txt
+    supporting_text: &gt;-
+      Promotes absorption of the essential vitamin cobalamin (Cbl) in the ileum. After
+      interaction with CUBN, the CBLIF-cobalamin complex is internalized via
+      receptor-mediated endocytosis.
+- description: &gt;-
+    Acts as the cargo ligand for the ileal endocytic cubam receptor: the cobalamin-loaded
+    CBLIF complex is recognized by CUBN/AMN and internalized by receptor-mediated
+    endocytosis, coupling cobalamin binding to its cellular uptake.
+  molecular_function:
+    id: GO:0140355
+    label: cargo receptor ligand activity
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0005576
+    label: extracellular region
+  supported_by:
+  - reference_id: PMID:20237569
+    supporting_text: &gt;-
+      This occurs by the combined action of the gastric intrinsic factor (IF) and the ileal
+      endocytic cubam receptor formed by the 460-kilodalton (kDa) protein cubilin and the
+      45-kDa transmembrane protein amnionless.
+  - reference_id: PMID:17954916
+    supporting_text: &gt;-
+      CUB recognizes both the full-length Cbl-saturated IF complex and the Cbl-saturated
+      cleaved IF complex but not the isolated
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:14695536
+  title: A genetic polymorphism in the coding region of the gastric intrinsic factor
+    gene (GIF) is associated with congenital intrinsic factor deficiency.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Reports the GIF Q5R (mature Q23R) coding polymorphism associated with
+      congenital IF deficiency and shows recombinant IF is secreted with native-like
+      properties; supports secreted localization and cobalamin binding of the protein.
+- id: PMID:15738392
+  title: Hereditary juvenile cobalamin deficiency caused by mutations in the intrinsic
+    factor gene.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Establishes that biallelic GIF (CBLIF) mutations cause hereditary
+      intrinsic factor deficiency (juvenile megaloblastic anemia from B12 malabsorption);
+      strong genetic support for CBLIF&#39;s role in intestinal cobalamin transport.
+- id: PMID:17954916
+  title: &#39;Crystal structure of human intrinsic factor: cobalamin complex at 2.6-A
+    resolution.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Crystal structure of human IF-cobalamin; establishes cobalamin
+      binding at the two-domain interface and discusses CUBN receptor recognition of the
+      Cbl-saturated complex.
+- id: PMID:20237569
+  title: Structural basis for receptor recognition of vitamin-B(12)-intrinsic factor
+    complexes.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (abstract-only in cache). Crystal structure of the IF-Cbl complex bound
+      to cubilin CUB(5-8); source of the CUBN IPI and defines cubam receptor recognition.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: LOW_QUALITY
+    review_notes: &gt;-
+      PubMed-verified. HuRI high-throughput binary (Y2H) interactome; the CBLIF hits
+      (FFAR2, SLC13A4, SLC22A23, SLC7A1, SLC7A14, TMEM237) are unvalidated screen
+      interactions with no established biological role for a secreted Cbl-binding protein.
+- id: PMID:8886952
+  title: Human gastric intrinsic factor expression is not restricted to parietal cells.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified. Immuno-localization of intrinsic factor in human gastric mucosa;
+      supports parietal-cell production and apical/endocytic membrane localization; source
+      of the endosome/microvillus/apical plasma membrane IDA localizations.
+- id: file:human/CBLIF/CBLIF-uniprot.txt
+  title: UniProtKB entry P27352 (IF_HUMAN), Cobalamin binding intrinsic factor
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      UniProt curated record; source of the FUNCTION (secreted cobalamin absorption via
+      CUBN), SUBUNIT (interacts with CUBN via CUB domains), secreted subcellular location,
+      gastric-mucosa tissue specificity, and IFD disease association.
+- id: Reactome:R-HSA-3000103
+  title: CUBN:AMN binds CBLIF:RCbl
+  findings: []
+- id: Reactome:R-HSA-3000120
+  title: CBLIF binds RCbl
+  findings: []
+- id: Reactome:R-HSA-3000137
+  title: CUBN:AMN-mediated CBLIF:RCbl uptake and delivery to lysosome
+  findings: []
+- id: Reactome:R-HSA-3000243
+  title: Unknown lysosomal protease degrades CBLIF:RCbl to release Cbl
+  findings: []
+- id: Reactome:R-HSA-3296462
+  title: Defective CUBN does not transport GIF:Cbl
+  findings: []
+- id: Reactome:R-HSA-3296477
+  title: Defective AMN does not transport GIF:Cbl
+  findings: []
+- id: Reactome:R-HSA-3315455
+  title: Defective CBLIF does not bind Cbl
+  findings: []
+- id: Reactome:R-HSA-9758881
+  title: Uptake of dietary cobalamins into enterocytes
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/CD320/CD320-ai-review.html
+++ b/genes/human/CD320/CD320-ai-review.html
@@ -1,0 +1,4268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CD320 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>CD320</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9NPF0" target="_blank" class="term-link">
+                        Q9NPF0
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "CD320";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9NPF0" data-a="DESCRIPTION: CD320 (CD320 antigen; transcobalamin receptor, TCb..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>CD320 (CD320 antigen; transcobalamin receptor, TCblR; historically the &#34;8D6 antigen&#34; or follicular dendritic cell signaling molecule 8D6) is a single-pass type I plasma membrane glycoprotein of the low-density lipoprotein receptor (LDLR) family. Its extracellular region contains two LDLR class A (LDLR-A) domains, each coordinating a central calcium ion, separated by an EGF/complement-like cysteine-rich region. CD320 is a non-enzymatic cell-surface cargo/endocytic receptor that captures the transcobalamin-cobalamin complex (holo-transcobalamin, TC-Cbl) from the circulation and internalizes it by receptor-mediated endocytosis, providing the principal route for cellular uptake of vitamin B12 (cobalamin) by peripheral tissues. It binds transcobalamin with high affinity and specificity (and does not bind haptocorrin); ligand binding is calcium-dependent and is released at endosomal low pH, allowing the receptor to recycle to the cell surface. CD320 expression is coupled to the cell cycle, being highest in actively proliferating cells and upregulated in many cancers. Biallelic in-frame variants (most commonly a p.Glu88 deletion in LDLR-A1) reduce cobalamin-transport function and cause transient/mild methylmalonic aciduria detected on newborn screening (transcobalamin receptor defect, MATR/MMATC), a largely asymptomatic condition.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that CD320 acts at the plasma membrane. This is correct and central to its function: CD320 is a single-pass type I cell-surface receptor that binds and internalizes the TC-Cbl complex from the extracellular space.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by experimental subcellular-location data and by the biology of the receptor. The plasma membrane is the site where CD320 captures circulating holo-transcobalamin.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                                        PMID:18779389
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC- cobalamin (Cbl) and internalizes the complex by endocytosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005886" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt subcellular-location keyword mapping to plasma membrane. Consistent with the experimentally established cell-membrane localization of CD320.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with, but consistent with, the experimental plasma membrane annotations (PMID:10727470, PMID:18779389). UniProt annotates &#34;Cell membrane; Single-pass type I membrane protein&#34;.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CD320/CD320-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0016020" data-r="GO_REF:0000117" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic annotation to the generic parent term &#34;membrane&#34;. True but far less informative than the plasma membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CD320 is a single-pass membrane protein, so &#34;membrane&#34; is not wrong, but the more specific and better-supported term is plasma membrane. Recommend replacing with the specific location.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    plasma membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CD320/CD320-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Single-pass</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016192" target="_blank" class="term-link">
+                                    GO:0016192
+                                </a>
+                            </span>
+                            <span class="term-label">vesicle-mediated transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0016192" data-r="GO_REF:0000117" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA electronic annotation to vesicle-mediated transport. CD320 internalizes its ligand by receptor-mediated endocytosis, which is a form of vesicle-mediated transport, so this is correct but general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The specific mechanism is receptor-mediated endocytosis of the TC-Cbl complex; recommend the more precise child term rather than the broad parent.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006898" target="_blank" class="term-link">
+                                    receptor-mediated endocytosis
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                        PMID:27411955
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated endocytosis, which requires Ca2+-dependent complex formation of TC with its cognate cell surface receptor CD320</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27411955
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis of transcobalamin recognition by human CD32...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005515" data-r="PMID:27411955" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI capturing the physical interaction of CD320 with its physiological ligand transcobalamin (TCN2, P20062), shown by crystallography and biochemistry. &#34;protein binding&#34; is uninformative on its own; the informative molecular function is captured by cargo receptor activity (GO:0038024) and cobalamin binding (GO:0031419) in core_functions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The interaction is real and important (CD320-TCN2), but the bare &#34;protein binding&#34; term does not convey the receptor function. The specific cargo-receptor/cobalamin role is captured elsewhere; per curation guidelines the generic term is retained but flagged rather than used as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                        PMID:27411955
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cellular uptake of vitamin B12 (cobalamin) requires capture of transcobalamin</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CD320/CD320-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interacts (via LDL-receptor class A domains) with TCN2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35922511" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35922511
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A physical wiring diagram for the human immune system.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005515" data-r="PMID:35922511" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI from a large-scale human immune surface-receptor interactome screen, recording the CD320-JAML (AMICA1, Q86YT9) interaction; in that study CD320 contributed to natural killer cell activation. This is a secondary immune interaction distinct from the core B12-receptor function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A genuine physical interaction from a systematic screen, but &#34;protein binding&#34; is uninformative and this immune adhesion/costimulation role is peripheral to the core cobalamin-uptake function. Retained but flagged rather than treated as core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35922511" target="_blank" class="term-link">
+                                        PMID:35922511
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the adhesion proteins CHL1 and CD320 (along with CD58 as previously described31) facilitating natural killer (NK) cell activation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9758890
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0015889" data-r="Reactome:R-HSA-9758890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement annotation placing CD320 in cobalamin transport (transport of cobalamins within the body). This is a core biological process for CD320: it delivers TC-bound cobalamin into cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported by experimental literature (PMID:18779389, PMID:20524213) and by the Reactome pathway model of TC-Cbl uptake and distribution.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20524213" target="_blank" class="term-link">
+                                        PMID:20524213
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TCblR expressed on the plasma membrane binds transcobalamin (TC) saturated with Cbl (holo-TC) and mediates cellular uptake of Cbl</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11418631" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11418631
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The distinct roles of T cell-derived cytokines and a novel f...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005886" data-r="PMID:11418631" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental plasma-membrane localization from the FDC-signaling-molecule 8D6 characterization (8D6 = CD320). CD320 is detected on follicular dendritic cells at the cell surface.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct cell-surface localization; consistent with the receptor&#39;s function and with other experimental and IBA plasma-membrane annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11418631" target="_blank" class="term-link">
+                                        PMID:11418631
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A novel FDC-signaling molecule 8D6 (FDC-SM-8D6) produced by FDC augments PC generation in the GC.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                                    GO:0038024
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15652495" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15652495
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The binding properties of the human receptor for the cellula...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0038024" data-r="PMID:15652495" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental molecular-function annotation to cargo receptor activity. This is the core molecular function of CD320: it is the plasma-membrane receptor that binds the transcobalamin-cobalamin cargo and mediates its endocytic internalization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported: the receptor binds holo-TC and internalizes the TC-Cbl complex by endocytosis, the defining activity of an endocytic cargo receptor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15652495" target="_blank" class="term-link">
+                                        PMID:15652495
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is mediated by a receptor</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15652495" target="_blank" class="term-link">
+                                        PMID:15652495
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">internalizes the TC-Cbl by endocytosis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005509" target="_blank" class="term-link">
+                                    GO:0005509
+                                </a>
+                            </span>
+                            <span class="term-label">calcium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27411955
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis of transcobalamin recognition by human CD32...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005509" data-r="PMID:27411955" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay calcium-ion binding from the crystal structure: each of the two LDLR-A domains of CD320 coordinates a central Ca2+ ion. Calcium is required for formation of the TC-CD320 complex and hence for ligand capture.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Structurally demonstrated Ca2+ coordination in both LDLR-A domains (PDB:4ZRP/4ZRQ); UniProt annotates twelve Ca2+-binding residues across the two domains. This is a genuine structural molecular function underpinning ligand binding, though secondary to the cargo-receptor function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                        PMID:27411955
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both LDLR-A domains contain central Ca2+ ions bound by four conserved acidic residues and two backbone carbonyls in an octahedral coordination.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10727470" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10727470
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of a human follicular dendritic cell molecule...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005886" data-r="PMID:10727470" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay plasma-membrane localization from the original 8D6/CD320 identification: the 8D6 antigen (CD320) is expressed abundantly on the surface of follicular dendritic cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and well supported cell-surface localization consistent with the receptor function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10727470" target="_blank" class="term-link">
+                                        PMID:10727470
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The 8D6 Ag is a novel protein of 282 amino acids that is expressed abundantly on FDCs.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18779389
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The protein and the gene encoding the receptor for the cellu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0015889" data-r="PMID:18779389" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cobalamin transport based on characterization of the purified receptor protein and its gene: TCblR/CD320 on the plasma membrane binds holo-TC and internalizes the complex by endocytosis, mediating cellular cobalamin uptake. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental basis for CD320&#39;s role in cobalamin transport; the receptor was purified and shown to bind and internalize TC-Cbl.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                                        PMID:18779389
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC- cobalamin (Cbl) and internalizes the complex by endocytosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030890" target="_blank" class="term-link">
+                                    GO:0030890
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of B cell proliferation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10727470" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10727470
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of a human follicular dendritic cell molecule...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0030890" data-r="PMID:10727470" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Based on the original 8D6/CD320 characterization on follicular dendritic cells: CD320 (8D6 antigen) costimulates growth of germinal-center B cells, and blocking mAb 8D6 inhibits their proliferation. This is a genuine but tissue/context-specific immune role predating the identification of the B12-receptor function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported (IMP with blocking antibody), so retained; but this immune costimulatory activity is peripheral to CD320&#39;s universal core function as the transcobalamin/cobalamin-uptake receptor and is plausibly downstream of proliferation-coupled B12 supply. Marked non-core rather than removed, deferring to the experimental curation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10727470" target="_blank" class="term-link">
+                                        PMID:10727470
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Monolayers of COS cells transiently transfected with the 8D6 Ag cDNA stimulate B cell growth.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031296" target="_blank" class="term-link">
+                                    GO:0031296
+                                </a>
+                            </span>
+                            <span class="term-label">B cell costimulation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10727470" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10727470
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of a human follicular dendritic cell molecule...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0031296" data-r="PMID:10727470" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CD320 (8D6 antigen) on follicular dendritic cells provides a costimulatory signal for germinal-center B-cell growth and differentiation; blocking mAb 8D6 abolishes this costimulation. Genuine but context-specific immune role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported costimulation activity, retained; peripheral to the core cobalamin-uptake receptor function and specific to the FDC-B cell context.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10727470" target="_blank" class="term-link">
+                                        PMID:10727470
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The mAb 8D6 blocks the costimulatory function completely.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20524213" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20524213
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Positive newborn screen for methylmalonic aciduria identifie...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0015889" data-r="PMID:20524213" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Cobalamin transport supported by the first disease mutation: an in-frame p.E88del in CD320 decreases uptake of holo-TC in patient fibroblasts and causes methylmalonic aciduria; reinserting the codon restores receptor function. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genetic loss-of-function evidence (IMP) directly ties CD320 to cobalamin transport, the only physiologic route for TC-bound cobalamin into cells.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20524213" target="_blank" class="term-link">
+                                        PMID:20524213
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The only route for physiologic transport of TC-bound Cbl into cells is via TCblR.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20524213" target="_blank" class="term-link">
+                                        PMID:20524213
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Inserting the codon by site-directed mutagenesis fully restored TCblR function.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0016020" data-r="PMID:19946888" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mass-spectrometry detection of CD320 in the membrane proteome of an NK-like cell line. Supports membrane localization but at the generic &#34;membrane&#34; level.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct that CD320 is membrane-associated, but this proteomic dataset does not distinguish membrane compartments; the specific and better-supported term is plasma membrane.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    plasma membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mass spectrometric analysis identified 1843 proteins with high confidence scores.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3325546
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005886" data-r="Reactome:R-HSA-3325546" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS plasma-membrane annotation from the model of defective CD320 failing to transport TCII:Cbl to the endosome. Consistent with the receptor&#39;s cell-surface location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct cell-surface localization, corroborated by experimental data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                                        PMID:18779389
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC- cobalamin (Cbl) and internalizes the complex by endocytosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000112
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005886" data-r="Reactome:R-HSA-3000112" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS plasma-membrane annotation from the CD320-mediated TCN2:RCbl uptake and lysosomal delivery model, in which CD320 recycles to the plasma membrane after internalization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct cell-surface localization; the receptor cycles between the plasma membrane and endosomes during ligand uptake.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                                        PMID:18779389
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC- cobalamin (Cbl) and internalizes the complex by endocytosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000122
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005886" data-r="Reactome:R-HSA-3000122" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS plasma-membrane annotation from the &#34;CD320 binds extracellular TCN2:RCbl&#34; reaction. Consistent with the receptor capturing its ligand at the cell surface.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct cell-surface localization; site of ligand capture.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                                        PMID:18779389
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC- cobalamin (Cbl) and internalizes the complex by endocytosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18779389
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The protein and the gene encoding the receptor for the cellu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005886" data-r="PMID:18779389" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI-assigned direct-assay plasma-membrane localization from characterization of the purified receptor. The receptor is a plasma-membrane protein that binds and internalizes TC-Cbl.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported cell-surface localization consistent with all other localization evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                                        PMID:18779389
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC- cobalamin (Cbl) and internalizes the complex by endocytosis.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18779389
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The protein and the gene encoding the receptor for the cellu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0031419" data-r="PMID:18779389" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay cobalamin binding: CD320 binds cobalamin in the form of the transcobalamin-cobalamin complex (holo-TC), the ligand it captures at the cell surface. Core molecular function alongside cargo receptor activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The purified receptor binds holo-TC (TC saturated with Cbl); recognition of the cobalamin-loaded ligand is central to its function. LDLR-family; binds TC-Cbl with high affinity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                                        PMID:18779389
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC- cobalamin (Cbl) and internalizes the complex by endocytosis.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                                        PMID:18779389
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">TCblR belongs to the low-density lipoprotein receptor family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000054
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NPF0" data-a="GO:0005783" data-r="GO_REF:0000054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> LIFEdb annotation from imaging of an overexpressed GFP/epitope-tagged fusion protein. ER signal for a plasma-membrane receptor most likely reflects the biosynthetic/secretory pathway of an overexpressed membrane protein rather than a functional ER localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CD320 is a single-pass plasma-membrane receptor; like all such proteins it transits the ER during biosynthesis, but its functional compartment is the cell surface (and endosomes during uptake). ER localization from a single high-throughput overexpressed-fusion assay is not a core function and is an over-annotation of the functional site.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CD320/CD320-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cell-surface cargo/endocytic receptor that captures the transcobalamin-cobalamin complex (holo-TC) from plasma and mediates its uptake by receptor-mediated endocytosis, delivering vitamin B12 (cobalamin) into cells.</h3>
+                <span class="vote-buttons" data-g="Q9NPF0" data-a="FUNCTION: Cell-surface cargo/endocytic receptor that capture..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                            cargo receptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                                PMID:18779389
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC- cobalamin (Cbl) and internalizes the complex by endocytosis.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15652495" target="_blank" class="term-link">
+                                PMID:15652495
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">internalizes the TC-Cbl by endocytosis</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Internalization of the bound transcobalamin-cobalamin ligand from the plasma membrane via receptor-mediated endocytosis; ligand is released at endosomal low pH and the receptor recycles to the cell surface.</h3>
+                <span class="vote-buttons" data-g="Q9NPF0" data-a="FUNCTION: Internalization of the bound transcobalamin-cobala..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                            cargo receptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006898" target="_blank" class="term-link">
+                                receptor-mediated endocytosis
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                PMID:27411955
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated endocytosis, which requires Ca2+-dependent complex formation of TC with its cognate cell surface receptor CD320</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Recognition and binding of cobalamin in the form of the transcobalamin-cobalamin (holo-TC) complex, the ligand captured by CD320 at the cell surface.</h3>
+                <span class="vote-buttons" data-g="Q9NPF0" data-a="FUNCTION: Recognition and binding of cobalamin in the form o..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                            cobalamin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                                PMID:18779389
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC- cobalamin (Cbl) and internalizes the complex by endocytosis.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000054.md" target="_blank" class="term-link">
+                            GO_REF:0000054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of intracellular localizations of expressed fusion proteins in living cells</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/CD320/CD320-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q9NPF0 (CD320_HUMAN)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10727470" target="_blank" class="term-link">
+                            PMID:10727470
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of a human follicular dendritic cell molecule that stimulates germinal center B cell growth.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11418631" target="_blank" class="term-link">
+                            PMID:11418631
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The distinct roles of T cell-derived cytokines and a novel follicular dendritic cell-signaling molecule 8D6 in germinal center-B cell differentiation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15652495" target="_blank" class="term-link">
+                            PMID:15652495
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The binding properties of the human receptor for the cellular uptake of vitamin B12.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18779389" target="_blank" class="term-link">
+                            PMID:18779389
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The protein and the gene encoding the receptor for the cellular uptake of transcobalamin-bound cobalamin.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20524213" target="_blank" class="term-link">
+                            PMID:20524213
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Positive newborn screen for methylmalonic aciduria identifies the first mutation in TCblR/CD320, the gene for cellular uptake of transcobalamin-bound vitamin B(12).</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                            PMID:27411955
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis of transcobalamin recognition by human CD320 receptor.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35922511" target="_blank" class="term-link">
+                            PMID:35922511
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A physical wiring diagram for the human immune system.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000112
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CD320-mediated TCN2:RCbl uptake and delivery to lysosome</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000122
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CD320 binds extracellular TCN2:RCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3325546
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective CD320 does not transport extracellular TCII:Cbl to endosome</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9758890
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Transport of RCbl within the body</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CD320-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9NPF0" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cd320-q9npf0-review-notes">CD320 (Q9NPF0) review notes</h1>
+<p>CD320 antigen = transcobalamin receptor (TCblR), aka 8D6 antigen / FDC-signaling molecule 8D6.<br />
+Single-pass type I plasma-membrane glycoprotein (282 aa; signal 1-35, extracellular 36-229,<br />
+TM 230-250, cytoplasmic 251-282). Member of the LDLR family: two LDLR class A (LDLR-A) domains<br />
+(53-90, 131-168) separated by an EGF/complement-like cysteine-rich region. Non-enzymatic.</p>
+<h2 id="core-biology">Core biology</h2>
+<ul>
+<li>Cell-surface receptor that captures transcobalamin-bound cobalamin (holo-TC / TC-Cbl) from<br />
+  plasma and internalizes it by receptor-mediated endocytosis, supplying cobalamin (vitamin B12)<br />
+  to cells throughout the body; the only physiologic route for TC-bound Cbl uptake.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/18779389" title="The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC- cobalamin (Cbl) and internalizes the complex by endocytosis">PMID:18779389</a><br />
+  [PMID:20524213 "TCblR expressed on the plasma membrane binds transcobalamin (TC) saturated with Cbl (holo-TC) and mediates cellular uptake of Cbl"; "The only route for physiologic transport of TC-bound Cbl into cells is via TCblR"]</li>
+<li>Uptake is Ca2+-dependent; each LDLR-A domain binds a central Ca2+ ion.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27411955" title="transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated endocytosis, which requires Ca2+-dependent complex formation of TC with its cognate cell surface receptor CD320">PMID:27411955</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27411955" title="Both LDLR-A domains contain central Ca2+ ions bound by four conserved acidic residues and two backbone carbonyls in an octahedral coordination">PMID:27411955</a></li>
+<li>Expression is coupled to cell cycle; highest in actively proliferating cells and upregulated<br />
+  in cancer cells (drug-delivery target). [PMID:20524213; PMID:27411955]</li>
+<li>Binds TC with high affinity/specificity (KD ~1.5 nM); does NOT bind haptocorrin. <a href="https://pubmed.ncbi.nlm.nih.gov/27411955">PMID:27411955</a></li>
+<li>Ligand released at endosomal low pH; receptor recycles to plasma membrane. [PMID:27411955; Reactome R-HSA-3000112]</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>CD320-related transient/mild methylmalonic aciduria (MATR / MMATC; MIM:613646), autosomal<br />
+  recessive, detected on newborn screening. Common in-frame p.E88del (loss of Glu88 in LDLR-A1)<br />
+  decreases cobalamin-transport function; most patients clinically asymptomatic.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/20524213" title="identified a homozygous single codon deletion, c.262_264GAG (p.E88del) ... Inserting the codon by site-directed mutagenesis fully restored TCblR function">PMID:20524213</a><br />
+  UniProt DISEASE MATR; variants E88del, R129L, S142G, G220R.</li>
+</ul>
+<h2 id="immunology-historic-first-description-likely-secondaryover-annotated">Immunology (historic first description; likely secondary/over-annotated)</h2>
+<ul>
+<li>First cloned as "8D6 antigen" on follicular dendritic cells (FDCs); mAb 8D6 blocks FDC-mediated<br />
+  costimulation of germinal-center B-cell growth. <a href="https://pubmed.ncbi.nlm.nih.gov/10727470">PMID:10727470</a></li>
+<li>FDC-SM-8D6 augments plasma-cell generation from CD27+ precursors. <a href="https://pubmed.ncbi.nlm.nih.gov/11418631">PMID:11418631</a><br />
+  These immune roles predate the identification of the B12-receptor function and are plausibly<br />
+  downstream of proliferation-coupled B12 supply; kept as non-core. The Growth-factor keyword<br />
+  (UniProt-KW -&gt; GO:0008083) derives from this 8D6/FDC work but CD320 is a membrane receptor,<br />
+  not a secreted growth factor -&gt; not brought in.</li>
+</ul>
+<h2 id="interactions">Interactions</h2>
+<ul>
+<li>TCN2 (P20062): the physiological ligand; structural + IntAct evidence. <a href="https://pubmed.ncbi.nlm.nih.gov/27411955">PMID:27411955</a></li>
+<li>JAML/AMICA1 (Q86YT9): CD320-JAML pair from a large immune surface-interactome screen; CD320<br />
+  facilitates NK-cell activation in that assay. <a href="https://pubmed.ncbi.nlm.nih.gov/35922511">PMID:35922511</a> Secondary immune adhesion role.</li>
+</ul>
+<h2 id="goa-term-choices-current-labels-verified-against-local-godb">GOA term choices (current labels verified against local go.db)</h2>
+<ul>
+<li>GO:0038024 cargo receptor activity (MF) — core</li>
+<li>GO:0031419 cobalamin binding (MF) — core (binds Cbl via the TC-Cbl complex)</li>
+<li>GO:0015889 cobalamin transport (BP) — core</li>
+<li>GO:0006898 receptor-mediated endocytosis (BP) — core mechanism</li>
+<li>GO:0005886 plasma membrane (CC) — core location</li>
+<li>GO:0005509 calcium ion binding (MF) — accept (structural, LDLR-A Ca2+ sites)</li>
+<li>GO:0005783 endoplasmic reticulum — LIFEdb GFP overexpression artifact; over-annotated</li>
+<li>GO:0016020 membrane — accept but generic (subsumed by plasma membrane)</li>
+<li>GO:0005515 protein binding — uninformative; TCN2 IPI captured by cargo-receptor/cobalamin-binding MF; JAML IPI is a secondary immune interaction<br />
+</content></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9NPF0
+gene_symbol: CD320
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  CD320 (CD320 antigen; transcobalamin receptor, TCblR; historically the &#34;8D6 antigen&#34;
+  or follicular dendritic cell signaling molecule 8D6) is a single-pass type I plasma
+  membrane glycoprotein of the low-density lipoprotein receptor (LDLR) family. Its
+  extracellular region contains two LDLR class A (LDLR-A) domains, each coordinating a
+  central calcium ion, separated by an EGF/complement-like cysteine-rich region. CD320
+  is a non-enzymatic cell-surface cargo/endocytic receptor that captures the
+  transcobalamin-cobalamin complex (holo-transcobalamin, TC-Cbl) from the circulation
+  and internalizes it by receptor-mediated endocytosis, providing the principal route
+  for cellular uptake of vitamin B12 (cobalamin) by peripheral tissues. It binds
+  transcobalamin with high affinity and specificity (and does not bind haptocorrin);
+  ligand binding is calcium-dependent and is released at endosomal low pH, allowing the
+  receptor to recycle to the cell surface. CD320 expression is coupled to the cell
+  cycle, being highest in actively proliferating cells and upregulated in many cancers.
+  Biallelic in-frame variants (most commonly a p.Glu88 deletion in LDLR-A1) reduce
+  cobalamin-transport function and cause transient/mild methylmalonic aciduria detected
+  on newborn screening (transcobalamin receptor defect, MATR/MMATC), a largely
+  asymptomatic condition.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q9NPF0-1
+- name: &#39;2&#39;
+  id: Q9NPF0-2
+  sequence_note: VSP_045368
+existing_annotations:
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that CD320 acts at the plasma membrane. This is
+      correct and central to its function: CD320 is a single-pass type I cell-surface
+      receptor that binds and internalizes the TC-Cbl complex from the extracellular
+      space.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by experimental subcellular-location data and by the biology
+      of the receptor. The plasma membrane is the site where CD320 captures circulating
+      holo-transcobalamin.
+    supported_by:
+    - reference_id: PMID:18779389
+      supporting_text: &gt;-
+        The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC-
+        cobalamin (Cbl) and internalizes the complex by endocytosis.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      UniProt subcellular-location keyword mapping to plasma membrane. Consistent with
+      the experimentally established cell-membrane localization of CD320.
+    action: ACCEPT
+    reason: &gt;-
+      Redundant with, but consistent with, the experimental plasma membrane annotations
+      (PMID:10727470, PMID:18779389). UniProt annotates &#34;Cell membrane; Single-pass type
+      I membrane protein&#34;.
+    supported_by:
+    - reference_id: file:human/CD320/CD320-uniprot.txt
+      supporting_text: &gt;-
+        SUBCELLULAR LOCATION: Cell membrane
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ARBA electronic annotation to the generic parent term &#34;membrane&#34;. True but far
+      less informative than the plasma membrane annotations.
+    action: MODIFY
+    reason: &gt;-
+      CD320 is a single-pass membrane protein, so &#34;membrane&#34; is not wrong, but the more
+      specific and better-supported term is plasma membrane. Recommend replacing with
+      the specific location.
+    proposed_replacement_terms:
+    - id: GO:0005886
+      label: plasma membrane
+    supported_by:
+    - reference_id: file:human/CD320/CD320-uniprot.txt
+      supporting_text: &gt;-
+        Single-pass
+- term:
+    id: GO:0016192
+    label: vesicle-mediated transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ARBA electronic annotation to vesicle-mediated transport. CD320 internalizes its
+      ligand by receptor-mediated endocytosis, which is a form of vesicle-mediated
+      transport, so this is correct but general.
+    action: MODIFY
+    reason: &gt;-
+      The specific mechanism is receptor-mediated endocytosis of the TC-Cbl complex;
+      recommend the more precise child term rather than the broad parent.
+    proposed_replacement_terms:
+    - id: GO:0006898
+      label: receptor-mediated endocytosis
+    supported_by:
+    - reference_id: PMID:27411955
+      supporting_text: &gt;-
+        transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated
+        endocytosis, which requires Ca2+-dependent complex formation of TC with its
+        cognate cell surface receptor CD320
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:27411955
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI capturing the physical interaction of CD320 with its physiological
+      ligand transcobalamin (TCN2, P20062), shown by crystallography and biochemistry.
+      &#34;protein binding&#34; is uninformative on its own; the informative molecular function
+      is captured by cargo receptor activity (GO:0038024) and cobalamin binding
+      (GO:0031419) in core_functions.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The interaction is real and important (CD320-TCN2), but the bare &#34;protein binding&#34;
+      term does not convey the receptor function. The specific cargo-receptor/cobalamin
+      role is captured elsewhere; per curation guidelines the generic term is retained
+      but flagged rather than used as a core function.
+    supported_by:
+    - reference_id: PMID:27411955
+      supporting_text: &gt;-
+        Cellular uptake of vitamin B12 (cobalamin) requires capture of transcobalamin
+    - reference_id: file:human/CD320/CD320-uniprot.txt
+      supporting_text: &gt;-
+        Interacts (via LDL-receptor class A domains) with TCN2
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35922511
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI from a large-scale human immune surface-receptor interactome screen,
+      recording the CD320-JAML (AMICA1, Q86YT9) interaction; in that study CD320
+      contributed to natural killer cell activation. This is a secondary immune
+      interaction distinct from the core B12-receptor function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      A genuine physical interaction from a systematic screen, but &#34;protein binding&#34; is
+      uninformative and this immune adhesion/costimulation role is peripheral to the
+      core cobalamin-uptake function. Retained but flagged rather than treated as core.
+    supported_by:
+    - reference_id: PMID:35922511
+      supporting_text: &gt;-
+        the adhesion proteins CHL1 and CD320 (along with CD58 as previously described31)
+        facilitating natural killer (NK) cell activation
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9758890
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author-statement annotation placing CD320 in cobalamin
+      transport (transport of cobalamins within the body). This is a core biological
+      process for CD320: it delivers TC-bound cobalamin into cells.
+    action: ACCEPT
+    reason: &gt;-
+      Well supported by experimental literature (PMID:18779389, PMID:20524213) and by
+      the Reactome pathway model of TC-Cbl uptake and distribution.
+    supported_by:
+    - reference_id: PMID:20524213
+      supporting_text: &gt;-
+        TCblR expressed on the plasma membrane binds transcobalamin (TC) saturated with
+        Cbl (holo-TC) and mediates cellular uptake of Cbl
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: EXP
+  original_reference_id: PMID:11418631
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental plasma-membrane localization from the FDC-signaling-molecule 8D6
+      characterization (8D6 = CD320). CD320 is detected on follicular dendritic cells at
+      the cell surface.
+    action: ACCEPT
+    reason: &gt;-
+      Correct cell-surface localization; consistent with the receptor&#39;s function and
+      with other experimental and IBA plasma-membrane annotations.
+    supported_by:
+    - reference_id: PMID:11418631
+      supporting_text: &gt;-
+        A novel FDC-signaling molecule 8D6 (FDC-SM-8D6) produced by FDC augments PC
+        generation in the GC.
+- term:
+    id: GO:0038024
+    label: cargo receptor activity
+  evidence_type: EXP
+  original_reference_id: PMID:15652495
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental molecular-function annotation to cargo receptor activity. This is the
+      core molecular function of CD320: it is the plasma-membrane receptor that binds
+      the transcobalamin-cobalamin cargo and mediates its endocytic internalization.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported: the receptor binds holo-TC and internalizes the TC-Cbl complex
+      by endocytosis, the defining activity of an endocytic cargo receptor.
+    supported_by:
+    - reference_id: PMID:15652495
+      supporting_text: &gt;-
+        is mediated by a receptor
+    - reference_id: PMID:15652495
+      supporting_text: &gt;-
+        internalizes the TC-Cbl by endocytosis
+- term:
+    id: GO:0005509
+    label: calcium ion binding
+  evidence_type: IDA
+  original_reference_id: PMID:27411955
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct-assay calcium-ion binding from the crystal structure: each of the two
+      LDLR-A domains of CD320 coordinates a central Ca2+ ion. Calcium is required for
+      formation of the TC-CD320 complex and hence for ligand capture.
+    action: ACCEPT
+    reason: &gt;-
+      Structurally demonstrated Ca2+ coordination in both LDLR-A domains
+      (PDB:4ZRP/4ZRQ); UniProt annotates twelve Ca2+-binding residues across the two
+      domains. This is a genuine structural molecular function underpinning ligand
+      binding, though secondary to the cargo-receptor function.
+    supported_by:
+    - reference_id: PMID:27411955
+      supporting_text: &gt;-
+        Both LDLR-A domains contain central Ca2+ ions bound by four conserved acidic
+        residues and two backbone carbonyls in an octahedral coordination.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IDA
+  original_reference_id: PMID:10727470
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct-assay plasma-membrane localization from the original 8D6/CD320
+      identification: the 8D6 antigen (CD320) is expressed abundantly on the surface of
+      follicular dendritic cells.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and well supported cell-surface localization consistent with the receptor
+      function.
+    supported_by:
+    - reference_id: PMID:10727470
+      supporting_text: &gt;-
+        The 8D6 Ag is a novel protein of 282 amino acids that is expressed abundantly on
+        FDCs.
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IMP
+  original_reference_id: PMID:18779389
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Cobalamin transport based on characterization of the purified receptor protein and
+      its gene: TCblR/CD320 on the plasma membrane binds holo-TC and internalizes the
+      complex by endocytosis, mediating cellular cobalamin uptake. Core biological
+      process.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental basis for CD320&#39;s role in cobalamin transport; the receptor
+      was purified and shown to bind and internalize TC-Cbl.
+    supported_by:
+    - reference_id: PMID:18779389
+      supporting_text: &gt;-
+        The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC-
+        cobalamin (Cbl) and internalizes the complex by endocytosis.
+- term:
+    id: GO:0030890
+    label: positive regulation of B cell proliferation
+  evidence_type: IMP
+  original_reference_id: PMID:10727470
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Based on the original 8D6/CD320 characterization on follicular dendritic cells:
+      CD320 (8D6 antigen) costimulates growth of germinal-center B cells, and blocking
+      mAb 8D6 inhibits their proliferation. This is a genuine but tissue/context-specific
+      immune role predating the identification of the B12-receptor function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported (IMP with blocking antibody), so retained; but this
+      immune costimulatory activity is peripheral to CD320&#39;s universal core function as
+      the transcobalamin/cobalamin-uptake receptor and is plausibly downstream of
+      proliferation-coupled B12 supply. Marked non-core rather than removed, deferring to
+      the experimental curation.
+    supported_by:
+    - reference_id: PMID:10727470
+      supporting_text: &gt;-
+        Monolayers of COS cells transiently transfected with the 8D6 Ag cDNA stimulate B
+        cell growth.
+- term:
+    id: GO:0031296
+    label: B cell costimulation
+  evidence_type: IMP
+  original_reference_id: PMID:10727470
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      CD320 (8D6 antigen) on follicular dendritic cells provides a costimulatory signal
+      for germinal-center B-cell growth and differentiation; blocking mAb 8D6 abolishes
+      this costimulation. Genuine but context-specific immune role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Experimentally supported costimulation activity, retained; peripheral to the core
+      cobalamin-uptake receptor function and specific to the FDC-B cell context.
+    supported_by:
+    - reference_id: PMID:10727470
+      supporting_text: &gt;-
+        The mAb 8D6 blocks the costimulatory function completely.
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IMP
+  original_reference_id: PMID:20524213
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Cobalamin transport supported by the first disease mutation: an in-frame p.E88del
+      in CD320 decreases uptake of holo-TC in patient fibroblasts and causes
+      methylmalonic aciduria; reinserting the codon restores receptor function. Core
+      biological process.
+    action: ACCEPT
+    reason: &gt;-
+      Genetic loss-of-function evidence (IMP) directly ties CD320 to cobalamin transport,
+      the only physiologic route for TC-bound cobalamin into cells.
+    supported_by:
+    - reference_id: PMID:20524213
+      supporting_text: &gt;-
+        The only route for physiologic transport of TC-bound Cbl into cells is via TCblR.
+    - reference_id: PMID:20524213
+      supporting_text: &gt;-
+        Inserting the codon by site-directed mutagenesis fully restored TCblR function.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mass-spectrometry detection of CD320 in the membrane proteome of an
+      NK-like cell line. Supports membrane localization but at the generic &#34;membrane&#34;
+      level.
+    action: MODIFY
+    reason: &gt;-
+      Correct that CD320 is membrane-associated, but this proteomic dataset does not
+      distinguish membrane compartments; the specific and better-supported term is
+      plasma membrane.
+    proposed_replacement_terms:
+    - id: GO:0005886
+      label: plasma membrane
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: &gt;-
+        Mass spectrometric analysis identified 1843 proteins with high confidence scores.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3325546
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS plasma-membrane annotation from the model of defective CD320 failing
+      to transport TCII:Cbl to the endosome. Consistent with the receptor&#39;s cell-surface
+      location.
+    action: ACCEPT
+    reason: &gt;-
+      Correct cell-surface localization, corroborated by experimental data.
+    supported_by:
+    - reference_id: PMID:18779389
+      supporting_text: &gt;-
+        The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC-
+        cobalamin (Cbl) and internalizes the complex by endocytosis.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000112
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS plasma-membrane annotation from the CD320-mediated TCN2:RCbl uptake
+      and lysosomal delivery model, in which CD320 recycles to the plasma membrane after
+      internalization.
+    action: ACCEPT
+    reason: &gt;-
+      Correct cell-surface localization; the receptor cycles between the plasma membrane
+      and endosomes during ligand uptake.
+    supported_by:
+    - reference_id: PMID:18779389
+      supporting_text: &gt;-
+        The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC-
+        cobalamin (Cbl) and internalizes the complex by endocytosis.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000122
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS plasma-membrane annotation from the &#34;CD320 binds extracellular
+      TCN2:RCbl&#34; reaction. Consistent with the receptor capturing its ligand at the cell
+      surface.
+    action: ACCEPT
+    reason: &gt;-
+      Correct cell-surface localization; site of ligand capture.
+    supported_by:
+    - reference_id: PMID:18779389
+      supporting_text: &gt;-
+        The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC-
+        cobalamin (Cbl) and internalizes the complex by endocytosis.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IDA
+  original_reference_id: PMID:18779389
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      MGI-assigned direct-assay plasma-membrane localization from characterization of the
+      purified receptor. The receptor is a plasma-membrane protein that binds and
+      internalizes TC-Cbl.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported cell-surface localization consistent with all other localization
+      evidence.
+    supported_by:
+    - reference_id: PMID:18779389
+      supporting_text: &gt;-
+        The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC-
+        cobalamin (Cbl) and internalizes the complex by endocytosis.
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IDA
+  original_reference_id: PMID:18779389
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct-assay cobalamin binding: CD320 binds cobalamin in the form of the
+      transcobalamin-cobalamin complex (holo-TC), the ligand it captures at the cell
+      surface. Core molecular function alongside cargo receptor activity.
+    action: ACCEPT
+    reason: &gt;-
+      The purified receptor binds holo-TC (TC saturated with Cbl); recognition of the
+      cobalamin-loaded ligand is central to its function. LDLR-family; binds TC-Cbl with
+      high affinity.
+    supported_by:
+    - reference_id: PMID:18779389
+      supporting_text: &gt;-
+        The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC-
+        cobalamin (Cbl) and internalizes the complex by endocytosis.
+    - reference_id: PMID:18779389
+      supporting_text: &gt;-
+        TCblR belongs to the low-density lipoprotein receptor family
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000054
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      LIFEdb annotation from imaging of an overexpressed GFP/epitope-tagged fusion
+      protein. ER signal for a plasma-membrane receptor most likely reflects the
+      biosynthetic/secretory pathway of an overexpressed membrane protein rather than a
+      functional ER localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      CD320 is a single-pass plasma-membrane receptor; like all such proteins it transits
+      the ER during biosynthesis, but its functional compartment is the cell surface (and
+      endosomes during uptake). ER localization from a single high-throughput
+      overexpressed-fusion assay is not a core function and is an over-annotation of the
+      functional site.
+    supported_by:
+    - reference_id: file:human/CD320/CD320-uniprot.txt
+      supporting_text: &gt;-
+        SUBCELLULAR LOCATION: Cell membrane
+core_functions:
+- description: &gt;-
+    Cell-surface cargo/endocytic receptor that captures the transcobalamin-cobalamin
+    complex (holo-TC) from plasma and mediates its uptake by receptor-mediated
+    endocytosis, delivering vitamin B12 (cobalamin) into cells.
+  molecular_function:
+    id: GO:0038024
+    label: cargo receptor activity
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0005886
+    label: plasma membrane
+  supported_by:
+  - reference_id: PMID:18779389
+    supporting_text: &gt;-
+      The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC-
+      cobalamin (Cbl) and internalizes the complex by endocytosis.
+  - reference_id: PMID:15652495
+    supporting_text: &gt;-
+      internalizes the TC-Cbl by endocytosis
+- description: &gt;-
+    Internalization of the bound transcobalamin-cobalamin ligand from the plasma membrane
+    via receptor-mediated endocytosis; ligand is released at endosomal low pH and the
+    receptor recycles to the cell surface.
+  molecular_function:
+    id: GO:0038024
+    label: cargo receptor activity
+  directly_involved_in:
+  - id: GO:0006898
+    label: receptor-mediated endocytosis
+  locations:
+  - id: GO:0005886
+    label: plasma membrane
+  supported_by:
+  - reference_id: PMID:27411955
+    supporting_text: &gt;-
+      transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated
+      endocytosis, which requires Ca2+-dependent complex formation of TC with its
+      cognate cell surface receptor CD320
+- description: &gt;-
+    Recognition and binding of cobalamin in the form of the transcobalamin-cobalamin
+    (holo-TC) complex, the ligand captured by CD320 at the cell surface.
+  molecular_function:
+    id: GO:0031419
+    label: cobalamin binding
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0005886
+    label: plasma membrane
+  supported_by:
+  - reference_id: PMID:18779389
+    supporting_text: &gt;-
+      The transcobalamin (TC, TCII) receptor (TCblR) on the plasma membrane binds TC-
+      cobalamin (Cbl) and internalizes the complex by endocytosis.
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000054
+  title: Gene Ontology annotation based on curation of intracellular localizations
+    of expressed fusion proteins in living cells
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: file:human/CD320/CD320-uniprot.txt
+  title: UniProtKB entry Q9NPF0 (CD320_HUMAN)
+  findings: []
+- id: PMID:10727470
+  title: Identification of a human follicular dendritic cell molecule that stimulates
+    germinal center B cell growth.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Original cloning of CD320 as the FDC &#34;8D6 antigen&#34;; establishes plasma-membrane
+      localization and B-cell costimulation. Immune role predates the B12-receptor
+      identification and is treated as non-core.
+- id: PMID:11418631
+  title: The distinct roles of T cell-derived cytokines and a novel follicular dendritic
+    cell-signaling molecule 8D6 in germinal center-B cell differentiation.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Characterizes FDC-SM-8D6 (CD320) in germinal-center B cell differentiation;
+      supports plasma-membrane location and the non-core immune costimulation role.
+- id: PMID:15652495
+  title: The binding properties of the human receptor for the cellular uptake of vitamin
+    B12.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes the receptor binds holo-TC and internalizes TC-Cbl by endocytosis;
+      supports cargo receptor activity.
+- id: PMID:18779389
+  title: The protein and the gene encoding the receptor for the cellular uptake of
+    transcobalamin-bound cobalamin.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Purification and gene identification of TCblR/CD320; core evidence for
+      plasma-membrane localization, cobalamin binding (as holo-TC) and cobalamin
+      transport.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput proteomic detection in an NK-like line; supports generic membrane
+      localization only.
+- id: PMID:20524213
+  title: Positive newborn screen for methylmalonic aciduria identifies the first mutation
+    in TCblR/CD320, the gene for cellular uptake of transcobalamin-bound vitamin B(12).
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      First CD320 disease mutation (p.E88del) causing transient/mild methylmalonic
+      aciduria on newborn screening; loss-of-function evidence for cobalamin transport.
+- id: PMID:27411955
+  title: Structural basis of transcobalamin recognition by human CD320 receptor.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Crystal structure of holo-TC bound to the CD320 ectodomain; supports Ca2+ binding
+      by the LDLR-A domains, Ca2+-dependent receptor-mediated endocytosis, and TCN2
+      interaction.
+- id: PMID:35922511
+  title: A physical wiring diagram for the human immune system.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Systematic immune surface-interactome screen; records CD320-JAML interaction and a
+      role in NK-cell activation. Peripheral immune interaction, not core function.
+- id: Reactome:R-HSA-3000112
+  title: CD320-mediated TCN2:RCbl uptake and delivery to lysosome
+  findings: []
+- id: Reactome:R-HSA-3000122
+  title: CD320 binds extracellular TCN2:RCbl
+  findings: []
+- id: Reactome:R-HSA-3325546
+  title: Defective CD320 does not transport extracellular TCII:Cbl to endosome
+  findings: []
+- id: Reactome:R-HSA-9758890
+  title: Transport of RCbl within the body
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/CUBN/CUBN-ai-review.html
+++ b/genes/human/CUBN/CUBN-ai-review.html
@@ -1,0 +1,8253 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CUBN - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>CUBN</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O60494" target="_blank" class="term-link">
+                        O60494
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "CUBN";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O60494" data-a="DESCRIPTION: Cubilin is a very large (~3623 aa) peripheral apic..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Cubilin is a very large (~3623 aa) peripheral apical-membrane glycoprotein built from an N-terminal coiled-coil region, eight EGF-like domains and a cluster of 27 CUB domains. It has no transmembrane segment and is tethered to the apical plasma membrane through the transmembrane protein amnionless (AMN), with which it assembles into the cubam endocytic receptor (one CUBN trimer plus one AMN chain). Functioning as a non-enzymatic multiligand cargo receptor, cubilin binds the intrinsic factor-cobalamin (IF-B12) complex through its CUB5-8 domains in a calcium-dependent manner and, together with AMN and megalin (LRP2), mediates receptor-mediated endocytosis of ligands. In the ileum this drives intestinal absorption of dietary vitamin B12, while in the renal proximal tubule cubam reabsorbs abundant filtered proteins such as albumin, transferrin, vitamin-D-binding protein (GC), apolipoprotein A-I/HDL and hemoglobin. Ligands are delivered to endosomes and lysosomes for processing. Loss-of-function mutations in CUBN cause Imerslund-Grasbeck syndrome 1 (megaloblastic anemia 1), characterized by selective intestinal B12 malabsorption with proteinuria, and C-terminal variants are associated with chronic benign proteinuria.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation placing cubilin at the plasma membrane. Consistent with cubilin acting as a cubam-anchored receptor at the apical cell surface. The more specific apical plasma membrane term is preferred as the core location, but plasma membrane is correct as a broader term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin is a peripheral apical-membrane protein and its active site (ligand capture and endocytosis) is at the cell surface. Supported by experimental localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">anchored to the apical membrane via interaction with the type-1 transmembrane protein amnionless (AMN)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005509" target="_blank" class="term-link">
+                                    GO:0005509
+                                </a>
+                            </span>
+                            <span class="term-label">calcium ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005509" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based electronic annotation for calcium ion binding, based on EGF-like calcium-binding and CUB domains. Cubilin has multiple Ca2+-binding sites in its CUB and EGF-like domains, and calcium is required both for structural integrity and for ligand binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported. The crystal structure of the CUB5-8/IF-Cbl complex resolved four calcium ions coordinated by CUB domains, and ligand binding is calcium-dependent. This is an enabling activity rather than the core receptor function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link">
+                                        PMID:20237569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">how two distant CUB domains embrace the Cbl molecule by binding the two IF domains in a Ca(2+)-dependent manner</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005765" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCell electronic annotation to lysosomal membrane. Cubilin traffics with its ligands through the endocytic apparatus and can be detected in the lysosomal compartment during ligand degradation, but this is a downstream trafficking location rather than the core functional site.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Endocytosed ligands are delivered to lysosomes and cubilin can localize to the lysosomal membrane transiently, but the functionally defining location is the apical plasma membrane where ligand capture occurs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Lysosome membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    GO:0005768
+                                </a>
+                            </span>
+                            <span class="term-label">endosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005768" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCell electronic annotation to endosome. Cubilin/cubam and its cargo are internalized into endosomes as part of the receptor-mediated endocytosis pathway. Directly supported experimentally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Endosomal localization is part of the endocytic itinerary of the cubam receptor and is experimentally documented (see the IDA/EXP endosome annotations for this gene).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCell electronic annotation to plasma membrane. Correct; cubilin is displayed at the cell surface as part of the AMN-anchored cubam complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with experimental and phylogenetic annotations placing cubilin at the (apical) plasma membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCell electronic annotation to the generic membrane term. True but uninformative given the more specific apical/plasma membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct as a high-level parent of the more specific (apical) plasma membrane localization. Retained but subsumed by more specific terms.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Peripheral membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0016324" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Combined-methods (IEA) annotation to apical plasma membrane. This is the core functional location of cubilin, which is displayed on the apical/brush-border surface of enterocytes and proximal tubule cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Apical plasma membrane is the defining site of cubilin function, well supported experimentally (IDA) and by orthology (ISS) as well as this IEA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29402915" target="_blank" class="term-link">
+                                        PMID:29402915
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin is secreted at the apical surface in a glycosylation-dependent process</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030139" target="_blank" class="term-link">
+                                    GO:0030139
+                                </a>
+                            </span>
+                            <span class="term-label">endocytic vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0030139" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA (IEA) annotation to endocytic vesicle. Consistent with cubilin&#39;s role in receptor-mediated endocytosis and its experimentally documented endocytic-vesicle localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin/cubam and cargo are internalized into endocytic vesicles; supported by the experimental IDA endocytic vesicle annotation for this gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031253" target="_blank" class="term-link">
+                                    GO:0031253
+                                </a>
+                            </span>
+                            <span class="term-label">cell projection membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0031253" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ARBA (IEA) annotation to cell projection membrane. Cubilin localizes to the microvillus/brush-border membrane, which is a cell-projection membrane, so this is a correct broader term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the microvillus/brush-border membrane annotations; cell projection membrane is an accurate parent term for the microvilli of the brush border.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubam location the enterocyte brush-border membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20237569
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for receptor recognition of vitamin-B(12)-i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005515" data-r="PMID:20237569" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare protein binding IPI capturing the physical interaction with intrinsic factor (CBLIF, P27352), which is the ligand recognized by cubilin&#39;s CUB5-8 domains. The term itself is uninformative; the biologically meaningful function is cargo/receptor activity toward the IF-cobalamin complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines the generic protein binding term should be avoided. The interaction it records (with CBLIF) is better captured by the cargo receptor activity MF and the cubam complex; per policy the IPI is not removed but flagged as over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link">
+                                        PMID:20237569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the crystal structure of the complex between IF-Cbl and the cubilin IF-Cbl-binding-region (CUB(5-8))</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30523278
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural assembly of the megadalton-sized receptor for int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005515" data-r="PMID:30523278" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare protein binding IPI capturing the physical interaction with amnionless (AMN, Q9BXJ7), the partner that anchors cubilin to the apical membrane in the cubam complex. The generic term is uninformative; the interaction is better captured by cubam complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding is uninformative. The AMN interaction is more precisely represented by the cubam receptor complex membership; per policy the IPI is retained but flagged as over-annotated rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">combine into an intertwined β-helical structure that docks on to a corresponding β-helix domain in AMN</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9758881
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0015889" data-r="Reactome:R-HSA-9758881" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation for cobalamin transport (&#34;Uptake of dietary cobalamins into enterocytes&#34;). This is a core biological process for cubilin, which as part of cubam mediates intestinal uptake of IF-bound B12.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cobalamin transport (intestinal uptake of IF-B12) is the best-characterized physiological role of cubilin and is well supported by multiple lines of evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042359" target="_blank" class="term-link">
+                                    GO:0042359
+                                </a>
+                            </span>
+                            <span class="term-label">vitamin D metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-196791
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0042359" data-r="Reactome:R-HSA-196791" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation for vitamin D metabolic process. Cubilin, with megalin, reabsorbs vitamin-D-binding protein (GC) carrying 25(OH)D from the glomerular filtrate, contributing to vitamin D handling. This is a physiologically relevant but non-core role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin binds GC:25(OH)D and participates in renal handling of vitamin D via reabsorption, but this is one of many reabsorbed ligands and is downstream of its core cargo-receptor/endocytosis function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts together with LRP2 to mediate endocytosis of high-density</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                                    GO:0038024
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-350186
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0038024" data-r="Reactome:R-HSA-350186" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation for cargo receptor activity (&#34;CUBN binds GC:25(OH)D&#34;). This is the core molecular function of cubilin - a non-enzymatic multiligand cargo/endocytic receptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cargo receptor activity is the defining molecular function of cubilin, supported by extensive experimental data (binding of IF-cobalamin and multiple other ligands for endocytosis).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endocytic receptor which plays a role in lipoprotein, vitamin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0015889" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IDA annotation for cobalamin transport based on the demonstration that the cubilin/AMN (cubam) complex mediates IF-cobalamin endocytosis and delivery to lysosomes. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence that cubam confers IF-cobalamin endocytosis; this is cubilin&#39;s canonical transport role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cells exhibited IF-cobalamin endocytosis and lysosomal degradation of IF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0016020" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IDA annotation to the generic membrane term. Correct but subsumed by the more specific apical plasma / microvillus membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct high-level location; cubilin is a peripheral membrane protein at the cell surface. Retained as a broad parent of more specific terms.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0016324" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal NAS annotation to apical plasma membrane. Cubilin (via cubam) is displayed on the apical surface of polarized epithelial cells; this is its core functional location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Apical plasma membrane is the defining functional site of cubilin, supported by experimental localization in intestinal and renal epithelia.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030139" target="_blank" class="term-link">
+                                    GO:0030139
+                                </a>
+                            </span>
+                            <span class="term-label">endocytic vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0030139" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IDA annotation to endocytic vesicle, based on colocalization of cubilin and AMN in the endocytic apparatus and internalization of IF-cobalamin.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for endocytic-vesicle localization as part of the receptor-mediated endocytosis pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030139" target="_blank" class="term-link">
+                                    GO:0030139
+                                </a>
+                            </span>
+                            <span class="term-label">endocytic vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0030139" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Duplicate IDA annotation to endocytic vesicle (UniProt-assigned, same supporting study). Reflects internalization of cubilin/cubam and cargo into endocytic vesicles during receptor-mediated endocytosis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the ComplexPortal endocytic-vesicle annotation; a genuine duplicate from a different assigning source.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN colocalize in the endocytic apparatus of polarized epithelial cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043235" target="_blank" class="term-link">
+                                    GO:0043235
+                                </a>
+                            </span>
+                            <span class="term-label">signaling receptor complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30523278
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural assembly of the megadalton-sized receptor for int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0043235" data-r="PMID:30523278" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IPI annotation placing cubilin in a receptor complex, reflecting the cubam complex (one CUBN trimer plus one AMN chain). Cubam is an endocytic/cargo receptor complex rather than a signaling receptor complex, so the term label is somewhat imprecise, but complex membership is accurate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin is genuinely part of the cubam receptor complex with AMN. The &#34;signaling&#34; qualifier of this term is a minor misnomer (cubilin is an endocytic, not signaling, receptor), but the assertion of receptor-complex membership is experimentally correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">combine into an intertwined β-helical structure that docks on to a corresponding β-helix domain in AMN</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                                    GO:0038024
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0038024" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation for cargo receptor activity from the study showing that cubilin, complexed with AMN as cubam, confers IF-cobalamin endocytosis. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental demonstration of cubilin as the ligand-binding subunit of an endocytic cargo receptor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AMN binds to the amino-terminal third of cubilin and directs subcellular localization and endocytosis of cubilin with its ligand</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                                    GO:0038024
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20237569
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for receptor recognition of vitamin-B(12)-i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0038024" data-r="PMID:20237569" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation for cargo receptor activity based on the crystal structure showing how cubilin CUB5-8 recognizes IF-cobalamin. Directly establishes cubilin&#39;s ligand-recognition (cargo receptor) function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The structure defines the molecular basis of cubilin&#39;s cargo-receptor recognition of the IF-Cbl ligand, supporting the core MF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link">
+                                        PMID:20237569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the crystal structure of the complex between IF-Cbl and the cubilin IF-Cbl-binding-region (CUB(5-8))</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                                    GO:0038024
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30523278
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural assembly of the megadalton-sized receptor for int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0038024" data-r="PMID:30523278" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation for cargo receptor activity based on the structural assembly of cubam, the receptor for intestinal B12 uptake and kidney protein reabsorption. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Establishes cubilin as the multivalent ligand-binding component of the cubam endocytic receptor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">essential for intestinal vitamin B12 (B12) uptake and for protein (e.g. albumin) reabsorption from the kidney filtrate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005765" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation to lysosomal membrane by transfer from rodent ortholog (O70244). Reflects trafficking of cubilin/cargo to the lysosome during ligand degradation; a non-core, downstream location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with delivery of endocytosed ligands to lysosomes, but the defining functional location is the apical plasma membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Lysosome membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    GO:0005768
+                                </a>
+                            </span>
+                            <span class="term-label">endosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005768" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation to endosome, based on the demonstration that cubilin trafficks to the cell surface and endosomes when co-expressed with AMN. Part of the endocytic pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental endosomal localization consistent with cubilin&#39;s receptor-mediated endocytosis role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    GO:0005768
+                                </a>
+                            </span>
+                            <span class="term-label">endosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29402915" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29402915
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Amnionless-mediated glycosylation is crucial for cell surfac...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005768" data-r="PMID:29402915" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation to endosome from the study of AMN-mediated cubilin surface targeting, which documented internalization of cubilin from the apical surface into vesicles. Endocytic-pathway localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin is internalized from the apical surface into the endocytic/endosomal compartment; experimentally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29402915" target="_blank" class="term-link">
+                                        PMID:29402915
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mini-cubilin was internalised from the apical surface</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation to plasma membrane, based on the demonstration that cubilin trafficks to the cell surface only when co-expressed with AMN. Core surface location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for plasma-membrane (cell-surface) localization of cubilin as part of the cubam complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29402915" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29402915
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Amnionless-mediated glycosylation is crucial for cell surfac...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="PMID:29402915" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation to plasma membrane from the AMN-dependent surface-targeting study, which showed AMN-dependent cubilin plasma-membrane expression in renal and intestinal cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support for AMN-dependent plasma-membrane localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29402915" target="_blank" class="term-link">
+                                        PMID:29402915
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">when cubilin was co-expressed with amnionless, a fraction of cubilin expressed at the plasma membrane was detected</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30523278
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural assembly of the megadalton-sized receptor for int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="PMID:30523278" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental annotation to plasma membrane from the cubam structural-assembly study, which established that cubilin is anchored to the apical membrane via AMN.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin is displayed at the (apical) plasma membrane through AMN anchoring; experimentally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">anchored to the apical membrane via interaction with the type-1 transmembrane protein amnionless (AMN)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0016324" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation to apical plasma membrane by transfer from rodent ortholog (Q9JLB4). Consistent with the core apical localization of cubilin.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Apical plasma membrane is the core functional location, well supported experimentally and by orthology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0016324" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Duplicate ISS annotation to apical plasma membrane, transferred from a second rodent ortholog (O70244). Consistent with the core apical localization of cubilin.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine duplicate of the apical plasma membrane ISS from a different ortholog; apical plasma membrane is the core functional location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0009235" data-r="PMID:14576052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI IDA annotation to cobalamin metabolic process (acts_upstream_of_or_within). Cubilin mediates intestinal B12 uptake, which is upstream of cellular cobalamin metabolism. The direct role is transport; the metabolic-process framing is broader.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin&#39;s direct action is cobalamin transport/uptake, which is upstream of cobalamin metabolism. The metabolic-process term is a valid broader/upstream description but not the most precise statement of cubilin&#39;s function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intestinal cobalamin (vitamin B(12)) malabsorption</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031528" target="_blank" class="term-link">
+                                    GO:0031528
+                                </a>
+                            </span>
+                            <span class="term-label">microvillus membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0031528" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI IDA annotation to microvillus membrane. Cubilin localizes to the brush-border microvilli of enterocytes and proximal tubule cells; a specific and accurate apical location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Microvillus (brush border) membrane is a precise and correct description of cubilin&#39;s apical localization in absorptive epithelia.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubam location the enterocyte brush-border membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                                    GO:0038024
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0038024" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI IDA annotation for cargo receptor activity, from the demonstration that cubam confers IF-cobalamin endocytosis. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence for cubilin&#39;s cargo/endocytic receptor function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AMN binds to the amino-terminal third of cubilin and directs subcellular localization and endocytosis of cubilin with its ligand</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                                    GO:0038024
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0038024" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Duplicate MGI IDA annotation for cargo receptor activity from the same supporting study (a separate MGI annotation record). Core molecular function of cubilin as the ligand-binding subunit of the cubam endocytic receptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine duplicate of the MGI cargo receptor activity IDA; direct experimental support for cubilin&#39;s cargo/endocytic receptor function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">AMN binds to the amino-terminal third of cubilin and directs subcellular localization and endocytosis of cubilin with its ligand</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031528" target="_blank" class="term-link">
+                                    GO:0031528
+                                </a>
+                            </span>
+                            <span class="term-label">microvillus membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0031528" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI IDA annotation (is_active_in) to microvillus membrane, indicating that cubilin acts at the brush-border microvillus membrane. Consistent with the core apical site of ligand capture.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The microvillus (brush border) membrane is where cubilin performs its ligand-capture function; correct and precise active-site localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubam location the enterocyte brush-border membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0009235" data-r="PMID:14576052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MGI IDA annotation (involved_in) to cobalamin metabolic process. As with the acts_upstream_of_or_within duplicate, cubilin&#39;s direct role is B12 transport/uptake, which is part of overall cobalamin metabolism.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin participates in cobalamin metabolism by mediating uptake; the more precise statement is cobalamin transport (retained as core). Kept as non-core broader process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intestinal cobalamin (vitamin B(12)) malabsorption</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043235" target="_blank" class="term-link">
+                                    GO:0043235
+                                </a>
+                            </span>
+                            <span class="term-label">signaling receptor complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0043235" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation placing cubilin in a receptor complex, by transfer from rodent ortholog (O70244). Reflects the cubam complex. As with the IPI duplicate, &#34;signaling&#34; is a minor misnomer for what is an endocytic/cargo receptor complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin is genuinely part of the cubam receptor complex with AMN; complex membership is accurate even though the &#34;signaling&#34; qualifier is imprecise.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Component of the cubam complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                                    GO:0038024
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9478979" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9478979
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The intrinsic factor-vitamin B12 receptor and target of tera...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0038024" data-r="PMID:9478979" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GO_Central TAS annotation for cargo receptor activity, from the original molecular characterization of cubilin as the 460-kDa peripheral membrane receptor that facilitates uptake of IF-B12. Core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The founding characterization of cubilin identified it as the endocytic receptor facilitating IF-B12 uptake, the basis for its cargo-receptor MF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9478979" target="_blank" class="term-link">
+                                        PMID:9478979
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">functions as the receptor facilitating uptake of intrinsic factor-vitamin B12 complexes in the intestine and kidney</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031526" target="_blank" class="term-link">
+                                    GO:0031526
+                                </a>
+                            </span>
+                            <span class="term-label">brush border membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0031526" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation to brush border membrane by transfer from rodent ortholog (O70244). Cubilin is a brush-border receptor of absorptive epithelia; specific and accurate apical location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Brush border membrane is a precise, correct description of cubilin&#39;s apical localization; supported experimentally and by orthology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubam location the enterocyte brush-border membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23533145
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    In-depth proteomic analyses of exosomes isolated from expres...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0070062" data-r="PMID:23533145" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomics (HDA) detection of cubilin in prostatic-secretion/urinary exosomes. Reflects shedding of the apical brush-border protein into extracellular vesicles rather than a functional site.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Detection in exosomes is a byproduct of cubilin&#39;s abundant apical membrane localization and its shedding into urine; not a functional localization but a valid observation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                                        PMID:23533145
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">exosome preparations were characterized by a shotgun proteomics procedure</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21082674" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21082674
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Comprehensive analysis of low-abundance proteins in human ur...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0070062" data-r="PMID:21082674" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA detection of cubilin in low-abundance urinary-exosome proteomics. As above, reflects shedding of the apical membrane protein into urinary exosomes rather than a functional site.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with cubilin&#39;s presence in urinary exosomes shed from renal epithelia; a non-functional localization observation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21082674" target="_blank" class="term-link">
+                                        PMID:21082674
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">relatively low-abundant proteins in urinary exosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005515" data-r="PMID:14576052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare protein binding IPI capturing the physical interaction with amnionless (AMN, Q9BXJ7) demonstrated during the identification of the cubam complex. The generic term is uninformative; the interaction is better captured by cubam complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding is uninformative per curation guidelines. The AMN interaction is more precisely represented by cubam complex membership; the IPI is retained but flagged as over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin and AMN are subunits of a novel cubilin/AMN (cubam) complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19056867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Large-scale proteomics and phosphoproteomics of urinary exos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0070062" data-r="PMID:19056867" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomics (HDA) detection of cubilin in the human urinary-exosome proteome. Reflects shedding into urinary exosomes rather than a functional site.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with cubilin&#39;s abundance at the apical surface of renal epithelia and its shedding into urinary exosomes; a non-functional localization observation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                                        PMID:19056867
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">profile the proteome of human urinary exosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                    GO:0016324
+                                </a>
+                            </span>
+                            <span class="term-label">apical plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14576052
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The functional cobalamin (vitamin B12)-intrinsic factor rece...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0016324" data-r="PMID:14576052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt IDA annotation to apical plasma membrane. Core functional location of cubilin as displayed on polarized epithelial apical surfaces.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Apical plasma membrane is the defining functional site of cubilin; experimentally supported.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubilin trafficked to the cell surface and endosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3296462
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="Reactome:R-HSA-3296462" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to plasma membrane (from a defective-CUBN transport reaction). Correct high-level location subsumed by the apical plasma membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct as a broad location for the cell-surface receptor; retained as parent of apical plasma membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-209760
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005829" data-r="Reactome:R-HSA-209760" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to cytosol, arising from Reactome pathway modeling of endocytic translocation reactions. Cubilin is a peripheral, extracellular-facing membrane protein without a cytoplasmic domain, so a cytosolic localization is biologically implausible and likely an artifact of pathway-reaction compartment assignment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin lacks a transmembrane and cytoplasmic domain and faces the extracellular/luminal space; it is not a cytosolic protein. The cytosol assignment reflects Reactome reaction compartmentalization rather than genuine cytosolic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Lacks a transmembrane domain and depends on</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-350168
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005829" data-r="Reactome:R-HSA-350168" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to cytosol (from the LRP2-mediated uptake reaction). As above, cubilin is an extracellular-facing peripheral membrane protein, so cytosolic localization is an artifact of Reactome reaction compartments.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin is not a cytosolic protein; this reflects Reactome pathway modeling rather than genuine localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Lacks a transmembrane domain and depends on</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043202" target="_blank" class="term-link">
+                                    GO:0043202
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-209760
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0043202" data-r="Reactome:R-HSA-209760" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to lysosomal lumen, from the pathway modeling of endocytic delivery of the CUBN:GC:25(OH)D complex to the lysosome. Reflects trafficking of endocytosed cargo to lysosomes; a downstream, non-core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Endocytosed ligands and cubilin can be delivered to the lysosome for degradation; a valid downstream location but not the core functional site.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">lysosomal degradation of IF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043202" target="_blank" class="term-link">
+                                    GO:0043202
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-350158
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0043202" data-r="Reactome:R-HSA-350158" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to lysosomal lumen (LGMN-mediated release of CUBN and 25(OH)D). Downstream lysosomal delivery of endocytosed cargo; non-core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with delivery of cubilin-bound cargo to the lysosome; downstream, non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                        PMID:14576052
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">lysosomal degradation of IF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-264834
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="Reactome:R-HSA-264834" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to plasma membrane (endocytosis/degradation of apoA-I reaction). Correct broad cell-surface location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin at the plasma membrane captures apoA-I/HDL for endocytosis; correct broad location subsumed by apical plasma membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts together with LRP2 to mediate endocytosis of high-density</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-264848
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="Reactome:R-HSA-264848" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to plasma membrane (apoA-I binds CUBN:AMN reaction). Correct broad cell-surface location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with cubilin&#39;s cell-surface (apical) localization where it binds apoA-I; retained as broad parent term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000103
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="Reactome:R-HSA-3000103" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to plasma membrane (CUBN:AMN binds CBLIF:RCbl reaction). Correct broad cell-surface location where IF-cobalamin is captured.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct broad location; cubam binds IF-cobalamin at the (apical) plasma membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000137
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="Reactome:R-HSA-3000137" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to plasma membrane (CUBN:AMN-mediated CBLIF:RCbl uptake reaction). Correct broad cell-surface location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with cubam-mediated IF-cobalamin uptake at the cell surface; retained as broad parent of apical plasma membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3296477
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="Reactome:R-HSA-3296477" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to plasma membrane (defective-AMN transport reaction). Correct broad cell-surface location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct broad location for the cubam receptor at the cell surface.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-350168
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="Reactome:R-HSA-350168" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to plasma membrane (LRP2-mediated uptake of extracellular CUBN:GC:25(OH)D reaction). Correct broad cell-surface location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with cubilin&#39;s cell-surface localization; retained as broad parent of apical plasma membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-350186
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0005886" data-r="Reactome:R-HSA-350186" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to plasma membrane (CUBN binds GC:25(OH)D reaction). Correct broad cell-surface location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct broad location where cubilin binds vitamin-D-binding protein for reabsorption; retained as parent of apical plasma membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Apical cell membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001894" target="_blank" class="term-link">
+                                    GO:0001894
+                                </a>
+                            </span>
+                            <span class="term-label">tissue homeostasis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11994745" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11994745
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Megalin and cubilin: multifunctional endocytic receptors.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0001894" data-r="PMID:11994745" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NAS annotation to tissue homeostasis from a review of megalin/cubilin as multifunctional endocytic receptors. This is a very general process term; cubilin&#39;s contributions (protein/vitamin reabsorption) are better captured by specific transport/endocytosis terms.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Tissue homeostasis is too vague to be informative for cubilin. Its physiological roles are more precisely described by cobalamin transport, receptor-mediated endocytosis and protein reabsorption.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11994745" target="_blank" class="term-link">
+                                        PMID:11994745
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Megalin and cubilin are two structurally different endocytic receptors that interact to serve such functions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006898" target="_blank" class="term-link">
+                                    GO:0006898
+                                </a>
+                            </span>
+                            <span class="term-label">receptor-mediated endocytosis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11994745" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11994745
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Megalin and cubilin: multifunctional endocytic receptors.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0006898" data-r="PMID:11994745" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NAS annotation to receptor-mediated endocytosis from the megalin/cubilin review. This is the core mechanistic process by which cubilin/cubam internalizes IF-cobalamin and reabsorbed proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Receptor-mediated endocytosis is the defining biological process of cubilin, well supported across the literature.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11994745" target="_blank" class="term-link">
+                                        PMID:11994745
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Megalin and cubilin are two structurally different endocytic receptors that interact to serve such functions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031232" target="_blank" class="term-link">
+                                    GO:0031232
+                                </a>
+                            </span>
+                            <span class="term-label">extrinsic component of external side of plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11994745" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11994745
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Megalin and cubilin: multifunctional endocytic receptors.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0031232" data-r="PMID:11994745" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NAS annotation describing cubilin as an extrinsic (peripheral) component of the external side of the plasma membrane. This is an accurate and informative topology statement - cubilin lacks a transmembrane domain and is peripheral, facing the extracellular/luminal space.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate description of cubilin&#39;s membrane topology; it is a peripheral membrane protein displayed on the extracellular side of the apical membrane through AMN.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Lacks a transmembrane domain and depends on</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031526" target="_blank" class="term-link">
+                                    GO:0031526
+                                </a>
+                            </span>
+                            <span class="term-label">brush border membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11994745" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11994745
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Megalin and cubilin: multifunctional endocytic receptors.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0031526" data-r="PMID:11994745" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NAS annotation to brush border membrane. Cubilin is a brush-border receptor of absorptive epithelia; a specific and correct apical location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Brush border membrane accurately describes cubilin&#39;s apical localization in intestinal and renal epithelia.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cubam location the enterocyte brush-border membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
+                                    GO:0042803
+                                </a>
+                            </span>
+                            <span class="term-label">protein homodimerization activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10552972" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10552972
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic evidence of an accessory activity required specifica...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0042803" data-r="PMID:10552972" data-act="UNDECIDED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt IDA annotation for protein homodimerization activity, cited to the canine genetics study of an accessory activity required for cubilin brush-border expression. The cached abstract addresses genetic linkage (an accessory protein required for cubilin surface expression) and does not describe a homodimerization assay; the full text is not available to verify the supporting evidence. Structurally, cubilin is now known to trimerize via its N-terminal beta-helix rather than simply homodimerize.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The self-association MF is plausible (cubilin oligomerizes - it forms trimers and cubam can dimerize) but &#34;homodimerization&#34; is imprecise, and I cannot verify the experimental basis from the cached abstract of the cited reference. Per policy, UNDECIDED rather than REMOVE for an experimental annotation whose full text is unavailable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                        PMID:30523278
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">potential of dimerization into an even larger complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10080186" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10080186
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in CUBN, encoding the intrinsic factor-vitamin B12...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0015889" data-r="PMID:10080186" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PINC TAS annotation for cobalamin transport, citing the paper identifying CUBN mutations as the cause of hereditary megaloblastic anemia 1 via selective intestinal B12 malabsorption. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genetic evidence that CUBN loss causes selective intestinal B12 malabsorption directly supports cubilin&#39;s role in cobalamin transport.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10080186" target="_blank" class="term-link">
+                                        PMID:10080186
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MGA1 is characterized by selective intestinal vitamin B12 (B12, cobalamin) malabsorption</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9478979" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9478979
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The intrinsic factor-vitamin B12 receptor and target of tera...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0016020" data-r="PMID:9478979" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PINC TAS annotation to the generic membrane term, from the original characterization of cubilin as a peripheral membrane receptor. Correct but high-level.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct as a broad location; cubilin is a peripheral membrane protein. Subsumed by more specific apical/brush-border membrane terms.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9478979" target="_blank" class="term-link">
+                                        PMID:9478979
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a megalin-binding peripheral membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038023" target="_blank" class="term-link">
+                                    GO:0038023
+                                </a>
+                            </span>
+                            <span class="term-label">signaling receptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10080186" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10080186
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in CUBN, encoding the intrinsic factor-vitamin B12...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O60494" data-a="GO:0038023" data-r="PMID:10080186" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Old PINC TAS annotation to signaling receptor activity. This is a misclassification - cubilin is an endocytic/cargo receptor, not a signal-transducing (signaling) receptor. It has no signaling domain and no described role in signal transduction; its function is ligand capture for endocytosis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cubilin is a non-enzymatic endocytic cargo receptor (cargo receptor activity, GO:0038024), not a signaling receptor. The signaling receptor activity term mischaracterizes its molecular function; the correct MF is already annotated. Per policy for a TAS mapping that is biologically wrong in kind, this is flagged as over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CUBN/CUBN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endocytic receptor which plays a role in lipoprotein, vitamin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Non-enzymatic multiligand cargo/endocytic receptor that binds the intrinsic factor-cobalamin (IF-B12) complex via its CUB5-8 domains and, together with AMN (cubam) and megalin, mediates receptor-mediated endocytosis of B12 and reabsorbed proteins.</h3>
+                <span class="vote-buttons" data-g="O60494" data-a="FUNCTION: Non-enzymatic multiligand cargo/endocytic receptor..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                            cargo receptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                apical plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043235" target="_blank" class="term-link">
+                            receptor complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                                PMID:14576052
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">AMN binds to the amino-terminal third of cubilin and directs subcellular localization and endocytosis of cubilin with its ligand</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link">
+                                PMID:20237569
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">how two distant CUB domains embrace the Cbl molecule by binding the two IF domains in a Ca(2+)-dependent manner</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As the ligand-binding subunit of the cubam receptor at the apical/brush-border membrane, cubilin captures diverse filtered and luminal ligands for receptor-mediated endocytosis, driving intestinal B12 uptake and renal proximal-tubule reabsorption of proteins.</h3>
+                <span class="vote-buttons" data-g="O60494" data-a="FUNCTION: As the ligand-binding subunit of the cubam recepto..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038024" target="_blank" class="term-link">
+                            cargo receptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006898" target="_blank" class="term-link">
+                                receptor-mediated endocytosis
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016324" target="_blank" class="term-link">
+                                apical plasma membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031526" target="_blank" class="term-link">
+                                brush border membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9478979" target="_blank" class="term-link">
+                                PMID:9478979
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">functions as the receptor facilitating uptake of intrinsic factor-vitamin B12 complexes in the intestine and kidney</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                                PMID:30523278
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">it is responsible for reabsorption of abundant proteins in the renal ultrafiltrate</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10080186" target="_blank" class="term-link">
+                            PMID:10080186
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in CUBN, encoding the intrinsic factor-vitamin B12 receptor, cubilin, cause hereditary megaloblastic anaemia 1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10552972" target="_blank" class="term-link">
+                            PMID:10552972
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic evidence of an accessory activity required specifically for cubilin brush-border expression and intrinsic factor-cobalamin absorption.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11994745" target="_blank" class="term-link">
+                            PMID:11994745
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Megalin and cubilin: multifunctional endocytic receptors.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14576052" target="_blank" class="term-link">
+                            PMID:14576052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The functional cobalamin (vitamin B12)-intrinsic factor receptor is a novel complex of cubilin and amnionless.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                            PMID:19056867
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" target="_blank" class="term-link">
+                            PMID:20237569
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for receptor recognition of vitamin-B(12)-intrinsic factor complexes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21082674" target="_blank" class="term-link">
+                            PMID:21082674
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Comprehensive analysis of low-abundance proteins in human urinary exosomes using peptide ligand library technology, peptide OFFGEL fractionation and nanoHPLC-chip-MS/MS.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
+                            PMID:23533145
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29402915" target="_blank" class="term-link">
+                            PMID:29402915
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Amnionless-mediated glycosylation is crucial for cell surface targeting of cubilin in renal and intestinal cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30523278" target="_blank" class="term-link">
+                            PMID:30523278
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural assembly of the megadalton-sized receptor for intestinal vitamin B(12) uptake and kidney protein reabsorption.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9478979" target="_blank" class="term-link">
+                            PMID:9478979
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The intrinsic factor-vitamin B12 receptor and target of teratogenic antibodies is a megalin-binding peripheral membrane protein with homology to developmental proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-196791
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Vitamin D (calciferol) metabolism</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-209760
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Endocytic translocation of CUBN:GC:25(OH)D to lysosomal lumen</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-264834
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Endocytosis and degradation of apoA-I</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-264848
+
+                    </span>
+                </div>
+
+                <div class="reference-title">apoA-I binds to CUBN:AMN</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000103
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CUBN:AMN binds CBLIF:RCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000137
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CUBN:AMN-mediated CBLIF:RCbl uptake and delivery to lysosome</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3296462
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective CUBN does not transport GIF:Cbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3296477
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective AMN does not transport GIF:Cbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-350158
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LGMN hydrolyzes GC, releasing CUBN and 25(OH)D</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-350168
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LRP2-mediated uptake of extracellular CUBN:GC:25(OH)D</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-350186
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CUBN binds GC:25(OH)D</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9758881
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Uptake of dietary cobalamins into enterocytes</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/CUBN/CUBN-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry O60494 (CUBN_HUMAN), Cubilin</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CUBN-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O60494" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cubn-cubilin-review-notes">CUBN (Cubilin) — review notes</h1>
+<p>UniProtKB:O60494, HGNC:2548, human. 3623 aa precursor; large peripheral apical-membrane<br />
+glycoprotein. No transmembrane domain; anchored to the apical membrane through the<br />
+transmembrane protein amnionless (AMN), forming the <strong>cubam</strong> endocytic receptor.</p>
+<h2 id="core-biology-verified">Core biology (verified)</h2>
+<ul>
+<li>
+<p><strong>Domain architecture:</strong> N-terminal region (coiled-coil), 8 EGF-like domains, then 27<br />
+  CUB domains (CUB accounts for ~88% of the mass). <a href="https://pubmed.ncbi.nlm.nih.gov/9478979" title="a cluster of eight   epidermal growth factor type domains followed by a cluster of 27 CUB domains">PMID:9478979</a>. Lacks a<br />
+  hydrophobic membrane-spanning segment; released from membranes by non-enzymatic means —<br />
+  a <strong>peripheral membrane protein</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/9478979" title="the receptor could be released from   renal cortex membranes by nonenzymatic and nonsolubilizing procedures">PMID:9478979</a>.</p>
+</li>
+<li>
+<p><strong>Cubam receptor:</strong> cubilin + AMN. Three cubilin chains combine into an intertwined<br />
+  β-helix that docks onto AMN; AMN provides the transmembrane anchor and clathrin-coated-pit<br />
+  internalization signals [PMID:30523278; PMID:14576052 "cubilin and AMN are subunits of a<br />
+  novel cubilin/AMN (cubam) complex"]. UniProt: "Component of the cubam complex composed of<br />
+  one CUBN trimer and one AMN chain." AMN is required for cubilin surface expression and<br />
+  glycosylation maturation; without AMN cubilin is retained in the ER [PMID:29402915;<br />
+  PMID:14576052].</p>
+</li>
+<li>
+<p><strong>Molecular function = cargo/endocytic receptor.</strong> Non-enzymatic. Binds IF (CBLIF)-cobalamin<br />
+  and many other ligands; internalized (with AMN/megalin) by receptor-mediated endocytosis.<br />
+  IF-B12 binding is by CUB5-8 in a Ca2+-dependent dual-point mechanism <a href="https://pubmed.ncbi.nlm.nih.gov/20237569" title="how   two distant CUB domains embrace the Cbl molecule by binding the two IF domains in a   Ca(2+)-dependent manner">PMID:20237569</a>. UniProt DOMAIN: "The CUB domains 5 to 8 mediate binding to CBLIF<br />
+  and ALB. CUB domains 1 and 2 mediate interaction with LRP2."</p>
+</li>
+<li>
+<p><strong>Ileum:</strong> binds intrinsic-factor–cobalamin (IF-B12) and mediates dietary B12 absorption.</p>
+</li>
+<li>
+<p><strong>Kidney proximal tubule:</strong> reabsorbs filtered ligands (albumin, transferrin, vitamin-D-binding<br />
+  protein GC, apoA-I/HDL, hemoglobin, etc.) via cubam + megalin (LRP2). [PMID:30523278;<br />
+  PMID:11994745 review].</p>
+</li>
+<li>
+<p><strong>Disease:</strong> loss of function → Imerslund-Gräsbeck syndrome 1 / megaloblastic anemia 1<br />
+  (IGS1, MIM 261100): selective intestinal B12 malabsorption + mild proteinuria<br />
+  [PMID:10080186; PMID:14576052]. Also chronic benign proteinuria (PROCHOB, MIM 618884) from<br />
+  C-terminal variants (UniProt).</p>
+</li>
+</ul>
+<h2 id="go-annotation-assessment-summary">GO annotation assessment summary</h2>
+<ul>
+<li><strong>MF core:</strong> cargo receptor activity (GO:0038024) — strongly supported (EXP/IDA, Reactome,<br />
+  ComplexPortal). This is the exact MF term in GOA and is the appropriate non-enzymatic<br />
+  receptor MF. <code>signaling receptor activity</code> (GO:0038023, old ProtInc TAS) is a misnomer —<br />
+  cubilin is an endocytic/cargo receptor, not a signaling receptor → MARK_AS_OVER_ANNOTATED.</li>
+<li><strong>calcium ion binding</strong> (GO:0005509, IEA InterPro): supported — EGF-Ca and CUB-Ca sites;<br />
+  ligand binding is Ca2+-dependent (structure PMID:20237569). ACCEPT (non-core; enabling).</li>
+<li><strong>protein homodimerization activity</strong> (GO:0042803, IDA PMID:10552972): cited PMID is the<br />
+  canine-accessory-activity genetics paper (abstract has no homodimerization assay) — but<br />
+  this is an experimental IDA I cannot fully verify; per policy keep as UNDECIDED rather than<br />
+  REMOVE. (Cubilin actually trimerizes via the N-terminal β-helix per PMID:30523278/20237569;<br />
+  "homodimerization" is imprecise.)</li>
+<li><strong>protein binding</strong> (GO:0005515, IPI x3): uninformative bare term → MARK_AS_OVER_ANNOTATED<br />
+  (partners AMN Q9BXJ7, CBLIF/IF P27352 are captured better by cubam complex + cargo receptor).</li>
+<li><strong>BP core:</strong> cobalamin transport (GO:0015889) — ACCEPT (IDA ComplexPortal PMID:14576052; TAS).<br />
+  receptor-mediated endocytosis (GO:0006898, NAS) — ACCEPT (mechanism of uptake).<br />
+  cobalamin metabolic process (GO:0009235, IDA) — KEEP_AS_NON_CORE (transport is the direct<br />
+  role; "metabolic process" is broader/upstream).<br />
+  vitamin D metabolic process (GO:0042359, Reactome TAS) — KEEP_AS_NON_CORE (reabsorbs GC:25(OH)D).<br />
+  tissue homeostasis (GO:0001894, NAS) — MARK_AS_OVER_ANNOTATED (vague).</li>
+<li><strong>CC core:</strong> apical plasma membrane (GO:0016324) — ACCEPT. plasma membrane / membrane —<br />
+  ACCEPT (broader). brush border membrane / microvillus membrane — ACCEPT (specific apical).<br />
+  endosome, endocytic vesicle, coated pit — ACCEPT (endocytic pathway). lysosomal membrane /<br />
+  lumen — KEEP_AS_NON_CORE (ligand delivered to lysosome; ISS/TAS). cytosol (Reactome TAS) —<br />
+  MARK_AS_OVER_ANNOTATED (peripheral extracellular-facing protein, not cytosolic).<br />
+  extracellular exosome (HDA/IDA urinary-exosome proteomics) — KEEP_AS_NON_CORE (shed into<br />
+  urine; not a functional site). signaling receptor complex (GO:0043235) — the complex is<br />
+  cubam; "signaling" is a misnomer but it is the cubam receptor complex → ACCEPT the complex<br />
+  membership (part_of receptor complex) but note "signaling" is imprecise.<br />
+  extrinsic component of external side of plasma membrane (GO:0031232, NAS) — ACCEPT (accurate:<br />
+  peripheral, extracellular-facing).</li>
+</ul>
+<h2 id="references">References</h2>
+<p>Grounded in CUBN-uniprot.txt (O60494), CUBN-goa.tsv, and cached publications/PMID_*.md.<br />
+No falcon deep research (provider out of credits, HTTP 402).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O60494
+gene_symbol: CUBN
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: Cubilin is a very large (~3623 aa) peripheral apical-membrane glycoprotein
+  built from an N-terminal coiled-coil region, eight EGF-like domains and a cluster
+  of 27 CUB domains. It has no transmembrane segment and is tethered to the apical
+  plasma membrane through the transmembrane protein amnionless (AMN), with which it
+  assembles into the cubam endocytic receptor (one CUBN trimer plus one AMN chain).
+  Functioning as a non-enzymatic multiligand cargo receptor, cubilin binds the intrinsic
+  factor-cobalamin (IF-B12) complex through its CUB5-8 domains in a calcium-dependent
+  manner and, together with AMN and megalin (LRP2), mediates receptor-mediated endocytosis
+  of ligands. In the ileum this drives intestinal absorption of dietary vitamin B12,
+  while in the renal proximal tubule cubam reabsorbs abundant filtered proteins such
+  as albumin, transferrin, vitamin-D-binding protein (GC), apolipoprotein A-I/HDL and
+  hemoglobin. Ligands are delivered to endosomes and lysosomes for processing. Loss-of-function
+  mutations in CUBN cause Imerslund-Grasbeck syndrome 1 (megaloblastic anemia 1), characterized
+  by selective intestinal B12 malabsorption with proteinuria, and C-terminal variants
+  are associated with chronic benign proteinuria.
+existing_annotations:
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) annotation placing cubilin at the plasma membrane.
+      Consistent with cubilin acting as a cubam-anchored receptor at the apical cell
+      surface. The more specific apical plasma membrane term is preferred as the core
+      location, but plasma membrane is correct as a broader term.
+    action: ACCEPT
+    reason: Cubilin is a peripheral apical-membrane protein and its active site (ligand
+      capture and endocytosis) is at the cell surface. Supported by experimental localization.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: anchored to the apical membrane via interaction with the type-1
+        transmembrane protein amnionless (AMN)
+- term:
+    id: GO:0005509
+    label: calcium ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro-based electronic annotation for calcium ion binding, based on
+      EGF-like calcium-binding and CUB domains. Cubilin has multiple Ca2+-binding sites
+      in its CUB and EGF-like domains, and calcium is required both for structural
+      integrity and for ligand binding.
+    action: ACCEPT
+    reason: Well supported. The crystal structure of the CUB5-8/IF-Cbl complex resolved
+      four calcium ions coordinated by CUB domains, and ligand binding is calcium-dependent.
+      This is an enabling activity rather than the core receptor function.
+    supported_by:
+    - reference_id: PMID:20237569
+      supporting_text: how two distant CUB domains embrace the Cbl molecule by binding
+        the two IF domains in a Ca(2+)-dependent manner
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt SubCell electronic annotation to lysosomal membrane. Cubilin traffics
+      with its ligands through the endocytic apparatus and can be detected in the lysosomal
+      compartment during ligand degradation, but this is a downstream trafficking location
+      rather than the core functional site.
+    action: KEEP_AS_NON_CORE
+    reason: Endocytosed ligands are delivered to lysosomes and cubilin can localize
+      to the lysosomal membrane transiently, but the functionally defining location
+      is the apical plasma membrane where ligand capture occurs.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Lysosome membrane
+- term:
+    id: GO:0005768
+    label: endosome
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt SubCell electronic annotation to endosome. Cubilin/cubam and its
+      cargo are internalized into endosomes as part of the receptor-mediated endocytosis
+      pathway. Directly supported experimentally.
+    action: ACCEPT
+    reason: Endosomal localization is part of the endocytic itinerary of the cubam receptor
+      and is experimentally documented (see the IDA/EXP endosome annotations for this
+      gene).
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt SubCell electronic annotation to plasma membrane. Correct; cubilin
+      is displayed at the cell surface as part of the AMN-anchored cubam complex.
+    action: ACCEPT
+    reason: Consistent with experimental and phylogenetic annotations placing cubilin
+      at the (apical) plasma membrane.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt SubCell electronic annotation to the generic membrane term. True
+      but uninformative given the more specific apical/plasma membrane annotations.
+    action: ACCEPT
+    reason: Correct as a high-level parent of the more specific (apical) plasma membrane
+      localization. Retained but subsumed by more specific terms.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Peripheral membrane protein
+- term:
+    id: GO:0016324
+    label: apical plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Combined-methods (IEA) annotation to apical plasma membrane. This is the
+      core functional location of cubilin, which is displayed on the apical/brush-border
+      surface of enterocytes and proximal tubule cells.
+    action: ACCEPT
+    reason: Apical plasma membrane is the defining site of cubilin function, well supported
+      experimentally (IDA) and by orthology (ISS) as well as this IEA.
+    supported_by:
+    - reference_id: PMID:29402915
+      supporting_text: cubilin is secreted at the apical surface in a glycosylation-dependent
+        process
+- term:
+    id: GO:0030139
+    label: endocytic vesicle
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: ARBA (IEA) annotation to endocytic vesicle. Consistent with cubilin&#39;s role
+      in receptor-mediated endocytosis and its experimentally documented endocytic-vesicle
+      localization.
+    action: ACCEPT
+    reason: Cubilin/cubam and cargo are internalized into endocytic vesicles; supported
+      by the experimental IDA endocytic vesicle annotation for this gene.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: cubilin and AMN colocalize in the endocytic apparatus of polarized
+        epithelial cells
+- term:
+    id: GO:0031253
+    label: cell projection membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: ARBA (IEA) annotation to cell projection membrane. Cubilin localizes to
+      the microvillus/brush-border membrane, which is a cell-projection membrane, so
+      this is a correct broader term.
+    action: ACCEPT
+    reason: Consistent with the microvillus/brush-border membrane annotations; cell
+      projection membrane is an accurate parent term for the microvilli of the brush
+      border.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: cubam location the enterocyte brush-border membrane
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20237569
+  qualifier: enables
+  review:
+    summary: Bare protein binding IPI capturing the physical interaction with intrinsic
+      factor (CBLIF, P27352), which is the ligand recognized by cubilin&#39;s CUB5-8 domains.
+      The term itself is uninformative; the biologically meaningful function is cargo/receptor
+      activity toward the IF-cobalamin complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &#39;Per curation guidelines the generic protein binding term should be avoided.
+      The interaction it records (with CBLIF) is better captured by the cargo receptor
+      activity MF and the cubam complex; per policy the IPI is not removed but flagged
+      as over-annotated.&#39;
+    supported_by:
+    - reference_id: PMID:20237569
+      supporting_text: the crystal structure of the complex between IF-Cbl and the cubilin
+        IF-Cbl-binding-region (CUB(5-8))
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:30523278
+  qualifier: enables
+  review:
+    summary: Bare protein binding IPI capturing the physical interaction with amnionless
+      (AMN, Q9BXJ7), the partner that anchors cubilin to the apical membrane in the
+      cubam complex. The generic term is uninformative; the interaction is better captured
+      by cubam complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic protein binding is uninformative. The AMN interaction is more precisely
+      represented by the cubam receptor complex membership; per policy the IPI is retained
+      but flagged as over-annotated rather than removed.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: combine into an intertwined β-helical structure that docks on
+        to a corresponding β-helix domain in AMN
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9758881
+  qualifier: involved_in
+  review:
+    summary: Reactome TAS annotation for cobalamin transport (&#34;Uptake of dietary cobalamins
+      into enterocytes&#34;). This is a core biological process for cubilin, which as part
+      of cubam mediates intestinal uptake of IF-bound B12.
+    action: ACCEPT
+    reason: Cobalamin transport (intestinal uptake of IF-B12) is the best-characterized
+      physiological role of cubilin and is well supported by multiple lines of evidence.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: the cells exhibited IF-cobalamin endocytosis and lysosomal degradation
+        of IF
+- term:
+    id: GO:0042359
+    label: vitamin D metabolic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-196791
+  qualifier: involved_in
+  review:
+    summary: Reactome TAS annotation for vitamin D metabolic process. Cubilin, with
+      megalin, reabsorbs vitamin-D-binding protein (GC) carrying 25(OH)D from the glomerular
+      filtrate, contributing to vitamin D handling. This is a physiologically relevant
+      but non-core role.
+    action: KEEP_AS_NON_CORE
+    reason: Cubilin binds GC:25(OH)D and participates in renal handling of vitamin D
+      via reabsorption, but this is one of many reabsorbed ligands and is downstream
+      of its core cargo-receptor/endocytosis function.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Acts together with LRP2 to mediate endocytosis of high-density
+- term:
+    id: GO:0038024
+    label: cargo receptor activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-350186
+  qualifier: enables
+  review:
+    summary: Reactome TAS annotation for cargo receptor activity (&#34;CUBN binds GC:25(OH)D&#34;).
+      This is the core molecular function of cubilin - a non-enzymatic multiligand cargo/endocytic
+      receptor.
+    action: ACCEPT
+    reason: Cargo receptor activity is the defining molecular function of cubilin, supported
+      by extensive experimental data (binding of IF-cobalamin and multiple other ligands
+      for endocytosis).
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Endocytic receptor which plays a role in lipoprotein, vitamin
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: involved_in
+  review:
+    summary: ComplexPortal IDA annotation for cobalamin transport based on the demonstration
+      that the cubilin/AMN (cubam) complex mediates IF-cobalamin endocytosis and delivery
+      to lysosomes. Core biological process.
+    action: ACCEPT
+    reason: Direct experimental evidence that cubam confers IF-cobalamin endocytosis;
+      this is cubilin&#39;s canonical transport role.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: the cells exhibited IF-cobalamin endocytosis and lysosomal degradation
+        of IF
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: ComplexPortal IDA annotation to the generic membrane term. Correct but
+      subsumed by the more specific apical plasma / microvillus membrane annotations.
+    action: ACCEPT
+    reason: Correct high-level location; cubilin is a peripheral membrane protein at
+      the cell surface. Retained as a broad parent of more specific terms.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0016324
+    label: apical plasma membrane
+  evidence_type: NAS
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: ComplexPortal NAS annotation to apical plasma membrane. Cubilin (via cubam)
+      is displayed on the apical surface of polarized epithelial cells; this is its
+      core functional location.
+    action: ACCEPT
+    reason: Apical plasma membrane is the defining functional site of cubilin, supported
+      by experimental localization in intestinal and renal epithelia.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0030139
+    label: endocytic vesicle
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: ComplexPortal IDA annotation to endocytic vesicle, based on colocalization
+      of cubilin and AMN in the endocytic apparatus and internalization of IF-cobalamin.
+    action: ACCEPT
+    reason: Direct experimental support for endocytic-vesicle localization as part of
+      the receptor-mediated endocytosis pathway.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: cubilin and AMN colocalize in the endocytic apparatus of polarized
+        epithelial cells
+- term:
+    id: GO:0030139
+    label: endocytic vesicle
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: Duplicate IDA annotation to endocytic vesicle (UniProt-assigned, same
+      supporting study). Reflects internalization of cubilin/cubam and cargo into endocytic
+      vesicles during receptor-mediated endocytosis.
+    action: ACCEPT
+    reason: Consistent with the ComplexPortal endocytic-vesicle annotation; a genuine
+      duplicate from a different assigning source.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: cubilin and AMN colocalize in the endocytic apparatus of polarized
+        epithelial cells
+- term:
+    id: GO:0043235
+    label: signaling receptor complex
+  evidence_type: IPI
+  original_reference_id: PMID:30523278
+  qualifier: part_of
+  review:
+    summary: ComplexPortal IPI annotation placing cubilin in a receptor complex, reflecting
+      the cubam complex (one CUBN trimer plus one AMN chain). Cubam is an endocytic/cargo
+      receptor complex rather than a signaling receptor complex, so the term label is
+      somewhat imprecise, but complex membership is accurate.
+    action: ACCEPT
+    reason: Cubilin is genuinely part of the cubam receptor complex with AMN. The &#34;signaling&#34;
+      qualifier of this term is a minor misnomer (cubilin is an endocytic, not signaling,
+      receptor), but the assertion of receptor-complex membership is experimentally
+      correct.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: combine into an intertwined β-helical structure that docks on
+        to a corresponding β-helix domain in AMN
+- term:
+    id: GO:0038024
+    label: cargo receptor activity
+  evidence_type: EXP
+  original_reference_id: PMID:14576052
+  qualifier: enables
+  review:
+    summary: Experimental annotation for cargo receptor activity from the study showing
+      that cubilin, complexed with AMN as cubam, confers IF-cobalamin endocytosis. Core
+      molecular function.
+    action: ACCEPT
+    reason: Direct experimental demonstration of cubilin as the ligand-binding subunit
+      of an endocytic cargo receptor.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: AMN binds to the amino-terminal third of cubilin and directs
+        subcellular localization and endocytosis of cubilin with its ligand
+- term:
+    id: GO:0038024
+    label: cargo receptor activity
+  evidence_type: EXP
+  original_reference_id: PMID:20237569
+  qualifier: enables
+  review:
+    summary: Experimental annotation for cargo receptor activity based on the crystal
+      structure showing how cubilin CUB5-8 recognizes IF-cobalamin. Directly establishes
+      cubilin&#39;s ligand-recognition (cargo receptor) function.
+    action: ACCEPT
+    reason: The structure defines the molecular basis of cubilin&#39;s cargo-receptor recognition
+      of the IF-Cbl ligand, supporting the core MF.
+    supported_by:
+    - reference_id: PMID:20237569
+      supporting_text: the crystal structure of the complex between IF-Cbl and the cubilin
+        IF-Cbl-binding-region (CUB(5-8))
+- term:
+    id: GO:0038024
+    label: cargo receptor activity
+  evidence_type: EXP
+  original_reference_id: PMID:30523278
+  qualifier: enables
+  review:
+    summary: Experimental annotation for cargo receptor activity based on the structural
+      assembly of cubam, the receptor for intestinal B12 uptake and kidney protein reabsorption.
+      Core molecular function.
+    action: ACCEPT
+    reason: Establishes cubilin as the multivalent ligand-binding component of the cubam
+      endocytic receptor.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: essential for intestinal vitamin B12 (B12) uptake and for protein
+        (e.g. albumin) reabsorption from the kidney filtrate
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: ISS annotation to lysosomal membrane by transfer from rodent ortholog (O70244).
+      Reflects trafficking of cubilin/cargo to the lysosome during ligand degradation;
+      a non-core, downstream location.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with delivery of endocytosed ligands to lysosomes, but the defining
+      functional location is the apical plasma membrane.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Lysosome membrane
+- term:
+    id: GO:0005768
+    label: endosome
+  evidence_type: EXP
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: Experimental annotation to endosome, based on the demonstration that cubilin
+      trafficks to the cell surface and endosomes when co-expressed with AMN. Part of
+      the endocytic pathway.
+    action: ACCEPT
+    reason: Directly supported experimental endosomal localization consistent with cubilin&#39;s
+      receptor-mediated endocytosis role.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0005768
+    label: endosome
+  evidence_type: EXP
+  original_reference_id: PMID:29402915
+  qualifier: located_in
+  review:
+    summary: Experimental annotation to endosome from the study of AMN-mediated cubilin
+      surface targeting, which documented internalization of cubilin from the apical
+      surface into vesicles. Endocytic-pathway localization.
+    action: ACCEPT
+    reason: Cubilin is internalized from the apical surface into the endocytic/endosomal
+      compartment; experimentally supported.
+    supported_by:
+    - reference_id: PMID:29402915
+      supporting_text: mini-cubilin was internalised from the apical surface
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: EXP
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: Experimental annotation to plasma membrane, based on the demonstration
+      that cubilin trafficks to the cell surface only when co-expressed with AMN. Core
+      surface location.
+    action: ACCEPT
+    reason: Direct experimental evidence for plasma-membrane (cell-surface) localization
+      of cubilin as part of the cubam complex.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: EXP
+  original_reference_id: PMID:29402915
+  qualifier: located_in
+  review:
+    summary: Experimental annotation to plasma membrane from the AMN-dependent surface-targeting
+      study, which showed AMN-dependent cubilin plasma-membrane expression in renal
+      and intestinal cells.
+    action: ACCEPT
+    reason: Direct experimental support for AMN-dependent plasma-membrane localization.
+    supported_by:
+    - reference_id: PMID:29402915
+      supporting_text: when cubilin was co-expressed with amnionless, a fraction of
+        cubilin expressed at the plasma membrane was detected
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: EXP
+  original_reference_id: PMID:30523278
+  qualifier: located_in
+  review:
+    summary: Experimental annotation to plasma membrane from the cubam structural-assembly
+      study, which established that cubilin is anchored to the apical membrane via AMN.
+    action: ACCEPT
+    reason: Cubilin is displayed at the (apical) plasma membrane through AMN anchoring;
+      experimentally supported.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: anchored to the apical membrane via interaction with the type-1
+        transmembrane protein amnionless (AMN)
+- term:
+    id: GO:0016324
+    label: apical plasma membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: ISS annotation to apical plasma membrane by transfer from rodent ortholog
+      (Q9JLB4). Consistent with the core apical localization of cubilin.
+    action: ACCEPT
+    reason: Apical plasma membrane is the core functional location, well supported experimentally
+      and by orthology.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0016324
+    label: apical plasma membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: Duplicate ISS annotation to apical plasma membrane, transferred from a second
+      rodent ortholog (O70244). Consistent with the core apical localization of cubilin.
+    action: ACCEPT
+    reason: Genuine duplicate of the apical plasma membrane ISS from a different ortholog;
+      apical plasma membrane is the core functional location.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: MGI IDA annotation to cobalamin metabolic process (acts_upstream_of_or_within).
+      Cubilin mediates intestinal B12 uptake, which is upstream of cellular cobalamin
+      metabolism. The direct role is transport; the metabolic-process framing is broader.
+    action: KEEP_AS_NON_CORE
+    reason: Cubilin&#39;s direct action is cobalamin transport/uptake, which is upstream
+      of cobalamin metabolism. The metabolic-process term is a valid broader/upstream
+      description but not the most precise statement of cubilin&#39;s function.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: intestinal cobalamin (vitamin B(12)) malabsorption
+- term:
+    id: GO:0031528
+    label: microvillus membrane
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: MGI IDA annotation to microvillus membrane. Cubilin localizes to the brush-border
+      microvilli of enterocytes and proximal tubule cells; a specific and accurate apical
+      location.
+    action: ACCEPT
+    reason: Microvillus (brush border) membrane is a precise and correct description
+      of cubilin&#39;s apical localization in absorptive epithelia.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: cubam location the enterocyte brush-border membrane
+- term:
+    id: GO:0038024
+    label: cargo receptor activity
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: enables
+  review:
+    summary: MGI IDA annotation for cargo receptor activity, from the demonstration that
+      cubam confers IF-cobalamin endocytosis. Core molecular function.
+    action: ACCEPT
+    reason: Direct experimental evidence for cubilin&#39;s cargo/endocytic receptor function.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: AMN binds to the amino-terminal third of cubilin and directs
+        subcellular localization and endocytosis of cubilin with its ligand
+- term:
+    id: GO:0038024
+    label: cargo receptor activity
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: enables
+  review:
+    summary: Duplicate MGI IDA annotation for cargo receptor activity from the same
+      supporting study (a separate MGI annotation record). Core molecular function of
+      cubilin as the ligand-binding subunit of the cubam endocytic receptor.
+    action: ACCEPT
+    reason: Genuine duplicate of the MGI cargo receptor activity IDA; direct experimental
+      support for cubilin&#39;s cargo/endocytic receptor function.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: AMN binds to the amino-terminal third of cubilin and directs
+        subcellular localization and endocytosis of cubilin with its ligand
+- term:
+    id: GO:0031528
+    label: microvillus membrane
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: is_active_in
+  review:
+    summary: MGI IDA annotation (is_active_in) to microvillus membrane, indicating that
+      cubilin acts at the brush-border microvillus membrane. Consistent with the core
+      apical site of ligand capture.
+    action: ACCEPT
+    reason: The microvillus (brush border) membrane is where cubilin performs its ligand-capture
+      function; correct and precise active-site localization.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: cubam location the enterocyte brush-border membrane
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: involved_in
+  review:
+    summary: MGI IDA annotation (involved_in) to cobalamin metabolic process. As with
+      the acts_upstream_of_or_within duplicate, cubilin&#39;s direct role is B12 transport/uptake,
+      which is part of overall cobalamin metabolism.
+    action: KEEP_AS_NON_CORE
+    reason: Cubilin participates in cobalamin metabolism by mediating uptake; the more
+      precise statement is cobalamin transport (retained as core). Kept as non-core broader
+      process.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: intestinal cobalamin (vitamin B(12)) malabsorption
+- term:
+    id: GO:0043235
+    label: signaling receptor complex
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: part_of
+  review:
+    summary: ISS annotation placing cubilin in a receptor complex, by transfer from rodent
+      ortholog (O70244). Reflects the cubam complex. As with the IPI duplicate, &#34;signaling&#34;
+      is a minor misnomer for what is an endocytic/cargo receptor complex.
+    action: ACCEPT
+    reason: Cubilin is genuinely part of the cubam receptor complex with AMN; complex
+      membership is accurate even though the &#34;signaling&#34; qualifier is imprecise.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Component of the cubam complex
+- term:
+    id: GO:0038024
+    label: cargo receptor activity
+  evidence_type: TAS
+  original_reference_id: PMID:9478979
+  qualifier: enables
+  review:
+    summary: GO_Central TAS annotation for cargo receptor activity, from the original
+      molecular characterization of cubilin as the 460-kDa peripheral membrane receptor
+      that facilitates uptake of IF-B12. Core molecular function.
+    action: ACCEPT
+    reason: The founding characterization of cubilin identified it as the endocytic receptor
+      facilitating IF-B12 uptake, the basis for its cargo-receptor MF.
+    supported_by:
+    - reference_id: PMID:9478979
+      supporting_text: functions as the receptor facilitating uptake of intrinsic factor-vitamin
+        B12 complexes in the intestine and kidney
+- term:
+    id: GO:0031526
+    label: brush border membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: ISS annotation to brush border membrane by transfer from rodent ortholog
+      (O70244). Cubilin is a brush-border receptor of absorptive epithelia; specific
+      and accurate apical location.
+    action: ACCEPT
+    reason: Brush border membrane is a precise, correct description of cubilin&#39;s apical
+      localization; supported experimentally and by orthology.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: cubam location the enterocyte brush-border membrane
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:23533145
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomics (HDA) detection of cubilin in prostatic-secretion/urinary
+      exosomes. Reflects shedding of the apical brush-border protein into extracellular
+      vesicles rather than a functional site.
+    action: KEEP_AS_NON_CORE
+    reason: Detection in exosomes is a byproduct of cubilin&#39;s abundant apical membrane
+      localization and its shedding into urine; not a functional localization but a
+      valid observation.
+    supported_by:
+    - reference_id: PMID:23533145
+      supporting_text: exosome preparations were characterized by a shotgun proteomics
+        procedure
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: IDA
+  original_reference_id: PMID:21082674
+  qualifier: located_in
+  review:
+    summary: IDA detection of cubilin in low-abundance urinary-exosome proteomics. As
+      above, reflects shedding of the apical membrane protein into urinary exosomes
+      rather than a functional site.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with cubilin&#39;s presence in urinary exosomes shed from renal epithelia;
+      a non-functional localization observation.
+    supported_by:
+    - reference_id: PMID:21082674
+      supporting_text: relatively low-abundant proteins in urinary exosomes
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:14576052
+  qualifier: enables
+  review:
+    summary: Bare protein binding IPI capturing the physical interaction with amnionless
+      (AMN, Q9BXJ7) demonstrated during the identification of the cubam complex. The
+      generic term is uninformative; the interaction is better captured by cubam complex
+      membership.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic protein binding is uninformative per curation guidelines. The AMN
+      interaction is more precisely represented by cubam complex membership; the IPI
+      is retained but flagged as over-annotated.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: cubilin and AMN are subunits of a novel cubilin/AMN (cubam) complex
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  qualifier: located_in
+  review:
+    summary: High-throughput proteomics (HDA) detection of cubilin in the human urinary-exosome
+      proteome. Reflects shedding into urinary exosomes rather than a functional site.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with cubilin&#39;s abundance at the apical surface of renal epithelia
+      and its shedding into urinary exosomes; a non-functional localization observation.
+    supported_by:
+    - reference_id: PMID:19056867
+      supporting_text: profile the proteome of human urinary exosomes
+- term:
+    id: GO:0016324
+    label: apical plasma membrane
+  evidence_type: IDA
+  original_reference_id: PMID:14576052
+  qualifier: located_in
+  review:
+    summary: UniProt IDA annotation to apical plasma membrane. Core functional location
+      of cubilin as displayed on polarized epithelial apical surfaces.
+    action: ACCEPT
+    reason: Apical plasma membrane is the defining functional site of cubilin; experimentally
+      supported.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: cubilin trafficked to the cell surface and endosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3296462
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to plasma membrane (from a defective-CUBN transport
+      reaction). Correct high-level location subsumed by the apical plasma membrane
+      annotations.
+    action: ACCEPT
+    reason: Correct as a broad location for the cell-surface receptor; retained as parent
+      of apical plasma membrane.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-209760
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to cytosol, arising from Reactome pathway modeling
+      of endocytic translocation reactions. Cubilin is a peripheral, extracellular-facing
+      membrane protein without a cytoplasmic domain, so a cytosolic localization is
+      biologically implausible and likely an artifact of pathway-reaction compartment
+      assignment.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Cubilin lacks a transmembrane and cytoplasmic domain and faces the extracellular/luminal
+      space; it is not a cytosolic protein. The cytosol assignment reflects Reactome
+      reaction compartmentalization rather than genuine cytosolic function.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Lacks a transmembrane domain and depends on
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-350168
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to cytosol (from the LRP2-mediated uptake reaction).
+      As above, cubilin is an extracellular-facing peripheral membrane protein, so cytosolic
+      localization is an artifact of Reactome reaction compartments.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Cubilin is not a cytosolic protein; this reflects Reactome pathway modeling
+      rather than genuine localization.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Lacks a transmembrane domain and depends on
+- term:
+    id: GO:0043202
+    label: lysosomal lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-209760
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to lysosomal lumen, from the pathway modeling of
+      endocytic delivery of the CUBN:GC:25(OH)D complex to the lysosome. Reflects trafficking
+      of endocytosed cargo to lysosomes; a downstream, non-core location.
+    action: KEEP_AS_NON_CORE
+    reason: Endocytosed ligands and cubilin can be delivered to the lysosome for degradation;
+      a valid downstream location but not the core functional site.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: lysosomal degradation of IF
+- term:
+    id: GO:0043202
+    label: lysosomal lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-350158
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to lysosomal lumen (LGMN-mediated release of CUBN
+      and 25(OH)D). Downstream lysosomal delivery of endocytosed cargo; non-core location.
+    action: KEEP_AS_NON_CORE
+    reason: Consistent with delivery of cubilin-bound cargo to the lysosome; downstream,
+      non-core.
+    supported_by:
+    - reference_id: PMID:14576052
+      supporting_text: lysosomal degradation of IF
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-264834
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to plasma membrane (endocytosis/degradation of
+      apoA-I reaction). Correct broad cell-surface location.
+    action: ACCEPT
+    reason: Cubilin at the plasma membrane captures apoA-I/HDL for endocytosis; correct
+      broad location subsumed by apical plasma membrane.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Acts together with LRP2 to mediate endocytosis of high-density
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-264848
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to plasma membrane (apoA-I binds CUBN:AMN reaction).
+      Correct broad cell-surface location.
+    action: ACCEPT
+    reason: Consistent with cubilin&#39;s cell-surface (apical) localization where it binds
+      apoA-I; retained as broad parent term.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000103
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to plasma membrane (CUBN:AMN binds CBLIF:RCbl reaction).
+      Correct broad cell-surface location where IF-cobalamin is captured.
+    action: ACCEPT
+    reason: Correct broad location; cubam binds IF-cobalamin at the (apical) plasma
+      membrane.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000137
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to plasma membrane (CUBN:AMN-mediated CBLIF:RCbl
+      uptake reaction). Correct broad cell-surface location.
+    action: ACCEPT
+    reason: Consistent with cubam-mediated IF-cobalamin uptake at the cell surface;
+      retained as broad parent of apical plasma membrane.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3296477
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to plasma membrane (defective-AMN transport reaction).
+      Correct broad cell-surface location.
+    action: ACCEPT
+    reason: Correct broad location for the cubam receptor at the cell surface.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-350168
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to plasma membrane (LRP2-mediated uptake of extracellular
+      CUBN:GC:25(OH)D reaction). Correct broad cell-surface location.
+    action: ACCEPT
+    reason: Consistent with cubilin&#39;s cell-surface localization; retained as broad parent
+      of apical plasma membrane.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-350186
+  qualifier: located_in
+  review:
+    summary: Reactome TAS annotation to plasma membrane (CUBN binds GC:25(OH)D reaction).
+      Correct broad cell-surface location.
+    action: ACCEPT
+    reason: Correct broad location where cubilin binds vitamin-D-binding protein for
+      reabsorption; retained as parent of apical plasma membrane.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Apical cell membrane
+- term:
+    id: GO:0001894
+    label: tissue homeostasis
+  evidence_type: NAS
+  original_reference_id: PMID:11994745
+  qualifier: involved_in
+  review:
+    summary: NAS annotation to tissue homeostasis from a review of megalin/cubilin as
+      multifunctional endocytic receptors. This is a very general process term; cubilin&#39;s
+      contributions (protein/vitamin reabsorption) are better captured by specific transport/endocytosis
+      terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Tissue homeostasis is too vague to be informative for cubilin. Its physiological
+      roles are more precisely described by cobalamin transport, receptor-mediated endocytosis
+      and protein reabsorption.
+    supported_by:
+    - reference_id: PMID:11994745
+      supporting_text: Megalin and cubilin are two structurally different endocytic
+        receptors that interact to serve such functions
+- term:
+    id: GO:0006898
+    label: receptor-mediated endocytosis
+  evidence_type: NAS
+  original_reference_id: PMID:11994745
+  qualifier: involved_in
+  review:
+    summary: NAS annotation to receptor-mediated endocytosis from the megalin/cubilin
+      review. This is the core mechanistic process by which cubilin/cubam internalizes
+      IF-cobalamin and reabsorbed proteins.
+    action: ACCEPT
+    reason: Receptor-mediated endocytosis is the defining biological process of cubilin,
+      well supported across the literature.
+    supported_by:
+    - reference_id: PMID:11994745
+      supporting_text: Megalin and cubilin are two structurally different endocytic
+        receptors that interact to serve such functions
+- term:
+    id: GO:0031232
+    label: extrinsic component of external side of plasma membrane
+  evidence_type: NAS
+  original_reference_id: PMID:11994745
+  qualifier: located_in
+  review:
+    summary: NAS annotation describing cubilin as an extrinsic (peripheral) component
+      of the external side of the plasma membrane. This is an accurate and informative
+      topology statement - cubilin lacks a transmembrane domain and is peripheral, facing
+      the extracellular/luminal space.
+    action: ACCEPT
+    reason: Accurate description of cubilin&#39;s membrane topology; it is a peripheral membrane
+      protein displayed on the extracellular side of the apical membrane through AMN.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Lacks a transmembrane domain and depends on
+- term:
+    id: GO:0031526
+    label: brush border membrane
+  evidence_type: NAS
+  original_reference_id: PMID:11994745
+  qualifier: located_in
+  review:
+    summary: NAS annotation to brush border membrane. Cubilin is a brush-border receptor
+      of absorptive epithelia; a specific and correct apical location.
+    action: ACCEPT
+    reason: Brush border membrane accurately describes cubilin&#39;s apical localization
+      in intestinal and renal epithelia.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: cubam location the enterocyte brush-border membrane
+- term:
+    id: GO:0042803
+    label: protein homodimerization activity
+  evidence_type: IDA
+  original_reference_id: PMID:10552972
+  qualifier: enables
+  review:
+    summary: UniProt IDA annotation for protein homodimerization activity, cited to
+      the canine genetics study of an accessory activity required for cubilin brush-border
+      expression. The cached abstract addresses genetic linkage (an accessory protein
+      required for cubilin surface expression) and does not describe a homodimerization
+      assay; the full text is not available to verify the supporting evidence. Structurally,
+      cubilin is now known to trimerize via its N-terminal beta-helix rather than simply
+      homodimerize.
+    action: UNDECIDED
+    reason: The self-association MF is plausible (cubilin oligomerizes - it forms trimers
+      and cubam can dimerize) but &#34;homodimerization&#34; is imprecise, and I cannot verify
+      the experimental basis from the cached abstract of the cited reference. Per policy,
+      UNDECIDED rather than REMOVE for an experimental annotation whose full text is
+      unavailable.
+    supported_by:
+    - reference_id: PMID:30523278
+      supporting_text: potential of dimerization into an even larger complex
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: PMID:10080186
+  qualifier: involved_in
+  review:
+    summary: PINC TAS annotation for cobalamin transport, citing the paper identifying
+      CUBN mutations as the cause of hereditary megaloblastic anemia 1 via selective
+      intestinal B12 malabsorption. Core biological process.
+    action: ACCEPT
+    reason: Genetic evidence that CUBN loss causes selective intestinal B12 malabsorption
+      directly supports cubilin&#39;s role in cobalamin transport.
+    supported_by:
+    - reference_id: PMID:10080186
+      supporting_text: MGA1 is characterized by selective intestinal vitamin B12 (B12,
+        cobalamin) malabsorption
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: TAS
+  original_reference_id: PMID:9478979
+  qualifier: located_in
+  review:
+    summary: PINC TAS annotation to the generic membrane term, from the original characterization
+      of cubilin as a peripheral membrane receptor. Correct but high-level.
+    action: ACCEPT
+    reason: Correct as a broad location; cubilin is a peripheral membrane protein. Subsumed
+      by more specific apical/brush-border membrane terms.
+    supported_by:
+    - reference_id: PMID:9478979
+      supporting_text: a megalin-binding peripheral membrane protein
+- term:
+    id: GO:0038023
+    label: signaling receptor activity
+  evidence_type: TAS
+  original_reference_id: PMID:10080186
+  qualifier: enables
+  review:
+    summary: Old PINC TAS annotation to signaling receptor activity. This is a misclassification -
+      cubilin is an endocytic/cargo receptor, not a signal-transducing (signaling) receptor.
+      It has no signaling domain and no described role in signal transduction; its function
+      is ligand capture for endocytosis.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Cubilin is a non-enzymatic endocytic cargo receptor (cargo receptor activity,
+      GO:0038024), not a signaling receptor. The signaling receptor activity term mischaracterizes
+      its molecular function; the correct MF is already annotated. Per policy for a TAS
+      mapping that is biologically wrong in kind, this is flagged as over-annotated.
+    supported_by:
+    - reference_id: file:human/CUBN/CUBN-uniprot.txt
+      supporting_text: Endocytic receptor which plays a role in lipoprotein, vitamin
+core_functions:
+- description: Non-enzymatic multiligand cargo/endocytic receptor that binds the intrinsic
+    factor-cobalamin (IF-B12) complex via its CUB5-8 domains and, together with AMN
+    (cubam) and megalin, mediates receptor-mediated endocytosis of B12 and reabsorbed
+    proteins.
+  molecular_function:
+    id: GO:0038024
+    label: cargo receptor activity
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0016324
+    label: apical plasma membrane
+  in_complex:
+    id: GO:0043235
+    label: receptor complex
+  supported_by:
+  - reference_id: PMID:14576052
+    supporting_text: AMN binds to the amino-terminal third of cubilin and directs subcellular
+      localization and endocytosis of cubilin with its ligand
+  - reference_id: PMID:20237569
+    supporting_text: how two distant CUB domains embrace the Cbl molecule by binding
+      the two IF domains in a Ca(2+)-dependent manner
+- description: As the ligand-binding subunit of the cubam receptor at the apical/brush-border
+    membrane, cubilin captures diverse filtered and luminal ligands for receptor-mediated
+    endocytosis, driving intestinal B12 uptake and renal proximal-tubule reabsorption
+    of proteins.
+  molecular_function:
+    id: GO:0038024
+    label: cargo receptor activity
+  directly_involved_in:
+  - id: GO:0006898
+    label: receptor-mediated endocytosis
+  locations:
+  - id: GO:0016324
+    label: apical plasma membrane
+  - id: GO:0031526
+    label: brush border membrane
+  supported_by:
+  - reference_id: PMID:9478979
+    supporting_text: functions as the receptor facilitating uptake of intrinsic factor-vitamin
+      B12 complexes in the intestine and kidney
+  - reference_id: PMID:30523278
+    supporting_text: it is responsible for reabsorption of abundant proteins in the
+      renal ultrafiltrate
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10080186
+  title: Mutations in CUBN, encoding the intrinsic factor-vitamin B12 receptor, cubilin,
+    cause hereditary megaloblastic anaemia 1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Establishes that CUBN loss-of-function causes selective
+      intestinal B12 malabsorption (MGA1/IGS1), supporting the cobalamin transport role.
+- id: PMID:10552972
+  title: Genetic evidence of an accessory activity required specifically for cubilin
+    brush-border expression and intrinsic factor-cobalamin absorption.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Canine genetics paper showing an accessory (AMN-like)
+      activity is required for cubilin brush-border expression; cited for a homodimerization
+      IDA whose experimental basis is not evident in the abstract (full text unavailable).
+- id: PMID:11994745
+  title: &#39;Megalin and cubilin: multifunctional endocytic receptors.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified review establishing cubilin (with megalin) as a multifunctional
+      endocytic receptor; source of the receptor-mediated endocytosis annotation.
+- id: PMID:14576052
+  title: The functional cobalamin (vitamin B12)-intrinsic factor receptor is a novel
+    complex of cubilin and amnionless.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Defines the cubam (cubilin/AMN) complex and shows
+      AMN directs cubilin surface localization and IF-cobalamin endocytosis; anchors
+      the cargo-receptor MF and cobalamin transport BP.
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: PubMed-verified urinary-exosome proteomics; supports only the incidental
+      extracellular exosome localization, not a functional role.
+- id: PMID:20237569
+  title: Structural basis for receptor recognition of vitamin-B(12)-intrinsic factor
+    complexes.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified crystal structure of CUB5-8/IF-Cbl; defines the calcium-dependent
+      dual-point recognition mechanism underlying the cargo-receptor and calcium-binding
+      functions.
+- id: PMID:21082674
+  title: Comprehensive analysis of low-abundance proteins in human urinary exosomes
+    using peptide ligand library technology, peptide OFFGEL fractionation and nanoHPLC-chip-MS/MS.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: PubMed-verified urinary-exosome proteomics; supports only incidental
+      exosome localization.
+- id: PMID:23533145
+  title: In-depth proteomic analyses of exosomes isolated from expressed prostatic
+    secretions in urine.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: PubMed-verified exosome proteomics; supports only incidental exosome
+      localization.
+- id: PMID:29402915
+  title: Amnionless-mediated glycosylation is crucial for cell surface targeting of
+    cubilin in renal and intestinal cells.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified full text. Shows AMN-dependent glycosylation and plasma-membrane/apical
+      targeting of cubilin and ER retention of mutants; supports localization annotations.
+- id: PMID:30523278
+  title: Structural assembly of the megadalton-sized receptor for intestinal vitamin
+    B(12) uptake and kidney protein reabsorption.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified full text. Cubam structure - three cubilin chains
+      dock onto AMN; establishes apical anchoring, trimer/dimer architecture and roles
+      in B12 uptake and renal reabsorption.
+- id: PMID:9478979
+  title: The intrinsic factor-vitamin B12 receptor and target of teratogenic antibodies
+    is a megalin-binding peripheral membrane protein with homology to developmental
+    proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Original molecular characterization naming cubilin;
+      identifies it as a peripheral (non-transmembrane) EGF/CUB-domain endocytic receptor
+      for IF-B12.
+- id: Reactome:R-HSA-196791
+  title: Vitamin D (calciferol) metabolism
+  findings: []
+- id: Reactome:R-HSA-209760
+  title: Endocytic translocation of CUBN:GC:25(OH)D to lysosomal lumen
+  findings: []
+- id: Reactome:R-HSA-264834
+  title: Endocytosis and degradation of apoA-I
+  findings: []
+- id: Reactome:R-HSA-264848
+  title: apoA-I binds to CUBN:AMN
+  findings: []
+- id: Reactome:R-HSA-3000103
+  title: CUBN:AMN binds CBLIF:RCbl
+  findings: []
+- id: Reactome:R-HSA-3000137
+  title: CUBN:AMN-mediated CBLIF:RCbl uptake and delivery to lysosome
+  findings: []
+- id: Reactome:R-HSA-3296462
+  title: Defective CUBN does not transport GIF:Cbl
+  findings: []
+- id: Reactome:R-HSA-3296477
+  title: Defective AMN does not transport GIF:Cbl
+  findings: []
+- id: Reactome:R-HSA-350158
+  title: LGMN hydrolyzes GC, releasing CUBN and 25(OH)D
+  findings: []
+- id: Reactome:R-HSA-350168
+  title: LRP2-mediated uptake of extracellular CUBN:GC:25(OH)D
+  findings: []
+- id: Reactome:R-HSA-350186
+  title: CUBN binds GC:25(OH)D
+  findings: []
+- id: Reactome:R-HSA-9758881
+  title: Uptake of dietary cobalamins into enterocytes
+  findings: []
+- id: file:human/CUBN/CUBN-uniprot.txt
+  title: UniProtKB entry O60494 (CUBN_HUMAN), Cubilin
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/LMBRD1/LMBRD1-ai-review.html
+++ b/genes/human/LMBRD1/LMBRD1-ai-review.html
@@ -1,0 +1,5746 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LMBRD1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>LMBRD1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9NUN5" target="_blank" class="term-link">
+                        Q9NUN5
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "LMBRD1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9NUN5" data-a="DESCRIPTION: LMBRD1 encodes LMBD1 (Lysosomal cobalamin transpor..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>LMBRD1 encodes LMBD1 (Lysosomal cobalamin transport escort protein LMBD1), a multi-pass glycosylated lysosomal membrane protein of the LIMR/LMBR1 family. It is required to export cobalamin (vitamin B12) from the lysosome to the cytosol after transcobalamin-bound cobalamin is endocytosed and degraded, making the vitamin available for cytosolic processing (by MMACHC/MMADHC) into the cofactors methylcobalamin and adenosylcobalamin. LMBD1 acts as an escort/chaperone for the half-ABC transporter ABCD4: it binds ABCD4 in the endoplasmic reticulum and is required to target and stabilize it at the lysosomal membrane, where the LMBD1:ABCD4 complex (handing off to cytosolic MMACHC) mediates ATP-dependent cobalamin efflux; the catalytic transport activity resides in ABCD4, while LMBD1 has no intrinsic cobalamin transport activity. Loss-of-function variants cause methylmalonic aciduria and homocystinuria, cblF type (MAHCF), in which free cobalamin accumulates in lysosomes. A minor plasma-membrane pool has been reported (mostly by similarity to the mouse ortholog) to act as a clathrin/AP-2 adaptor for internalization of the insulin receptor.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005765" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of LMBD1 to the lysosomal membrane. This matches the strong direct experimental evidence for lysosomal membrane localization and is a core cellular component for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LMBD1 is a bona fide lysosomal membrane protein, supported by multiple experimental studies (PMID:19136951, PMID:27456980, PMID:28572511, PMID:33845046). This is the core location of the protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The distribution of LMBD1-GFP coincided with that of LAMP1, i.e. having neither ER nor peroxisomal marker proteins (Fig. 1C), indicating that LMBD1-GFP is localized in lysosomes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061462" target="_blank" class="term-link">
+                                    GO:0061462
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to lysosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0061462" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment that LMBD1 is involved in protein localization to the lysosome. This reflects the verified escort role of LMBD1 in targeting the ABCD4 transporter from the ER to the lysosome.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LMBD1 is required to translocate ABCD4 from the ER to the lysosome and to retain it there; loss of LMBD1 disrupts ABCD4 lysosomal localization (PMID:27456980, PMID:28572511). This is a core molecular role of LMBD1 and is well captured by protein localization to lysosome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">our results support the view that the translocation of ABCD4 from the ER to lysosomes requires, at least in part, the lysosomal membrane protein LMBD1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005765" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCellular-location (SL-0157, Lysosome membrane) IEA mapping to lysosomal membrane. Redundant with, and confirmed by, the experimental annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location, well supported experimentally (see EXP/IDA entries).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LMBRD1/LMBRD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Lysosome membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCellular-location (SL-0097) IEA mapping to ER membrane. LMBD1 is present transiently in the ER membrane, where it binds newly synthesized ABCD4 before both traffic to the lysosome; this is a biosynthetic/mechanistic location rather than the steady-state functional compartment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ER-membrane localization is real (PMID:27456980 IDA) but represents the early biosynthetic step of the LMBD1/ABCD4 escort pathway, not the core lysosomal-membrane site of action. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LMBRD1/LMBRD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Targets ABCD4 transporter from the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005886" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Combined-methods IEA (with_from mouse ortholog Q8K0B2 SubCell SL-0039) placing LMBD1 at the plasma membrane. A minor plasma-membrane pool is reported in the mouse ortholog in the context of an insulin-receptor endocytosis adaptor role; human direct evidence is lacking.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Only a small portion of LMBD1 is reported at the plasma membrane, and the supporting evidence is by similarity to the mouse ortholog. The core location is the lysosomal membrane. Keep as a non-core minor location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recently a small region of LMBD1 was shown to be located on plasma membranes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0015889" data-r="GO_REF:0000108" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interontology (IEA, from MF GO:0015420) inference that LMBD1 is involved in cobalamin transport. LMBD1 is a subunit of the lysosomal cobalamin export complex and its loss (cblF) blocks lysosomal cobalamin efflux, so involvement in cobalamin transport is well supported at the process level.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cobalamin transport is the core biological process of LMBD1: loss of LMBD1 causes lysosomal cobalamin accumulation (cblF), and LMBD1 is an essential component of the LMBD1:ABCD4 lysosomal export complex (PMID:19136951, PMID:27456980).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ABCD4 and LMBD1, encoded by ABCD4 and LMBRD1 respectively, were shown to be involved in the export of cobalamin from lysosomes into the cytosol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030136" target="_blank" class="term-link">
+                                    GO:0030136
+                                </a>
+                            </span>
+                            <span class="term-label">clathrin-coated vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0030136" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Combined-methods IEA (with_from mouse ortholog Q8K0B2, SubCell SL-0070) placing LMBD1 in clathrin-coated vesicles, tied to the by-similarity insulin-receptor endocytosis adaptor role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This location relates to the secondary, by-similarity clathrin-mediated endocytosis function (insulin receptor) rather than the core lysosomal cobalamin role. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LMBRD1/LMBRD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasmic vesicle, clathrin-coated vesicle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035461" target="_blank" class="term-link">
+                                    GO:0035461
+                                </a>
+                            </span>
+                            <span class="term-label">vitamin transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0035461" data-r="GO_REF:0000108" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interontology (IEA, from MF GO:0090482) inference that LMBD1 is involved in vitamin transmembrane transport. This is the more general parent of the cobalamin (vitamin B12) transport process in which LMBD1 participates.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but less specific than cobalamin transport. Cobalamin is a vitamin (B12), so vitamin transmembrane transport is an accurate broader process term for the LMBD1:ABCD4 export function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link">
+                                        PMID:28572511
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The integral membrane proteins LMBD1 and ABCD4 are required for lysosomal</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005515" data-r="PMID:27456980" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI protein binding annotation with_from ABCD4 (O14678), from the study demonstrating the LMBD1-ABCD4 interaction and ABCD4 escort to lysosomes. The interaction is real and functionally central, but &#34;protein binding&#34; is uninformative as a molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The LMBD1-ABCD4 interaction is genuine and important (PMID:27456980), but the bare GO:0005515 protein binding term does not convey the specific escort/chaperone function. The functionally meaningful role is captured by protein localization to lysosome (GO:0061462) and the cobalamin transport process terms. Retain the interaction as evidence but treat the generic MF as an over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These results show that ABCD4 is able to form a complex with LMBD1 in cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28572511
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Clinical or ATPase domain mutations in ABCD4 disrupt the int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005515" data-r="PMID:28572511" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI protein binding annotation with_from ABCD4 (O14678), from the FRET-based confirmation of the selective ABCD4-LMBD1 interaction and its requirement for ABCD4 lysosomal targeting.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine and important LMBD1-ABCD4 interaction (PMID:28572511), but the generic protein binding MF is uninformative. The specific function is better represented by protein localization to lysosome and cobalamin transport.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link">
+                                        PMID:28572511
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we showed that ABCD4 lysosomal</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007369" target="_blank" class="term-link">
+                                    GO:0007369
+                                </a>
+                            </span>
+                            <span class="term-label">gastrulation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0007369" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara IEA transfer from the mouse ortholog (Q8K0B2) assigning involvement in gastrulation, reflecting an early embryonic role reported by similarity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A developmental/gastrulation role is asserted only by similarity to the mouse ortholog and is not part of the core, biochemically defined lysosomal cobalamin function. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LMBRD1/LMBRD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Essential for the initiation of gastrulation and early formation of mesoderm structures during embryogenesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032050" target="_blank" class="term-link">
+                                    GO:0032050
+                                </a>
+                            </span>
+                            <span class="term-label">clathrin heavy chain binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0032050" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara IEA transfer from the mouse ortholog (Q8K0B2) assigning clathrin heavy chain binding, part of the by-similarity insulin-receptor clathrin-mediated endocytosis adaptor role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Related to the secondary, by-similarity endocytic-adaptor function rather than the core lysosomal cobalamin role; human direct evidence is absent. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 is reported to be a specific adaptor for the clathrin-mediated endocytosis of the insulin receptor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035612" target="_blank" class="term-link">
+                                    GO:0035612
+                                </a>
+                            </span>
+                            <span class="term-label">AP-2 adaptor complex binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0035612" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara IEA transfer from the mouse ortholog (Q8K0B2) assigning AP-2 adaptor complex binding, consistent with the two putative AP-2 binding motifs (YERL and WTKF) noted in UniProt.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Part of the by-similarity clathrin/AP-2 endocytic-adaptor role for the insulin receptor rather than the core cobalamin function. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 possesses two putative AP-2 binding motifs</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038016" target="_blank" class="term-link">
+                                    GO:0038016
+                                </a>
+                            </span>
+                            <span class="term-label">insulin receptor internalization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0038016" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara IEA transfer from the mouse ortholog (Q8K0B2) assigning involvement in insulin receptor internalization, the endpoint of the by-similarity clathrin-mediated endocytosis adaptor role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Secondary, by-similarity role (adaptor for INSR endocytosis); not the core lysosomal cobalamin function. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 is reported to be a specific adaptor for the clathrin-mediated endocytosis of the insulin receptor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072583" target="_blank" class="term-link">
+                                    GO:0072583
+                                </a>
+                            </span>
+                            <span class="term-label">clathrin-dependent endocytosis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0072583" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Ensembl-Compara IEA transfer from the mouse ortholog (Q8K0B2) assigning involvement in clathrin-dependent endocytosis (the INSR adaptor role).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Secondary, by-similarity endocytic role; not the core cobalamin function. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 is reported to be a specific adaptor for the clathrin-mediated endocytosis of the insulin receptor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015420" target="_blank" class="term-link">
+                                    GO:0015420
+                                </a>
+                            </span>
+                            <span class="term-label">ABC-type vitamin B12 transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0015420" data-r="PMID:33845046" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA (via MGI) assigning ABC-type vitamin B12 transporter activity to LMBD1, from the liposome reconstitution study. However, that very study showed the transporter activity resides in ABCD4 and that LMBD1 by itself has no cobalamin transport (or ATPase) activity, so this MF is mis-attributed to LMBD1 as an enabler.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PMID:33845046 demonstrated that ABCD4 alone transports cobalamin in an ATP-dependent manner and that LMBD1 exhibited no cobalamin transport activity; LMBD1 lacks nucleotide-binding domains and is not an ABC transporter. LMBD1 is a subunit/escort of the transporting complex, so ABC-type vitamin B12 transporter activity should not be annotated as a function LMBD1 enables. Not removed because LMBD1 is a genuine component of the cobalamin-transporting LMBD1:ABCD4 complex; the activity is better attributed to ABCD4 (or the complex).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">no cobalamin transport activity. These results suggest that ABCD4 may be capable</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 itself had neither ATPase nor cobalamin transport activities</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090482" target="_blank" class="term-link">
+                                    GO:0090482
+                                </a>
+                            </span>
+                            <span class="term-label">vitamin transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0090482" data-r="PMID:27456980" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA (via MGI) assigning vitamin transmembrane transporter activity to LMBD1, citing the ABCD4-escort paper. That paper does not demonstrate LMBD1-intrinsic transporter activity; it shows LMBD1 escorts ABCD4 to lysosomes. The intrinsic transporter activity is ABCD4&#39;s (PMID:33845046).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No study demonstrates that LMBD1 itself is a transmembrane transporter; the direct in vitro test (PMID:33845046) found LMBD1 has no cobalamin transport activity. LMBD1 participates in transport as an escort/subunit of the LMBD1:ABCD4 complex, so an enabled transmembrane transporter MF is an over-annotation. Retained rather than removed because LMBD1 is part of the transporting complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 itself had neither ATPase nor cobalamin transport activities</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19136951" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19136951
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of a putative lysosomal cobalamin exporter al...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005765" data-r="PMID:19136951" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (EXP) lysosomal membrane localization from the founding cblF study that identified LMBD1 as a lysosomal membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental support that LMBD1 is a lysosomal membrane protein; core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19136951" target="_blank" class="term-link">
+                                        PMID:19136951
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBRD1, encoding LMBD1, a lysosomal membrane protein with homology to lipocalin membrane receptor LIMR</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28572511
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Clinical or ATPase domain mutations in ABCD4 disrupt the int...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005765" data-r="PMID:28572511" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (EXP) lysosomal membrane localization from the FRET-based ABCD4-LMBD1 interaction study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core location confirmed experimentally; LMBD1 is an integral lysosomal membrane protein required for lysosomal cobalamin release.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link">
+                                        PMID:28572511
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The integral membrane proteins LMBD1 and ABCD4 are required for lysosomal</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005765" data-r="PMID:33845046" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (EXP) lysosomal membrane localization from the liposome reconstitution study, which describes LMBD1 as the lysosomal membrane protein that complexes with ABCD4.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core lysosomal-membrane location, consistent across all functional studies.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The ABCD4 dimer then forms a complex with lysosomal membrane protein LMBD1, and this complex is translocated from the ER to lysosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005886" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer from the mouse ortholog (Q8K0B2) placing LMBD1 at the plasma membrane, reflecting the reported minor plasma-membrane pool linked to the INSR endocytosis adaptor role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Minor location supported only by similarity; core location is the lysosomal membrane. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recently a small region of LMBD1 was shown to be located on plasma membranes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090482" target="_blank" class="term-link">
+                                    GO:0090482
+                                </a>
+                            </span>
+                            <span class="term-label">vitamin transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0090482" data-r="PMID:27456980" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Duplicate IDA (via MGI, older date) assigning vitamin transmembrane transporter activity to LMBD1 from the ABCD4-escort paper; same over-annotation issue as the other GO:0090482 entry.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LMBD1 has no demonstrated intrinsic transporter activity (PMID:33845046); it escorts and complexes with ABCD4, which is the catalytic transporter. Over-annotation, not removed because LMBD1 is a subunit of the transporting complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 itself had neither ATPase nor cobalamin transport activities</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The lysosomal protein ABCD4 can transport vitamin B(12) acro...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005515" data-r="PMID:33845046" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI protein binding annotation with_from ABCD4 (O14678), from the in vitro pull-down/crosslinking showing purified LMBD1 and ABCD4 interact with 1:1 stoichiometry.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real and specific LMBD1-ABCD4 interaction, but the bare protein binding MF is uninformative. The functionally meaningful roles are protein localization to lysosome and cobalamin transport (as complex subunit).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                        PMID:33845046
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These results indicate that purified ABCD4 and LMBD1 interact each other with a 1:1 stoichiometry.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038016" target="_blank" class="term-link">
+                                    GO:0038016
+                                </a>
+                            </span>
+                            <span class="term-label">insulin receptor internalization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0038016" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer from the mouse ortholog (Q8K0B2) assigning involvement in insulin receptor internalization (the by-similarity endocytic adaptor role).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Secondary, by-similarity function; not the core lysosomal cobalamin role. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 is reported to be a specific adaptor for the clathrin-mediated endocytosis of the insulin receptor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005886" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer from the mouse ortholog (Q8K0B2) with part_of qualifier placing LMBD1 at the plasma membrane; a minor location tied to the by-similarity INSR endocytosis role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Minor, by-similarity plasma-membrane location; core location is the lysosomal membrane. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">recently a small region of LMBD1 was shown to be located on plasma membranes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007369" target="_blank" class="term-link">
+                                    GO:0007369
+                                </a>
+                            </span>
+                            <span class="term-label">gastrulation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0007369" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer from the mouse ortholog (Q8K0B2) assigning involvement in gastrulation, an early embryonic role asserted by similarity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Developmental role supported only by similarity to the mouse ortholog; not part of the core cobalamin function. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LMBRD1/LMBRD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Essential for the initiation of gastrulation and early formation of mesoderm structures during embryogenesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030136" target="_blank" class="term-link">
+                                    GO:0030136
+                                </a>
+                            </span>
+                            <span class="term-label">clathrin-coated vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0030136" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer from the mouse ortholog (Q8K0B2) placing LMBD1 in clathrin-coated vesicles, tied to the by-similarity INSR endocytosis adaptor role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Related to the secondary endocytic-adaptor function, by similarity; not the core lysosomal cobalamin role. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LMBRD1/LMBRD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasmic vesicle, clathrin-coated vesicle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032050" target="_blank" class="term-link">
+                                    GO:0032050
+                                </a>
+                            </span>
+                            <span class="term-label">clathrin heavy chain binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0032050" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer from the mouse ortholog (Q8K0B2) assigning clathrin heavy chain binding (by-similarity INSR endocytic adaptor role).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Secondary, by-similarity endocytic-adaptor function; not the core cobalamin role. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 is reported to be a specific adaptor for the clathrin-mediated endocytosis of the insulin receptor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035612" target="_blank" class="term-link">
+                                    GO:0035612
+                                </a>
+                            </span>
+                            <span class="term-label">AP-2 adaptor complex binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0035612" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer from the mouse ortholog (Q8K0B2) assigning AP-2 adaptor complex binding, consistent with the YERL/WTKF AP-2 binding motifs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Part of the by-similarity clathrin/AP-2 endocytic-adaptor role; not the core cobalamin function. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LMBRD1/LMBRD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">YERL motif; mediates interaction with adapter</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045334" target="_blank" class="term-link">
+                                    GO:0045334
+                                </a>
+                            </span>
+                            <span class="term-label">clathrin-coated endocytic vesicle</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0045334" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer from the mouse ortholog (Q8K0B2) placing LMBD1 in clathrin-coated endocytic vesicles, tied to the by-similarity INSR endocytosis adaptor role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Related to the secondary endocytic-adaptor function, by similarity; not the core lysosomal cobalamin role. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LMBRD1/LMBRD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasmic vesicle, clathrin-coated vesicle</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072583" target="_blank" class="term-link">
+                                    GO:0072583
+                                </a>
+                            </span>
+                            <span class="term-label">clathrin-dependent endocytosis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0072583" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer from the mouse ortholog (Q8K0B2) assigning involvement in clathrin-dependent endocytosis (INSR adaptor role).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Secondary, by-similarity endocytic role; not the core cobalamin function. Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">LMBD1 is reported to be a specific adaptor for the clathrin-mediated endocytosis of the insulin receptor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005789" data-r="PMID:27456980" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct (IDA) ER-membrane localization from the ABCD4-escort study; LMBD1 binds newly synthesized ABCD4 in the ER before both traffic to the lysosome.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ER localization is genuine but is the transient biosynthetic step of the escort pathway, not the steady-state functional compartment (the lysosomal membrane). Keep as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">This suggests that LMBD1 associates with ABCD4 at the ER membrane and transports ABCD4 to lysosomes.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005765" data-r="PMID:27456980" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct (IDA) lysosomal membrane localization from the ABCD4-escort study (LMBD1-GFP colocalizes with LAMP1). Core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strong direct experimental evidence for the core lysosomal membrane location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indicating that LMBD1-GFP is localized in lysosomes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061462" target="_blank" class="term-link">
+                                    GO:0061462
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to lysosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27456980
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Translocation of the ABC transporter ABCD4 from the endoplas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0061462" data-r="PMID:27456980" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct (IDA) evidence that LMBD1 is involved in protein localization to the lysosome, specifically escorting ABCD4 from the ER to the lysosome. This is a core, experimentally verified molecular role of LMBD1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> LMBD1 is required to translocate and retain ABCD4 at the lysosomal membrane; mislocalized LMBD1 mutants fail to bring ABCD4 to lysosomes (PMID:27456980). Core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                        PMID:27456980
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">our results support the view that the translocation of ABCD4 from the ER to lysosomes requires, at least in part, the lysosomal membrane protein LMBD1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25535791
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and interaction analyses of two human lysosomal...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005515" data-r="PMID:25535791" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI protein binding annotations from the SPR study, with_from ABCD4 (O14678) and MMACHC (Q9Y4U1). LMBD1 binds both ABCD4 and the cytosolic cobalamin-processing protein MMACHC with low-nanomolar affinity, forming the complex that vectorially delivers lysosomal cobalamin to MMACHC. Real and functionally central interactions, but bare protein binding is uninformative as an MF. (The GOA has two lines for this PMID, one per partner; both are represented by this entry.)
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The LMBD1-ABCD4 and LMBD1-MMACHC interactions are genuine and important (PMID:25535791), but the generic GO:0005515 term does not capture the escort/hand-off function; that is better represented by protein localization to lysosome and the cobalamin transport process. Retain the interactions as evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link">
+                                        PMID:25535791
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMACHC also interacts with LMBD1 and ABCD4 with low nanomolar affinity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link">
+                                        PMID:25535791
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">membrane-bound LMBD1 and ABCD4 facilitate the vectorial delivery of lysosomal vitamin B(12) to cytoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput (HDA) membrane-proteome identification of LMBD1 in an NK cell line, supporting a generic membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0016020 membrane is a high-level, uninformative location from a proteomic membrane-fractionation screen; it is subsumed by the specific, experimentally supported lysosomal membrane annotation. Not wrong, but over-general.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mass spectrometric analysis identified 1843 proteins with high confidence scores.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-5223313
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005765" data-r="Reactome:R-HSA-5223313" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS lysosomal membrane localization from the ABCD4:LMBRD1 cobalamin export reaction (gut mucosal cells). Consistent with the core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Curated pathway annotation consistent with all experimental evidence for lysosomal membrane localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-5223313
+
+                                </span>
+
+                                <div class="support-text">LMBRD1 stabilizes ABCD4 in the lysosomal membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-5683325
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005765" data-r="Reactome:R-HSA-5683325" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS lysosomal membrane localization from the defective ABCD4:LMBRD1 cobalamin transport reaction. Consistent with the core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Curated pathway annotation consistent with the experimentally established lysosomal membrane location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-5683325
+
+                                </span>
+
+                                <div class="support-text">ATP-binding cassette sub-family D member 4 (ABCD4) is thought to mediate the lysosomal export of cobalamin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                    GO:0005765
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9759206
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUN5" data-a="GO:0005765" data-r="Reactome:R-HSA-9759206" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS lysosomal membrane localization from the ABCD4:LMBRD1 cobalamin export reaction (cells throughout the body). Consistent with the core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Curated pathway annotation consistent with the experimentally established lysosomal membrane location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-9759206
+
+                                </span>
+
+                                <div class="support-text">LMBRD1 stabilizes ABCD4 in the lysosomal membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Lysosomal-membrane escort/chaperone that targets and stabilizes the ABC transporter ABCD4 at the lysosomal membrane (translocating it from the ER), thereby enabling assembly of the lysosomal cobalamin export machinery.</h3>
+                <span class="vote-buttons" data-g="Q9NUN5" data-a="FUNCTION: Lysosomal-membrane escort/chaperone that targets a..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061462" target="_blank" class="term-link">
+                                protein localization to lysosome
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                lysosomal membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                                PMID:27456980
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">our results support the view that the translocation of ABCD4 from the ER to lysosomes requires, at least in part, the lysosomal membrane protein LMBD1.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link">
+                                PMID:28572511
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">we showed that ABCD4 lysosomal</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As a subunit of the lysosomal LMBD1:ABCD4 complex (handing off to cytosolic MMACHC), participates in the export of cobalamin (vitamin B12) from the lysosomal lumen to the cytosol. LMBD1 has no intrinsic transport activity; the catalytic transport is performed by ABCD4. Loss of LMBD1 causes lysosomal cobalamin accumulation (cblF).</h3>
+                <span class="vote-buttons" data-g="Q9NUN5" data-a="FUNCTION: As a subunit of the lysosomal LMBD1:ABCD4 complex ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                lysosomal membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19136951" target="_blank" class="term-link">
+                                PMID:19136951
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">In the cblF inborn error of vitamin B(12)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link">
+                                PMID:25535791
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">membrane-bound LMBD1 and ABCD4 facilitate the vectorial delivery of lysosomal vitamin B(12) to cytoplasmic</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                                PMID:33845046
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">LMBD1 itself had neither ATPase nor cobalamin transport activities</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19136951" target="_blank" class="term-link">
+                            PMID:19136951
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of a putative lysosomal cobalamin exporter altered in the cblF defect of vitamin B12 metabolism.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25535791" target="_blank" class="term-link">
+                            PMID:25535791
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Purification and interaction analyses of two human lysosomal vitamin B12 transporters: LMBD1 and ABCD4.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" target="_blank" class="term-link">
+                            PMID:27456980
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Translocation of the ABC transporter ABCD4 from the endoplasmic reticulum to lysosomes requires the escort protein LMBD1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" target="_blank" class="term-link">
+                            PMID:28572511
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Clinical or ATPase domain mutations in ABCD4 disrupt the interaction between the vitamin B(12)-trafficking proteins ABCD4 and LMBD1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33845046" target="_blank" class="term-link">
+                            PMID:33845046
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The lysosomal protein ABCD4 can transport vitamin B(12) across liposomal membranes in vitro.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-5223313
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ABCD4:LMBRD1 transports RCbl from lysosomal lumen to cytosol (gut mucosal cells)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-5683325
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective ABCD4:LMBRD1 does not transport Cbl from lysosomal lumen to cytosol</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9759206
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ABCD4:LMBRD1 transports RCbl from lysosomal lumen to cytosol</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/LMBRD1/LMBRD1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q9NUN5 (LMBD1_HUMAN)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Given that LMBD1 has no intrinsic cobalamin transport or ATPase activity and ABCD4 alone suffices in vitro, is the correct molecular-function representation of LMBD1 a transporter-complex subunit / chaperone rather than an enabler of transporter activity, and should GO capture the LMBD1:ABCD4 (:MMACHC) complex explicitly?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9NUN5" data-a="Q: Given that LMBD1 has no intrinsic cobalamin transp..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Cryo-EM or crystal structure of the lysosomal LMBD1:ABCD4 complex (with and without MMACHC) to define the LMBD1 interaction surface and the cobalamin hand-off path from the lysosomal lumen to cytosolic MMACHC.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9NUN5" data-a="EXPERIMENT: Cryo-EM or crystal structure of the lysosomal LMBD..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitution of the LMBD1:ABCD4:MMACHC assembly to test whether LMBD1 modulates the rate, directionality, or MMACHC-coupling of ABCD4-mediated cobalamin efflux beyond its established role in ABCD4 lysosomal targeting.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9NUN5" data-a="EXPERIMENT: Reconstitution of the LMBD1:ABCD4:MMACHC assembly ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(LMBRD1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9NUN5" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="lmbrd1-q9nun5-review-notes">LMBRD1 (Q9NUN5) review notes</h1>
+<p>Deep research (falcon) was unavailable (HTTP 402, out of credits). This review is grounded in the<br />
+cached UniProt record (<code>LMBRD1-uniprot.txt</code>), the seeded GOA (<code>LMBRD1-goa.tsv</code>), and cached<br />
+publications in <code>publications/PMID_*.md</code> plus <code>reactome/R-HSA-*.md</code>.</p>
+<h2 id="core-biology">Core biology</h2>
+<p>LMBRD1 encodes LMBD1 (Lysosomal cobalamin transport escort protein LMBD1), a 540-aa, multi-pass<br />
+(9 predicted TM helices) glycosylated lysosomal membrane protein of the LIMR / LMBR1 family.</p>
+<ul>
+<li>Identified as the gene mutated in the <strong>cblF</strong> inborn error of vitamin B12 (cobalamin) metabolism;<br />
+  in cblF, free cobalamin accumulates in lysosomes, hindering its conversion to the cofactors<br />
+  adenosylcobalamin (AdoCbl) and methylcobalamin (MeCbl). <a href="https://pubmed.ncbi.nlm.nih.gov/19136951" title="In the cblF inborn error of   vitamin B(12) metabolism, free vitamin accumulates in lysosomes, thus hindering its conversion to   cofactors.">PMID:19136951</a> The paper concludes "LMBD1 is a lysosomal membrane exporter for cobalamin."<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/19136951" title="suggests that LMBD1 is a lysosomal membrane exporter for cobalamin">PMID:19136951</a></li>
+<li>Disease: Methylmalonic aciduria and homocystinuria, cblF type (MAHCF, MIM:277380), autosomal<br />
+  recessive. (UniProt DISEASE.)</li>
+</ul>
+<h2 id="mechanism-partners">Mechanism / partners</h2>
+<ul>
+<li><strong>ABCD4 escort/targeting</strong>: LMBD1 interacts with the half-ABC transporter ABCD4 (O14678) on the ER<br />
+  membrane and is required to translocate ABCD4 from the ER to lysosomes; loss of LMBD1 lysosomal<br />
+  targeting mislocalizes ABCD4. <a href="https://pubmed.ncbi.nlm.nih.gov/27456980" title="the translocation of ABCD4 from the endoplasmic   reticulum to lysosomes requires, at least in part, the lysosomal membrane protein LMBD1">PMID:27456980</a>. Confirmed<br />
+  by FRET / rescue in <a href="https://pubmed.ncbi.nlm.nih.gov/28572511" title="ABCD4 lysosomal targeting depends on co-expression of, and   interaction with, LMBD1">PMID:28572511</a>.</li>
+<li><strong>Complex with ABCD4 + MMACHC</strong> for vectorial handoff of lysosomal B12 to the cytosolic processing<br />
+  protein MMACHC (Q9Y4U1). [PMID:25535791 "the cytoplasmic vitamin B(12)-processing protein MMACHC<br />
+  also interacts with LMBD1 and ABCD4 with low nanomolar affinity"; "membrane-bound LMBD1 and ABCD4<br />
+  facilitate the vectorial delivery of lysosomal vitamin B(12) to cytoplasmic MMACHC"].</li>
+<li><strong>Who does the actual transport?</strong> In vitro reconstitution shows <strong>ABCD4 alone</strong> (ATP-dependent)<br />
+  transports cobalamin across liposomal membranes, and <strong>LMBD1 has no cobalamin transport activity</strong><br />
+  on its own. [PMID:33845046 "LMBD1 exhibited no cobalamin transport activity"; "LMBD1 itself had<br />
+  neither ATPase nor cobalamin transport activities"]. So LMBD1's core, verified role is as the<br />
+  lysosomal-membrane escort/chaperone that delivers and stabilizes ABCD4 (and organizes the<br />
+  LMBD1:ABCD4:MMACHC handoff), rather than as the catalytic transporter subunit.</li>
+<li>Reactome models the exporter as the <strong>ABCD4:LMBRD1</strong> complex; notes "ABCD4 by itself in liposomes can<br />
+  mediate RCbl transport, indicating that ABCD4, not LBRD1, is directly responsible for intracellular<br />
+  RCbl transport" and "LMBRD1 stabilizes ABCD4 in the lysosomal membrane". (reactome/R-HSA-5223313.)</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>Lysosome membrane: strong experimental support (EXP/IDA) in PMID:19136951, 27456980, 28572511,<br />
+  33845046; also IBA and UniProt SubCell IEA. This is the core CC.</li>
+<li>ER membrane (IDA, PMID:27456980): transient/biosynthetic — ABCD4 is escorted from here; part of the<br />
+  mechanism, non-core steady-state location.</li>
+<li>Plasma membrane / clathrin-coated vesicle / clathrin-coated endocytic vesicle / membrane (HDA):<br />
+  a minor pool at the plasma membrane is reported in the mouse ortholog (INSR endocytosis adaptor<br />
+  role, By similarity, Q8K0B2). Human evidence is ISS/IEA (from mouse) or a broad membrane proteome<br />
+  HDA. Non-core.</li>
+</ul>
+<h2 id="secondary-by-similarity-functions-mouse-ortholog-q8k0b2">Secondary / By-similarity functions (mouse ortholog Q8K0B2)</h2>
+<ul>
+<li>Adaptor for clathrin-mediated endocytosis of the insulin receptor (INSR): AP-2 adaptor complex<br />
+  binding (GO:0035612), clathrin heavy chain binding (GO:0032050), insulin receptor internalization<br />
+  (GO:0038016), clathrin-dependent endocytosis (GO:0072583). All are ISS/IEA transferred from the<br />
+  mouse ortholog (Q8K0B2). YERL (232-235) and WTKF (294-297) motifs mediate AP-2 binding (UniProt<br />
+  MOTIF, By similarity). Keep as non-core (not the cobalamin function, transferred by similarity).</li>
+<li>Gastrulation (GO:0007369): "Essential for the initiation of gastrulation..." — By similarity to<br />
+  mouse (Q8K0B2). ISS/IEA. Non-core developmental role.</li>
+</ul>
+<h2 id="isoform-3-nesi-microbial-infection">Isoform 3 / NESI (microbial infection)</h2>
+<p>Isoform 3 (NESI, lacks 73 N-terminal aa) may facilitate assembly/nuclear export of hepatitis delta<br />
+virus large antigen (PMID:15956556, not in GOA). Not a GO annotation here; noted for completeness.</p>
+<h2 id="goa-notes">GOA notes</h2>
+<ul>
+<li>The GOA (<code>LMBRD1-goa.tsv</code>) has <strong>40 annotation lines</strong>. The ai-review stub has 38 review entries; it<br />
+  collapses the two PMID:25535791 IPI lines (one with_from O14678/ABCD4, one with_from Q9Y4U1/MMACHC)<br />
+  into a single entry. Both interactions are real (UniProt SUBUNIT). I keep the single stub entry and<br />
+  note both partners.</li>
+<li>MF terms present in GOA (F-aspect): GO:0015420 (ABC-type vitamin B12 transporter activity, IDA<br />
+  PMID:33845046), GO:0090482 (vitamin transmembrane transporter activity, IDA PMID:27456980),<br />
+  GO:0005515 (protein binding, several IPI), GO:0032050 (clathrin heavy chain binding, ISS/IEA),<br />
+  GO:0035612 (AP-2 adaptor complex binding, ISS/IEA). So an F-aspect term IS present.</li>
+<li>The MF transporter terms are complicated: PMID:33845046 (source of the GO:0015420 IDA) actually<br />
+  demonstrated the transporter activity resides in <strong>ABCD4</strong>, and that <strong>LMBD1 has no transport<br />
+  activity</strong>. So annotating "ABC-type vitamin B12 transporter activity" directly to LMBD1 as an<br />
+  enabled MF is an over-annotation (the complex/ABCD4 transports; LMBD1 is the escort). Same logic for<br />
+  GO:0090482 vitamin transmembrane transporter activity (IDA PMID:27456980 — that paper is about<br />
+  escorting ABCD4, not demonstrating LMBD1 transport). These are marked MARK_AS_OVER_ANNOTATED /<br />
+  contributes-to at the complex level rather than removed (LMBD1 is a bona fide subunit of the<br />
+  transporting complex).</li>
+</ul>
+<h2 id="core-functions-my-synthesis">Core functions (my synthesis)</h2>
+<ol>
+<li>Lysosomal-membrane escort/chaperone that targets and stabilizes ABCD4 (protein localization to<br />
+   lysosome; GO:0061462) — verified experimentally.</li>
+<li>Part of the LMBD1:ABCD4 complex that exports cobalamin from the lysosomal lumen to the cytosol<br />
+   (cobalamin transport GO:0015889 / vitamin transmembrane transport) — as a complex subunit; the<br />
+   catalytic transport is ABCD4's.</li>
+<li>Localizes to the lysosomal membrane (GO:0005765).</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9NUN5
+gene_symbol: LMBRD1
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  LMBRD1 encodes LMBD1 (Lysosomal cobalamin transport escort protein LMBD1), a
+  multi-pass glycosylated lysosomal membrane protein of the LIMR/LMBR1 family.
+  It is required to export cobalamin (vitamin B12) from the lysosome to the
+  cytosol after transcobalamin-bound cobalamin is endocytosed and degraded,
+  making the vitamin available for cytosolic processing (by MMACHC/MMADHC) into
+  the cofactors methylcobalamin and adenosylcobalamin. LMBD1 acts as an
+  escort/chaperone for the half-ABC transporter ABCD4: it binds ABCD4 in the
+  endoplasmic reticulum and is required to target and stabilize it at the
+  lysosomal membrane, where the LMBD1:ABCD4 complex (handing off to cytosolic
+  MMACHC) mediates ATP-dependent cobalamin efflux; the catalytic transport
+  activity resides in ABCD4, while LMBD1 has no intrinsic cobalamin transport
+  activity. Loss-of-function variants cause methylmalonic aciduria and
+  homocystinuria, cblF type (MAHCF), in which free cobalamin accumulates in
+  lysosomes. A minor plasma-membrane pool has been reported (mostly by
+  similarity to the mouse ortholog) to act as a clathrin/AP-2 adaptor for
+  internalization of the insulin receptor.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q9NUN5-1
+- name: &#39;2&#39;
+  id: Q9NUN5-2
+  sequence_note: VSP_021630, VSP_036540
+- name: 3 (NESI)
+  id: Q9NUN5-3
+  sequence_note: VSP_021629
+- name: &#39;4&#39;
+  id: Q9NUN5-4
+  sequence_note: VSP_036539, VSP_021630, VSP_036540
+existing_annotations:
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment of LMBD1 to the lysosomal membrane. This
+      matches the strong direct experimental evidence for lysosomal membrane
+      localization and is a core cellular component for this gene.
+    action: ACCEPT
+    reason: &gt;-
+      LMBD1 is a bona fide lysosomal membrane protein, supported by multiple
+      experimental studies (PMID:19136951, PMID:27456980, PMID:28572511,
+      PMID:33845046). This is the core location of the protein.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        The distribution of LMBD1-GFP coincided with that of LAMP1, i.e. having
+        neither ER nor peroxisomal marker proteins (Fig. 1C), indicating that
+        LMBD1-GFP is localized in lysosomes.
+- term:
+    id: GO:0061462
+    label: protein localization to lysosome
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) assignment that LMBD1 is involved in protein
+      localization to the lysosome. This reflects the verified escort role of
+      LMBD1 in targeting the ABCD4 transporter from the ER to the lysosome.
+    action: ACCEPT
+    reason: &gt;-
+      LMBD1 is required to translocate ABCD4 from the ER to the lysosome and to
+      retain it there; loss of LMBD1 disrupts ABCD4 lysosomal localization
+      (PMID:27456980, PMID:28572511). This is a core molecular role of LMBD1
+      and is well captured by protein localization to lysosome.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        our results support the view that the translocation of ABCD4 from the
+        ER to lysosomes requires, at least in part, the lysosomal membrane
+        protein LMBD1.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      UniProt SubCellular-location (SL-0157, Lysosome membrane) IEA mapping to
+      lysosomal membrane. Redundant with, and confirmed by, the experimental
+      annotations.
+    action: ACCEPT
+    reason: &gt;-
+      Correct location, well supported experimentally (see EXP/IDA entries).
+    supported_by:
+    - reference_id: file:human/LMBRD1/LMBRD1-uniprot.txt
+      supporting_text: &#34;Lysosome membrane&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      UniProt SubCellular-location (SL-0097) IEA mapping to ER membrane. LMBD1
+      is present transiently in the ER membrane, where it binds newly
+      synthesized ABCD4 before both traffic to the lysosome; this is a
+      biosynthetic/mechanistic location rather than the steady-state functional
+      compartment.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      ER-membrane localization is real (PMID:27456980 IDA) but represents the
+      early biosynthetic step of the LMBD1/ABCD4 escort pathway, not the core
+      lysosomal-membrane site of action. Keep as non-core.
+    supported_by:
+    - reference_id: file:human/LMBRD1/LMBRD1-uniprot.txt
+      supporting_text: &#34;Targets ABCD4 transporter from the&#34;
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Combined-methods IEA (with_from mouse ortholog Q8K0B2 SubCell SL-0039)
+      placing LMBD1 at the plasma membrane. A minor plasma-membrane pool is
+      reported in the mouse ortholog in the context of an insulin-receptor
+      endocytosis adaptor role; human direct evidence is lacking.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Only a small portion of LMBD1 is reported at the plasma membrane, and the
+      supporting evidence is by similarity to the mouse ortholog. The core
+      location is the lysosomal membrane. Keep as a non-core minor location.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        recently a small region of LMBD1 was shown to be located on plasma
+        membranes
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Interontology (IEA, from MF GO:0015420) inference that LMBD1 is involved
+      in cobalamin transport. LMBD1 is a subunit of the lysosomal cobalamin
+      export complex and its loss (cblF) blocks lysosomal cobalamin efflux, so
+      involvement in cobalamin transport is well supported at the process
+      level.
+    action: ACCEPT
+    reason: &gt;-
+      Cobalamin transport is the core biological process of LMBD1: loss of
+      LMBD1 causes lysosomal cobalamin accumulation (cblF), and LMBD1 is an
+      essential component of the LMBD1:ABCD4 lysosomal export complex
+      (PMID:19136951, PMID:27456980).
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        ABCD4 and LMBD1, encoded by ABCD4 and LMBRD1 respectively, were shown
+        to be involved in the export of cobalamin from lysosomes into the
+        cytosol
+- term:
+    id: GO:0030136
+    label: clathrin-coated vesicle
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Combined-methods IEA (with_from mouse ortholog Q8K0B2, SubCell SL-0070)
+      placing LMBD1 in clathrin-coated vesicles, tied to the by-similarity
+      insulin-receptor endocytosis adaptor role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This location relates to the secondary, by-similarity clathrin-mediated
+      endocytosis function (insulin receptor) rather than the core lysosomal
+      cobalamin role. Keep as non-core.
+    supported_by:
+    - reference_id: file:human/LMBRD1/LMBRD1-uniprot.txt
+      supporting_text: &#34;Cytoplasmic vesicle, clathrin-coated vesicle&#34;
+- term:
+    id: GO:0035461
+    label: vitamin transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Interontology (IEA, from MF GO:0090482) inference that LMBD1 is involved
+      in vitamin transmembrane transport. This is the more general parent of
+      the cobalamin (vitamin B12) transport process in which LMBD1 participates.
+    action: ACCEPT
+    reason: &gt;-
+      Correct but less specific than cobalamin transport. Cobalamin is a
+      vitamin (B12), so vitamin transmembrane transport is an accurate broader
+      process term for the LMBD1:ABCD4 export function.
+    supported_by:
+    - reference_id: PMID:28572511
+      supporting_text: &gt;-
+        The integral membrane proteins LMBD1 and ABCD4 are required for
+        lysosomal
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:27456980
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI protein binding annotation with_from ABCD4 (O14678), from the study
+      demonstrating the LMBD1-ABCD4 interaction and ABCD4 escort to lysosomes.
+      The interaction is real and functionally central, but &#34;protein binding&#34;
+      is uninformative as a molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The LMBD1-ABCD4 interaction is genuine and important (PMID:27456980), but
+      the bare GO:0005515 protein binding term does not convey the specific
+      escort/chaperone function. The functionally meaningful role is captured
+      by protein localization to lysosome (GO:0061462) and the cobalamin
+      transport process terms. Retain the interaction as evidence but treat the
+      generic MF as an over-annotation.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        These results show that ABCD4 is able to form a complex with LMBD1 in
+        cells.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28572511
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI protein binding annotation with_from ABCD4 (O14678), from the
+      FRET-based confirmation of the selective ABCD4-LMBD1 interaction and its
+      requirement for ABCD4 lysosomal targeting.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Genuine and important LMBD1-ABCD4 interaction (PMID:28572511), but the
+      generic protein binding MF is uninformative. The specific function is
+      better represented by protein localization to lysosome and cobalamin
+      transport.
+    supported_by:
+    - reference_id: PMID:28572511
+      supporting_text: &gt;-
+        we showed that ABCD4 lysosomal
+- term:
+    id: GO:0007369
+    label: gastrulation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara IEA transfer from the mouse ortholog (Q8K0B2) assigning
+      involvement in gastrulation, reflecting an early embryonic role reported
+      by similarity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      A developmental/gastrulation role is asserted only by similarity to the
+      mouse ortholog and is not part of the core, biochemically defined
+      lysosomal cobalamin function. Keep as non-core.
+    supported_by:
+    - reference_id: file:human/LMBRD1/LMBRD1-uniprot.txt
+      supporting_text: &gt;-
+        Essential for the initiation of gastrulation and early formation of
+        mesoderm structures during embryogenesis
+- term:
+    id: GO:0032050
+    label: clathrin heavy chain binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Ensembl-Compara IEA transfer from the mouse ortholog (Q8K0B2) assigning
+      clathrin heavy chain binding, part of the by-similarity insulin-receptor
+      clathrin-mediated endocytosis adaptor role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Related to the secondary, by-similarity endocytic-adaptor function rather
+      than the core lysosomal cobalamin role; human direct evidence is absent.
+      Keep as non-core.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        LMBD1 is reported to be a specific adaptor for the clathrin-mediated
+        endocytosis of the insulin receptor
+- term:
+    id: GO:0035612
+    label: AP-2 adaptor complex binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Ensembl-Compara IEA transfer from the mouse ortholog (Q8K0B2) assigning
+      AP-2 adaptor complex binding, consistent with the two putative AP-2
+      binding motifs (YERL and WTKF) noted in UniProt.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Part of the by-similarity clathrin/AP-2 endocytic-adaptor role for the
+      insulin receptor rather than the core cobalamin function. Keep as
+      non-core.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        LMBD1 possesses two putative AP-2 binding motifs
+- term:
+    id: GO:0038016
+    label: insulin receptor internalization
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara IEA transfer from the mouse ortholog (Q8K0B2) assigning
+      involvement in insulin receptor internalization, the endpoint of the
+      by-similarity clathrin-mediated endocytosis adaptor role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Secondary, by-similarity role (adaptor for INSR endocytosis); not the
+      core lysosomal cobalamin function. Keep as non-core.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        LMBD1 is reported to be a specific adaptor for the clathrin-mediated
+        endocytosis of the insulin receptor
+- term:
+    id: GO:0072583
+    label: clathrin-dependent endocytosis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Ensembl-Compara IEA transfer from the mouse ortholog (Q8K0B2) assigning
+      involvement in clathrin-dependent endocytosis (the INSR adaptor role).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Secondary, by-similarity endocytic role; not the core cobalamin function.
+      Keep as non-core.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        LMBD1 is reported to be a specific adaptor for the clathrin-mediated
+        endocytosis of the insulin receptor
+- term:
+    id: GO:0015420
+    label: ABC-type vitamin B12 transporter activity
+  evidence_type: IDA
+  original_reference_id: PMID:33845046
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IDA (via MGI) assigning ABC-type vitamin B12 transporter activity to
+      LMBD1, from the liposome reconstitution study. However, that very study
+      showed the transporter activity resides in ABCD4 and that LMBD1 by itself
+      has no cobalamin transport (or ATPase) activity, so this MF is
+      mis-attributed to LMBD1 as an enabler.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      PMID:33845046 demonstrated that ABCD4 alone transports cobalamin in an
+      ATP-dependent manner and that LMBD1 exhibited no cobalamin transport
+      activity; LMBD1 lacks nucleotide-binding domains and is not an ABC
+      transporter. LMBD1 is a subunit/escort of the transporting complex, so
+      ABC-type vitamin B12 transporter activity should not be annotated as a
+      function LMBD1 enables. Not removed because LMBD1 is a genuine component
+      of the cobalamin-transporting LMBD1:ABCD4 complex; the activity is better
+      attributed to ABCD4 (or the complex).
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: &gt;-
+        no cobalamin transport activity. These results suggest that ABCD4 may
+        be capable
+    - reference_id: PMID:33845046
+      supporting_text: &gt;-
+        LMBD1 itself had neither ATPase nor cobalamin transport activities
+- term:
+    id: GO:0090482
+    label: vitamin transmembrane transporter activity
+  evidence_type: IDA
+  original_reference_id: PMID:27456980
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IDA (via MGI) assigning vitamin transmembrane transporter activity to
+      LMBD1, citing the ABCD4-escort paper. That paper does not demonstrate
+      LMBD1-intrinsic transporter activity; it shows LMBD1 escorts ABCD4 to
+      lysosomes. The intrinsic transporter activity is ABCD4&#39;s (PMID:33845046).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      No study demonstrates that LMBD1 itself is a transmembrane transporter;
+      the direct in vitro test (PMID:33845046) found LMBD1 has no cobalamin
+      transport activity. LMBD1 participates in transport as an escort/subunit
+      of the LMBD1:ABCD4 complex, so an enabled transmembrane transporter MF is
+      an over-annotation. Retained rather than removed because LMBD1 is part of
+      the transporting complex.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: &gt;-
+        LMBD1 itself had neither ATPase nor cobalamin transport activities
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: EXP
+  original_reference_id: PMID:19136951
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental (EXP) lysosomal membrane localization from the founding cblF
+      study that identified LMBD1 as a lysosomal membrane protein.
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental support that LMBD1 is a lysosomal membrane protein;
+      core location.
+    supported_by:
+    - reference_id: PMID:19136951
+      supporting_text: &gt;-
+        LMBRD1, encoding LMBD1, a lysosomal membrane protein with homology to
+        lipocalin membrane receptor LIMR
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: EXP
+  original_reference_id: PMID:28572511
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental (EXP) lysosomal membrane localization from the FRET-based
+      ABCD4-LMBD1 interaction study.
+    action: ACCEPT
+    reason: &gt;-
+      Core location confirmed experimentally; LMBD1 is an integral lysosomal
+      membrane protein required for lysosomal cobalamin release.
+    supported_by:
+    - reference_id: PMID:28572511
+      supporting_text: &gt;-
+        The integral membrane proteins LMBD1 and ABCD4 are required for
+        lysosomal
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: EXP
+  original_reference_id: PMID:33845046
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental (EXP) lysosomal membrane localization from the liposome
+      reconstitution study, which describes LMBD1 as the lysosomal membrane
+      protein that complexes with ABCD4.
+    action: ACCEPT
+    reason: &gt;-
+      Core lysosomal-membrane location, consistent across all functional
+      studies.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: &gt;-
+        The ABCD4 dimer then forms a complex with lysosomal membrane protein
+        LMBD1, and this complex is translocated from the ER to lysosomes
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ISS transfer from the mouse ortholog (Q8K0B2) placing LMBD1 at the plasma
+      membrane, reflecting the reported minor plasma-membrane pool linked to
+      the INSR endocytosis adaptor role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Minor location supported only by similarity; core location is the
+      lysosomal membrane. Keep as non-core.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        recently a small region of LMBD1 was shown to be located on plasma
+        membranes
+- term:
+    id: GO:0090482
+    label: vitamin transmembrane transporter activity
+  evidence_type: IDA
+  original_reference_id: PMID:27456980
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Duplicate IDA (via MGI, older date) assigning vitamin transmembrane
+      transporter activity to LMBD1 from the ABCD4-escort paper; same
+      over-annotation issue as the other GO:0090482 entry.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      LMBD1 has no demonstrated intrinsic transporter activity (PMID:33845046);
+      it escorts and complexes with ABCD4, which is the catalytic transporter.
+      Over-annotation, not removed because LMBD1 is a subunit of the
+      transporting complex.
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: &gt;-
+        LMBD1 itself had neither ATPase nor cobalamin transport activities
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33845046
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI protein binding annotation with_from ABCD4 (O14678), from the in
+      vitro pull-down/crosslinking showing purified LMBD1 and ABCD4 interact
+      with 1:1 stoichiometry.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Real and specific LMBD1-ABCD4 interaction, but the bare protein binding
+      MF is uninformative. The functionally meaningful roles are protein
+      localization to lysosome and cobalamin transport (as complex subunit).
+    supported_by:
+    - reference_id: PMID:33845046
+      supporting_text: &gt;-
+        These results indicate that purified ABCD4 and LMBD1 interact each
+        other with a 1:1 stoichiometry.
+- term:
+    id: GO:0038016
+    label: insulin receptor internalization
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ISS transfer from the mouse ortholog (Q8K0B2) assigning involvement in
+      insulin receptor internalization (the by-similarity endocytic adaptor
+      role).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Secondary, by-similarity function; not the core lysosomal cobalamin role.
+      Keep as non-core.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        LMBD1 is reported to be a specific adaptor for the clathrin-mediated
+        endocytosis of the insulin receptor
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ISS transfer from the mouse ortholog (Q8K0B2) with part_of qualifier
+      placing LMBD1 at the plasma membrane; a minor location tied to the
+      by-similarity INSR endocytosis role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Minor, by-similarity plasma-membrane location; core location is the
+      lysosomal membrane. Keep as non-core.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        recently a small region of LMBD1 was shown to be located on plasma
+        membranes
+- term:
+    id: GO:0007369
+    label: gastrulation
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ISS transfer from the mouse ortholog (Q8K0B2) assigning involvement in
+      gastrulation, an early embryonic role asserted by similarity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Developmental role supported only by similarity to the mouse ortholog;
+      not part of the core cobalamin function. Keep as non-core.
+    supported_by:
+    - reference_id: file:human/LMBRD1/LMBRD1-uniprot.txt
+      supporting_text: &gt;-
+        Essential for the initiation of gastrulation and early formation of
+        mesoderm structures during embryogenesis
+- term:
+    id: GO:0030136
+    label: clathrin-coated vesicle
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ISS transfer from the mouse ortholog (Q8K0B2) placing LMBD1 in
+      clathrin-coated vesicles, tied to the by-similarity INSR endocytosis
+      adaptor role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Related to the secondary endocytic-adaptor function, by similarity; not
+      the core lysosomal cobalamin role. Keep as non-core.
+    supported_by:
+    - reference_id: file:human/LMBRD1/LMBRD1-uniprot.txt
+      supporting_text: &#34;Cytoplasmic vesicle, clathrin-coated vesicle&#34;
+- term:
+    id: GO:0032050
+    label: clathrin heavy chain binding
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ISS transfer from the mouse ortholog (Q8K0B2) assigning clathrin heavy
+      chain binding (by-similarity INSR endocytic adaptor role).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Secondary, by-similarity endocytic-adaptor function; not the core
+      cobalamin role. Keep as non-core.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        LMBD1 is reported to be a specific adaptor for the clathrin-mediated
+        endocytosis of the insulin receptor
+- term:
+    id: GO:0035612
+    label: AP-2 adaptor complex binding
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ISS transfer from the mouse ortholog (Q8K0B2) assigning AP-2 adaptor
+      complex binding, consistent with the YERL/WTKF AP-2 binding motifs.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Part of the by-similarity clathrin/AP-2 endocytic-adaptor role; not the
+      core cobalamin function. Keep as non-core.
+    supported_by:
+    - reference_id: file:human/LMBRD1/LMBRD1-uniprot.txt
+      supporting_text: &gt;-
+        YERL motif; mediates interaction with adapter
+- term:
+    id: GO:0045334
+    label: clathrin-coated endocytic vesicle
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ISS transfer from the mouse ortholog (Q8K0B2) placing LMBD1 in
+      clathrin-coated endocytic vesicles, tied to the by-similarity INSR
+      endocytosis adaptor role.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Related to the secondary endocytic-adaptor function, by similarity; not
+      the core lysosomal cobalamin role. Keep as non-core.
+    supported_by:
+    - reference_id: file:human/LMBRD1/LMBRD1-uniprot.txt
+      supporting_text: &#34;Cytoplasmic vesicle, clathrin-coated vesicle&#34;
+- term:
+    id: GO:0072583
+    label: clathrin-dependent endocytosis
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ISS transfer from the mouse ortholog (Q8K0B2) assigning involvement in
+      clathrin-dependent endocytosis (INSR adaptor role).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Secondary, by-similarity endocytic role; not the core cobalamin function.
+      Keep as non-core.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        LMBD1 is reported to be a specific adaptor for the clathrin-mediated
+        endocytosis of the insulin receptor
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:27456980
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct (IDA) ER-membrane localization from the ABCD4-escort study;
+      LMBD1 binds newly synthesized ABCD4 in the ER before both traffic to the
+      lysosome.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      ER localization is genuine but is the transient biosynthetic step of the
+      escort pathway, not the steady-state functional compartment (the
+      lysosomal membrane). Keep as non-core.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        This suggests that LMBD1 associates with ABCD4 at the ER membrane and
+        transports ABCD4 to lysosomes.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: IDA
+  original_reference_id: PMID:27456980
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct (IDA) lysosomal membrane localization from the ABCD4-escort study
+      (LMBD1-GFP colocalizes with LAMP1). Core location.
+    action: ACCEPT
+    reason: &gt;-
+      Strong direct experimental evidence for the core lysosomal membrane
+      location.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        indicating that LMBD1-GFP is localized in lysosomes
+- term:
+    id: GO:0061462
+    label: protein localization to lysosome
+  evidence_type: IDA
+  original_reference_id: PMID:27456980
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct (IDA) evidence that LMBD1 is involved in protein localization to
+      the lysosome, specifically escorting ABCD4 from the ER to the lysosome.
+      This is a core, experimentally verified molecular role of LMBD1.
+    action: ACCEPT
+    reason: &gt;-
+      LMBD1 is required to translocate and retain ABCD4 at the lysosomal
+      membrane; mislocalized LMBD1 mutants fail to bring ABCD4 to lysosomes
+      (PMID:27456980). Core function.
+    supported_by:
+    - reference_id: PMID:27456980
+      supporting_text: &gt;-
+        our results support the view that the translocation of ABCD4 from the
+        ER to lysosomes requires, at least in part, the lysosomal membrane
+        protein LMBD1.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25535791
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI protein binding annotations from the SPR study, with_from ABCD4
+      (O14678) and MMACHC (Q9Y4U1). LMBD1 binds both ABCD4 and the cytosolic
+      cobalamin-processing protein MMACHC with low-nanomolar affinity, forming
+      the complex that vectorially delivers lysosomal cobalamin to MMACHC. Real
+      and functionally central interactions, but bare protein binding is
+      uninformative as an MF. (The GOA has two lines for this PMID, one per
+      partner; both are represented by this entry.)
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The LMBD1-ABCD4 and LMBD1-MMACHC interactions are genuine and important
+      (PMID:25535791), but the generic GO:0005515 term does not capture the
+      escort/hand-off function; that is better represented by protein
+      localization to lysosome and the cobalamin transport process. Retain the
+      interactions as evidence.
+    supported_by:
+    - reference_id: PMID:25535791
+      supporting_text: &gt;-
+        MMACHC also interacts with LMBD1 and ABCD4 with low nanomolar affinity.
+    - reference_id: PMID:25535791
+      supporting_text: &gt;-
+        membrane-bound LMBD1 and ABCD4 facilitate the vectorial delivery of
+        lysosomal vitamin B(12) to cytoplasmic
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput (HDA) membrane-proteome identification of LMBD1 in an NK
+      cell line, supporting a generic membrane localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      GO:0016020 membrane is a high-level, uninformative location from a
+      proteomic membrane-fractionation screen; it is subsumed by the specific,
+      experimentally supported lysosomal membrane annotation. Not wrong, but
+      over-general.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: &gt;-
+        Mass spectrometric analysis identified 1843 proteins with high
+        confidence scores.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5223313
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS lysosomal membrane localization from the ABCD4:LMBRD1
+      cobalamin export reaction (gut mucosal cells). Consistent with the core
+      location.
+    action: ACCEPT
+    reason: &gt;-
+      Curated pathway annotation consistent with all experimental evidence for
+      lysosomal membrane localization.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5223313
+      supporting_text: &gt;-
+        LMBRD1 stabilizes ABCD4 in the lysosomal membrane
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5683325
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS lysosomal membrane localization from the defective
+      ABCD4:LMBRD1 cobalamin transport reaction. Consistent with the core
+      location.
+    action: ACCEPT
+    reason: &gt;-
+      Curated pathway annotation consistent with the experimentally established
+      lysosomal membrane location.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683325
+      supporting_text: &gt;-
+        ATP-binding cassette sub-family D member 4 (ABCD4) is thought to
+        mediate the lysosomal export of cobalamin
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9759206
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS lysosomal membrane localization from the ABCD4:LMBRD1
+      cobalamin export reaction (cells throughout the body). Consistent with
+      the core location.
+    action: ACCEPT
+    reason: &gt;-
+      Curated pathway annotation consistent with the experimentally established
+      lysosomal membrane location.
+    supported_by:
+    - reference_id: Reactome:R-HSA-9759206
+      supporting_text: &gt;-
+        LMBRD1 stabilizes ABCD4 in the lysosomal membrane
+core_functions:
+- description: &gt;-
+    Lysosomal-membrane escort/chaperone that targets and stabilizes the ABC
+    transporter ABCD4 at the lysosomal membrane (translocating it from the ER),
+    thereby enabling assembly of the lysosomal cobalamin export machinery.
+  directly_involved_in:
+  - id: GO:0061462
+    label: protein localization to lysosome
+  locations:
+  - id: GO:0005765
+    label: lysosomal membrane
+  supported_by:
+  - reference_id: PMID:27456980
+    supporting_text: &gt;-
+      our results support the view that the translocation of ABCD4 from the ER
+      to lysosomes requires, at least in part, the lysosomal membrane protein
+      LMBD1.
+  - reference_id: PMID:28572511
+    supporting_text: &gt;-
+      we showed that ABCD4 lysosomal
+- description: &gt;-
+    As a subunit of the lysosomal LMBD1:ABCD4 complex (handing off to cytosolic
+    MMACHC), participates in the export of cobalamin (vitamin B12) from the
+    lysosomal lumen to the cytosol. LMBD1 has no intrinsic transport activity;
+    the catalytic transport is performed by ABCD4. Loss of LMBD1 causes
+    lysosomal cobalamin accumulation (cblF).
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0005765
+    label: lysosomal membrane
+  supported_by:
+  - reference_id: PMID:19136951
+    supporting_text: &gt;-
+      In the cblF inborn error of vitamin B(12)
+  - reference_id: PMID:25535791
+    supporting_text: &gt;-
+      membrane-bound LMBD1 and ABCD4 facilitate the vectorial delivery of
+      lysosomal vitamin B(12) to cytoplasmic
+  - reference_id: PMID:33845046
+    supporting_text: &gt;-
+      LMBD1 itself had neither ATPase nor cobalamin transport activities
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000108
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+    links
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:19136951
+  title: Identification of a putative lysosomal cobalamin exporter altered in the
+    cblF defect of vitamin B12 metabolism.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Founding cblF study; identified LMBRD1/LMBD1 as the lysosomal membrane
+      protein whose loss causes lysosomal cobalamin accumulation. Establishes
+      the core disease/localization link.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput NK-cell membrane proteome; source of the generic
+      GO:0016020 membrane HDA. Background-only for LMBRD1 function.
+- id: PMID:25535791
+  title: &#39;Purification and interaction analyses of two human lysosomal vitamin B12
+    transporters: LMBD1 and ABCD4.&#39;
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      SPR/biophysical study showing LMBD1 and ABCD4 (and MMACHC) interact with
+      low-nanomolar affinity and proposing vectorial hand-off of lysosomal B12
+      to cytosolic MMACHC. Source of the LMBD1-ABCD4 and LMBD1-MMACHC IPIs.
+- id: PMID:27456980
+  title: Translocation of the ABC transporter ABCD4 from the endoplasmic reticulum
+    to lysosomes requires the escort protein LMBD1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Key mechanistic paper: LMBD1 escorts ABCD4 from the ER to the lysosome;
+      LMBRD1 knockout mislocalizes ABCD4. Establishes the
+      protein-localization-to-lysosome core function.
+- id: PMID:28572511
+  title: Clinical or ATPase domain mutations in ABCD4 disrupt the interaction between
+    the vitamin B(12)-trafficking proteins ABCD4 and LMBD1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Live-cell FRET confirmation of the selective ABCD4-LMBD1 interaction and
+      that ABCD4 lysosomal targeting depends on LMBD1.
+- id: PMID:33845046
+  title: The lysosomal protein ABCD4 can transport vitamin B(12) across liposomal
+    membranes in vitro.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      In vitro reconstitution showing ABCD4 alone transports cobalamin
+      (ATP-dependent) and LMBD1 has no cobalamin transport or ATPase activity.
+      Directly informs the over-annotation of transporter MF terms to LMBD1.
+- id: Reactome:R-HSA-5223313
+  title: ABCD4:LMBRD1 transports RCbl from lysosomal lumen to cytosol (gut mucosal
+    cells)
+  findings: []
+- id: Reactome:R-HSA-5683325
+  title: Defective ABCD4:LMBRD1 does not transport Cbl from lysosomal lumen to cytosol
+  findings: []
+- id: Reactome:R-HSA-9759206
+  title: ABCD4:LMBRD1 transports RCbl from lysosomal lumen to cytosol
+  findings: []
+- id: file:human/LMBRD1/LMBRD1-uniprot.txt
+  title: UniProtKB entry Q9NUN5 (LMBD1_HUMAN)
+  findings: []
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Given that LMBD1 has no intrinsic cobalamin transport or ATPase activity and
+    ABCD4 alone suffices in vitro, is the correct molecular-function
+    representation of LMBD1 a transporter-complex subunit / chaperone rather than
+    an enabler of transporter activity, and should GO capture the LMBD1:ABCD4
+    (:MMACHC) complex explicitly?
+suggested_experiments:
+- description: &gt;-
+    Cryo-EM or crystal structure of the lysosomal LMBD1:ABCD4 complex (with and
+    without MMACHC) to define the LMBD1 interaction surface and the cobalamin
+    hand-off path from the lysosomal lumen to cytosolic MMACHC.
+- description: &gt;-
+    Reconstitution of the LMBD1:ABCD4:MMACHC assembly to test whether LMBD1
+    modulates the rate, directionality, or MMACHC-coupling of ABCD4-mediated
+    cobalamin efflux beyond its established role in ABCD4 lysosomal targeting.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/MMADHC/MMADHC-ai-review.html
+++ b/genes/human/MMADHC/MMADHC-ai-review.html
@@ -1,0 +1,4540 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MMADHC - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MMADHC</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9H3L0" target="_blank" class="term-link">
+                        Q9H3L0
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MMADHC";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9H3L0" data-a="DESCRIPTION: MMADHC (cobalamin trafficking protein CblD; the cb..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MMADHC (cobalamin trafficking protein CblD; the cblD complementation group) is a cobalamin (vitamin B12)-trafficking branch-point/adaptor protein. It acts downstream of MMACHC (cblC) in the cytosol, where it physically associates with MMACHC and, together with methionine synthase (MTR) and methionine synthase reductase (MTRR), directs the common cob(II)alamin intermediate into one of two coenzyme-synthesis branches: the mitochondrial adenosylcobalamin (AdoCbl) branch that supplies methylmalonyl-CoA mutase (MMUT), or the cytosolic methylcobalamin (MeCbl) branch that supplies methionine synthase (MTR). MMADHC is not an enzyme; its C-terminal domain adopts a nitro-FMN-reductase-like fold and provides a cysteine (Cys261) thiolate ligand to cob(II)alamin bound to MMACHC. The protein has both cytosolic and mitochondrial pools and carries a predicted N-terminal mitochondrial transit peptide. Distinct mutation positions determine which branch fails, producing three biochemical phenotypes: isolated methylmalonic aciduria (cblD-variant 2), isolated homocystinuria (cblD-variant 1), or combined methylmalonic aciduria and homocystinuria.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred mitochondrial localization. MMADHC has a predicted N-terminal mitochondrial transit peptide and a documented mitochondrial pool in addition to its cytosolic pool, consistent with its role in routing cobalamin toward the mitochondrial AdoCbl branch.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mitochondrial localization is supported experimentally (IDA/HTP) and by the UniProt transit peptide annotation, so the IBA localization is biologically correct. However, the functionally decisive branch-point/adaptor activity occurs in the cytosol (downstream of MMACHC, in complex with MMACHC/MTR/MTRR); the mitochondrial pool is a secondary compartment, hence retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MMADHC/MMADHC-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm {ECO:0000269|PubMed:23270877}.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0009235" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred involvement in cobalamin metabolism. This is the central, well-supported biological process for MMADHC: it acts as a branch point directing cobalamin into the AdoCbl (mitochondrial) and MeCbl (cytosolic) coenzyme pathways.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strongly corroborated by multiple experimental studies establishing MMADHC as a cobalamin-trafficking branch-point protein downstream of MMACHC. Represents a core biological process for this gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link">
+                                        PMID:22156578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">supporting the role of cblD protein as a branch point in</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC acts as a branch point for vitamin B(12) delivery to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140104" target="_blank" class="term-link">
+                                    GO:0140104
+                                </a>
+                            </span>
+                            <span class="term-label">molecular carrier activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0140104" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred molecular carrier activity. MMADHC is a non-enzymatic cobalamin-trafficking adaptor that receives/hands off the cobalamin cofactor (partitioning it between the MeCbl and AdoCbl branches) rather than catalyzing a chemical reaction. Molecular carrier activity captures this carrier/adaptor role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the multiple independent IDA/EXP/TAS annotations to the same term and with the biochemical evidence that MMADHC functions as an adaptor controlling intracellular cobalamin partitioning rather than as an enzyme. This is the best available molecular-function term for a non-catalytic cofactor-trafficking protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23415655" target="_blank" class="term-link">
+                                        PMID:23415655
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an adapter function for CblD</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link">
+                                        PMID:22156578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">supporting the role of cblD protein as a branch point in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt SubCell mapping) annotation to cytoplasm. Consistent with the documented cytoplasmic pool of MMADHC, where its branch-point/adaptor activity occurs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general; the more specific experimentally supported cytosol term (GO:0005829) is also annotated. Accept as a valid, if broad, localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MMADHC/MMADHC-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm {ECO:0000269|PubMed:23270877}.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt SubCell mapping) annotation to mitochondrion, matching the predicted N-terminal mitochondrial transit peptide and the experimentally observed mitochondrial pool.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Mitochondrial localization is real and supported (transit peptide; IDA; HTP), but secondary to the cytosolic branch-point activity, so kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0009235" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO electronic annotation (IPR019362, the MMADHC family) to cobalamin metabolic process. The InterPro family is specific to this cobalamin-trafficking protein, so the mapping is accurate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct biological process, redundant with the well-supported IBA/IDA annotations to the same term. Represents a core process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link">
+                                        PMID:22156578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">supporting the role of cblD protein as a branch point in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare protein binding from a large-scale binary interactome map (HuRI), with high-throughput yeast two-hybrid interactors (CREB5, POU4F2, TBC1D7, CINP) that are not part of the established cobalamin-trafficking machinery and are of unclear biological relevance to MMADHC function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidance, bare &#34;protein binding&#34; is uninformative and this comes from a genome-scale two-hybrid screen whose hits are not the biologically meaningful partners (MMACHC, MTR, MTRR). Not removed (experimental IPI), but marked as over-annotated; the informative partners are captured by the molecular carrier activity and cobalamin metabolic process terms.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we present a human &#39;all-by-all&#39; reference interactome map of human binary protein interactions, or &#39;HuRI&#39;.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9759218
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0009235" data-r="Reactome:R-HSA-9759218" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome pathway annotation (Cobalamin metabolism) placing MMADHC in cobalamin metabolic process. Consistent with all other evidence for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Traceable author statement from Reactome for a core biological process; concordant with the IBA/IDA/IEA annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC acts as a branch point for vitamin B(12) delivery to</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005739" data-r="PMID:34800366" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput detection of MMADHC in a high-confidence human mitochondrial proteome, corroborating the mitochondrial pool identified by immunofluorescence/fractionation and the predicted mitochondrial transit peptide.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Confirms mitochondrial localization but this compartment is secondary to the cytosolic branch-point activity; kept as non-core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                                        PMID:34800366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">high-confidence human mitochondrial proteome</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140104" target="_blank" class="term-link">
+                                    GO:0140104
+                                </a>
+                            </span>
+                            <span class="term-label">molecular carrier activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3149563
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0140104" data-r="Reactome:R-HSA-3149563" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation (MMADHC targets transport of cytosolic cob(II)alamin to mitochondria) to molecular carrier activity, capturing MMADHC&#39;s cobalamin carrier/routing role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the branch-point/adaptor function; molecular carrier activity is the appropriate non-enzymatic MF term. Redundant with the IBA/IDA/EXP annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23415655" target="_blank" class="term-link">
+                                        PMID:23415655
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an adapter function for CblD</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140104" target="_blank" class="term-link">
+                                    GO:0140104
+                                </a>
+                            </span>
+                            <span class="term-label">molecular carrier activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21071249" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21071249
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interaction between MMACHC and MMADHC, two human proteins pa...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0140104" data-r="PMID:21071249" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental support (via Reactome) for cobalamin carrier/adaptor activity, based on the demonstrated direct interaction of MMADHC with MMACHC, the partner that hands off the cobalamin cofactor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The MMACHC-MMADHC interaction underpins MMADHC&#39;s role as a downstream cobalamin carrier/adaptor; molecular carrier activity is the correct MF term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21071249" target="_blank" class="term-link">
+                                        PMID:21071249
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC was confirmed as a binding</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23270877
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subcellular location of MMACHC and MMADHC, two human protein...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005829" data-r="PMID:23270877" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (immunofluorescence and subcellular fractionation) localization of MMADHC to the cytosol, the compartment where it acts downstream of MMACHC as a cobalamin branch point.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported specific cytosolic localization; this is the primary site of MMADHC&#39;s branch-point/adaptor activity and is retained as a core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22156578
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular mechanisms leading to three different phenotypes i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0009235" data-r="PMID:22156578" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (complementation of cblD patient fibroblasts; mutation position correlating with biochemical phenotype) that MMADHC acts within cobalamin metabolism as a branch point balancing cytosolic MeCbl and mitochondrial AdoCbl synthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, directly demonstrated. The acts_upstream_of_or_within qualifier reflects the regulatory branch-point role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link">
+                                        PMID:22156578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">supporting the role of cblD protein as a branch point in</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link">
+                                        PMID:22156578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">correlate with the biochemical phenotype</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140104" target="_blank" class="term-link">
+                                    GO:0140104
+                                </a>
+                            </span>
+                            <span class="term-label">molecular carrier activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22156578
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular mechanisms leading to three different phenotypes i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0140104" data-r="PMID:22156578" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental support for MMADHC&#39;s cobalamin carrier/branch-point activity: a single protein with two functional domains that partition cobalamin between the cytosolic MeCbl and mitochondrial AdoCbl routes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Molecular carrier activity is the appropriate non-enzymatic MF term for this cofactor-partitioning adaptor; directly supported by the phenotype/rescue data.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link">
+                                        PMID:22156578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">supporting the role of cblD protein as a branch point in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140104" target="_blank" class="term-link">
+                                    GO:0140104
+                                </a>
+                            </span>
+                            <span class="term-label">molecular carrier activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32871076" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32871076
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An Interprotein Co-S Coordination Complex in the B(12)-Traff...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0140104" data-r="PMID:32871076" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that CblD/MMADHC provides a Cys261 thiolate ligand to cob(II)alamin bound to CblC/MMACHC, forming an interprotein Co-S coordination complex used for cofactor translocation in the trafficking pathway - a molecular carrier/handoff activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Biochemical/structural demonstration of direct cobalamin coordination by MMADHC in the trafficking pathway strongly supports molecular carrier activity as its MF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32871076" target="_blank" class="term-link">
+                                        PMID:32871076
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CblD provides a sulfur ligand to cob(II)alamin bound to CblC</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32871076" target="_blank" class="term-link">
+                                        PMID:32871076
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cys-261 on CblD as the sulfur donor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23270877
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subcellular location of MMACHC and MMADHC, two human protein...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005829" data-r="PMID:23270877" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that MMADHC is active in the cytosol, where it functions downstream of MMACHC as the cobalamin branch point (and in complex with MMACHC, MTR and MTRR).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytosol is the primary site of MMADHC&#39;s branch-point/adaptor activity; the is_active_in qualifier is appropriate and this is a core location for the molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22156578
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular mechanisms leading to three different phenotypes i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0009235" data-r="PMID:22156578" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental involvement in cobalamin metabolic process (branch-point control of MeCbl/AdoCbl synthesis), demonstrated by expression/complementation of cblD patient fibroblasts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, directly supported; duplicates the acts_upstream_of_or_within annotation from the same paper with an involved_in qualifier, both valid.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link">
+                                        PMID:22156578
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">supporting the role of cblD protein as a branch point in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27771510" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27771510
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Methionine synthase and methionine synthase reductase intera...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005515" data-r="PMID:27771510" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding annotation from co-IP/proximity-ligation demonstrating MMADHC interactions with methionine synthase (MTR/Q99707), methionine synthase reductase (MTRR/Q9UBK8) and MMACHC (Q9Y4U1) as part of a cytosolic multiprotein cobalamin-handling complex. These are biologically meaningful partners, but the term itself is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; does not convey function; the meaningful interactions (MMACHC/MTR/MTRR) reflect the cytosolic cobalamin-carrier complex and are captured by the molecular carrier activity MF and cobalamin metabolic process BP terms. Experimental IPI, so not removed, but marked over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27771510" target="_blank" class="term-link">
+                                        PMID:27771510
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">processing of Cbl in cytoplasm occurs in a multiprotein complex composed of at least MS, MSR, MMACHC and MMADHC</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23415655" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23415655
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The C-terminal domain of CblD interacts with CblC and influe...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005515" data-r="PMID:23415655" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding annotation for the MMADHC (CblD)-MMACHC (CblC, Q9Y4U1) interaction, shown biochemically to isolate a CblC-CblD complex that partitions cobalamin between the AdoCbl and MeCbl assimilation pathways.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The MMACHC interaction is central to MMADHC biology, but &#34;protein binding&#34; is uninformative; the functional consequence (adaptor/branch-point cobalamin carrier) is captured by molecular carrier activity and cobalamin metabolic process. Experimental IPI, not removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23415655" target="_blank" class="term-link">
+                                        PMID:23415655
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an adapter function for CblD</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23415655" target="_blank" class="term-link">
+                                        PMID:23415655
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">functions downstream of CblC in the cofactor assimilation pathway</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23270877
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subcellular location of MMACHC and MMADHC, two human protein...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005737" data-r="PMID:23270877" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental cytoplasmic localization of MMADHC (immunofluorescence/subcellular fractionation), consistent with its cytosolic branch-point activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but more general than the concurrently annotated cytosol (GO:0005829) term. Accept as valid localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23270877
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subcellular location of MMACHC and MMADHC, two human protein...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005739" data-r="PMID:23270877" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that MMADHC has a mitochondrial pool in addition to its cytoplasmic pool, consistent with its role in routing cobalamin toward the mitochondrial AdoCbl branch and with its predicted mitochondrial transit peptide.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genuine mitochondrial localization, but the decisive branch-point/adaptor activity is cytosolic; retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                    GO:0009235
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24722857" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24722857
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Characterization of functional domains of the cblD (MMADHC) ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0009235" data-r="PMID:24722857" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental involvement in cobalamin metabolism, from domain-mapping/rescue experiments showing that specific MMADHC regions differentially regulate AdoCbl and MeCbl synthesis (mapping to the three cblD phenotypes).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, directly demonstrated by functional-domain characterization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24722857" target="_blank" class="term-link">
+                                        PMID:24722857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">specific regions of MMADHC are</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24722857" target="_blank" class="term-link">
+                                        PMID:24722857
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">must be converted into two coenzyme</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3318571
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005829" data-r="Reactome:R-HSA-3318571" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation localizing MMADHC to the cytosol, consistent with the experimental cytosolic localization and its cytosolic branch-point function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with the IDA cytosol annotation; retained as a core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3149494
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005829" data-r="Reactome:R-HSA-3149494" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation (MMACHC:cob(II)alamin binds MMADHC) localizing MMADHC to the cytosol, the compartment where it receives cobalamin from MMACHC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with experimental cytosol localization; retained as a core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3149563
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005829" data-r="Reactome:R-HSA-3149563" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation localizing MMADHC to the cytosol, matching the experimental cytosolic localization and function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with the IDA cytosol annotation; retained as a core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3204318
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3L0" data-a="GO:0005829" data-r="Reactome:R-HSA-3204318" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation (cob(II)alamin transferred from MMACHC:MMADHC:cob(II)alamin to MTRR:MTR) localizing MMADHC to the cytosol, consistent with its cytosolic cobalamin-handoff role within the MMACHC/MTR/MTRR complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Concordant with experimental cytosol localization; retained as a core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                        PMID:23270877
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MMADHC is both mitochondrial and cytoplasmic</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27771510" target="_blank" class="term-link">
+                                        PMID:27771510
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">processing of Cbl in cytoplasm occurs in a multiprotein complex composed of at least MS, MSR, MMACHC and MMADHC</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Cobalamin-trafficking branch-point/adaptor activity: acting downstream of MMACHC (cblC) in the cytosol, MMADHC receives the common cob(II)alamin intermediate and partitions it between the cytosolic methylcobalamin (MeCbl) branch supplying methionine synthase (MTR) and the mitochondrial adenosylcobalamin (AdoCbl) branch supplying methylmalonyl-CoA mutase (MMUT).</h3>
+                <span class="vote-buttons" data-g="Q9H3L0" data-a="FUNCTION: Cobalamin-trafficking branch-point/adaptor activit..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140104" target="_blank" class="term-link">
+                            molecular carrier activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009235" target="_blank" class="term-link">
+                                cobalamin metabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link">
+                                PMID:22156578
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">supporting the role of cblD protein as a branch point in</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23415655" target="_blank" class="term-link">
+                                PMID:23415655
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">an adapter function for CblD</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                                PMID:23270877
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">MMADHC acts as a branch point for vitamin B(12) delivery to</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/MMADHC/MMADHC-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q9H3L0 (MMAD_HUMAN), Cobalamin trafficking protein CblD</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21071249" target="_blank" class="term-link">
+                            PMID:21071249
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interaction between MMACHC and MMADHC, two human proteins participating in intracellular vitamin B₁₂ metabolism.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22156578" target="_blank" class="term-link">
+                            PMID:22156578
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular mechanisms leading to three different phenotypes in the cblD defect of intracellular cobalamin metabolism.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23270877" target="_blank" class="term-link">
+                            PMID:23270877
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Subcellular location of MMACHC and MMADHC, two human proteins central to intracellular vitamin B(12) metabolism.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23415655" target="_blank" class="term-link">
+                            PMID:23415655
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The C-terminal domain of CblD interacts with CblC and influences intracellular cobalamin partitioning.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24722857" target="_blank" class="term-link">
+                            PMID:24722857
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Characterization of functional domains of the cblD (MMADHC) gene product.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27771510" target="_blank" class="term-link">
+                            PMID:27771510
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Methionine synthase and methionine synthase reductase interact with MMACHC and with MMADHC.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32871076" target="_blank" class="term-link">
+                            PMID:32871076
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An Interprotein Co-S Coordination Complex in the B(12)-Trafficking Pathway.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9759218
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cobalamin (Cbl) metabolism</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3149494
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MMACHC:cob(II)alamin binds MMADHC</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3149563
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MMADHC targets transport of cytosolic cob(II)alamin to mitochondria</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3204318
+
+                    </span>
+                </div>
+
+                <div class="reference-title">cob(II)alamin is transferred from MMACHC:MMADHC:cob(II)alamin to MTRR:MTR</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3318571
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective MMADHC does not bind MMACHC:B12r</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What molecular signals determine the partitioning of MMADHC between its cytosolic and mitochondrial pools, and does mitochondrial import of MMADHC itself carry cobalamin?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9H3L0" data-a="Q: What molecular signals determine the partitioning ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the Cys261-mediated interprotein Co-S coordination with MMACHC-bound cob(II)alamin the general mechanism of cobalamin handoff, or only one of several transfer modes?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9H3L0" data-a="Q: Is the Cys261-mediated interprotein Co-S coordinat..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure/cryo-EM of the full cytosolic MMACHC-MMADHC-MTR-MTRR complex with bound cobalamin to define the cofactor-handoff geometry and the basis of MeCbl-versus-AdoCbl branch selection.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9H3L0" data-a="EXPERIMENT: Structure/cryo-EM of the full cytosolic MMACHC-MMA..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantitative flux measurements of MeCbl versus AdoCbl synthesis in cells expressing domain-swapped or transit-peptide-modified MMADHC variants to test how localization and domain boundaries set the branch point.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9H3L0" data-a="EXPERIMENT: Quantitative flux measurements of MeCbl versus Ado..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MMADHC-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9H3L0" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mmadhc-cobalamin-trafficking-protein-cbld-review-notes">MMADHC (Cobalamin trafficking protein CblD) — review notes</h1>
+<p>UniProt: Q9H3L0 (MMAD_HUMAN). Gene MMADHC (a.k.a. C2orf25, cblD). 296 aa, MW ~32.9 kDa.<br />
+Predicted N-terminal mitochondrial transit peptide (1..38, ECO:0000255); mature chain 39..296.<br />
+Structure solved for C-terminal domain (residues 108-296; PDB 5CUZ/5CV0/6X8Z) — a nitro-FMN<br />
+reductase-like fold [PMID:26364851, not cached: "molecular mimicry ... new subfamily of nitro-FMN reductases"].</p>
+<h2 id="core-biology-verified-from-cached-publications-uniprot">Core biology (verified from cached publications + UniProt)</h2>
+<p>MMADHC is the cblD-complementation-group protein and acts as a <strong>branch-point / adaptor in<br />
+intracellular cobalamin (vitamin B12) trafficking</strong>, functioning <strong>downstream of MMACHC (cblC)</strong><br />
+in the cytosol. It is NOT an enzyme (the "-DHC" refers to the disease methylmalonic aciduria and<br />
+homocystinuria, not a dehydrogenase).</p>
+<ul>
+<li>Branch point routing MeCbl vs AdoCbl:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22156578" title="supporting the role of cblD protein as a branch point in intracellular cobalamin trafficking">PMID:22156578</a>;<br />
+  "a single protein exists with two different functional domains that interact with either cytosolic or mitochondrial targets";<br />
+  sequence after Met116 sufficient for MeCbl (cytosolic MTR branch), sequence between Met62 and Met116 required for AdoCbl (mitochondrial MMUT branch).</li>
+<li>Downstream of MMACHC/CblC; controls partitioning between cytoplasmic (MeCbl/MTR) and mitochondrial (AdoCbl) routes:<br />
+  [PMID:23415655 "functions downstream of CblC in the cofactor assimilation pathway"; "an adapter function for CblD"].</li>
+<li>Directs B12 delivery to cytoplasm vs mitochondria — branch point:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23270877" title="MMADHC acts as a branch point for vitamin B(12) delivery to the cytoplasm and mitochondria">PMID:23270877</a>;<br />
+  "MMADHC is both mitochondrial and cytoplasmic".</li>
+<li>Domain / mutation mapping to three cblD phenotypes:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/24722857" title="specific regions of MMADHC are involved in differential regulation of AdoCbl and MeCbl synthesis">PMID:24722857</a>.<br />
+  Null N-terminal to Met116 → isolated MMA (cblD-MMA, AdoCbl deficiency, MACD MIM:620953);<br />
+  null across C-terminus (p.Y140-R250) → combined MMA/HC (MAHCD MIM:277410);<br />
+  missense in conserved C-terminal region (p.D246-L259) → isolated HC (cblD-HC/HMAD MIM:620952, MeCbl deficiency).</li>
+</ul>
+<h2 id="molecular-interactions">Molecular interactions</h2>
+<ul>
+<li>Physical heterodimer with MMACHC/CblC (SPR + bacterial two-hybrid):<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21071249" title="MMADHC was confirmed as a binding partner for MMACHC both in vitro (SPR) and in vivo (bacterial two-hybrid system)">PMID:21071249</a>.</li>
+<li>Multiprotein cytosolic complex with MMACHC, MTR (methionine synthase), MTRR (MSR):<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27771510" title="processing of Cbl in cytoplasm occurs in a multiprotein complex composed of at least MS, MSR, MMACHC and MMADHC">PMID:27771510</a>;<br />
+  novel interactions "MS with MMADHC".</li>
+<li>Interprotein Co-S coordination: CblD donates a Cys-261 thiolate ligand to cob(II)alamin bound to CblC:<br />
+  [PMID:32871076 "CblD provides a sulfur ligand to cob(II)alamin bound to CblC"; "Cys-261 on CblD as the sulfur donor"].<br />
+  (UniProt FUNCTION: "Promotes oxidation of cob(II)alamin bound to MMACHC", PMID:26364851.)</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>Cytosol (IDA): <a href="https://pubmed.ncbi.nlm.nih.gov/23270877">PMID:23270877</a>. Also mitochondrion (IDA + HTP mito proteome PMID:34800366; UniProt SUBCELLULAR LOCATION Cytoplasm + Mitochondrion).<br />
+  The cytosol is where the branch-point adaptor activity occurs (in complex with MMACHC/MTR/MTRR).</li>
+</ul>
+<h2 id="goa-molecular-function">GOA molecular function</h2>
+<p>GOA carries <strong>GO:0140104 molecular carrier activity</strong> (IBA + multiple IDA/EXP/TAS from Reactome &amp; primary<br />
+papers) as the F-aspect term — this is the "carries/hands-off cobalamin" adaptor activity, NOT an enzyme<br />
+activity. There is no catalytic/EC term in GOA and none should be invented. Retain molecular carrier activity<br />
+as the MF for core_functions.</p>
+<p>The IPI "protein binding" (GO:0005515) annotations (PMID:32296183 HuRI high-throughput Y2H hits: CINP,<br />
+CREB5, POU4F2, TBC1D7; PMID:27771510 MTR/MTRR/MMACHC; PMID:23415655 MMACHC) are uninformative bare<br />
+protein-binding — mark as over-annotated per curation policy (do NOT REMOVE experimental IPIs), noting the<br />
+biologically meaningful partners (MMACHC, MTR, MTRR) are captured by the molecular carrier activity + BP terms.</p>
+<h2 id="reference-for-file-quote">Reference for file: quote</h2>
+<p>Add file:human/MMADHC/MMADHC-uniprot.txt to references for the UniProt FUNCTION/SUBCELLULAR quote support.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9H3L0
+gene_symbol: MMADHC
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  MMADHC (cobalamin trafficking protein CblD; the cblD complementation group) is a
+  cobalamin (vitamin B12)-trafficking branch-point/adaptor protein. It acts downstream of
+  MMACHC (cblC) in the cytosol, where it physically associates with MMACHC and, together
+  with methionine synthase (MTR) and methionine synthase reductase (MTRR), directs the
+  common cob(II)alamin intermediate into one of two coenzyme-synthesis branches: the
+  mitochondrial adenosylcobalamin (AdoCbl) branch that supplies methylmalonyl-CoA mutase
+  (MMUT), or the cytosolic methylcobalamin (MeCbl) branch that supplies methionine synthase
+  (MTR). MMADHC is not an enzyme; its C-terminal domain adopts a nitro-FMN-reductase-like
+  fold and provides a cysteine (Cys261) thiolate ligand to cob(II)alamin bound to MMACHC.
+  The protein has both cytosolic and mitochondrial pools and carries a predicted N-terminal
+  mitochondrial transit peptide. Distinct mutation positions determine which branch fails,
+  producing three biochemical phenotypes: isolated methylmalonic aciduria (cblD-variant 2),
+  isolated homocystinuria (cblD-variant 1), or combined methylmalonic aciduria and
+  homocystinuria.
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred mitochondrial localization. MMADHC has a predicted
+      N-terminal mitochondrial transit peptide and a documented mitochondrial pool in
+      addition to its cytosolic pool, consistent with its role in routing cobalamin
+      toward the mitochondrial AdoCbl branch.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Mitochondrial localization is supported experimentally (IDA/HTP) and by the UniProt
+      transit peptide annotation, so the IBA localization is biologically correct. However,
+      the functionally decisive branch-point/adaptor activity occurs in the cytosol
+      (downstream of MMACHC, in complex with MMACHC/MTR/MTRR); the mitochondrial pool is a
+      secondary compartment, hence retained as non-core.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+    - reference_id: file:human/MMADHC/MMADHC-uniprot.txt
+      supporting_text: Cytoplasm {ECO:0000269|PubMed:23270877}.
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetically inferred involvement in cobalamin metabolism. This is the central,
+      well-supported biological process for MMADHC: it acts as a branch point directing
+      cobalamin into the AdoCbl (mitochondrial) and MeCbl (cytosolic) coenzyme pathways.
+    action: ACCEPT
+    reason: &gt;-
+      Strongly corroborated by multiple experimental studies establishing MMADHC as a
+      cobalamin-trafficking branch-point protein downstream of MMACHC. Represents a core
+      biological process for this gene.
+    supported_by:
+    - reference_id: PMID:22156578
+      supporting_text: supporting the role of cblD protein as a branch point in
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC acts as a branch point for vitamin B(12) delivery to
+- term:
+    id: GO:0140104
+    label: molecular carrier activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetically inferred molecular carrier activity. MMADHC is a non-enzymatic
+      cobalamin-trafficking adaptor that receives/hands off the cobalamin cofactor
+      (partitioning it between the MeCbl and AdoCbl branches) rather than catalyzing a
+      chemical reaction. Molecular carrier activity captures this carrier/adaptor role.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the multiple independent IDA/EXP/TAS annotations to the same term and
+      with the biochemical evidence that MMADHC functions as an adaptor controlling
+      intracellular cobalamin partitioning rather than as an enzyme. This is the best
+      available molecular-function term for a non-catalytic cofactor-trafficking protein.
+    supported_by:
+    - reference_id: PMID:23415655
+      supporting_text: an adapter function for CblD
+    - reference_id: PMID:22156578
+      supporting_text: supporting the role of cblD protein as a branch point in
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (UniProt SubCell mapping) annotation to cytoplasm. Consistent with the
+      documented cytoplasmic pool of MMADHC, where its branch-point/adaptor activity occurs.
+    action: ACCEPT
+    reason: &gt;-
+      Correct but general; the more specific experimentally supported cytosol term
+      (GO:0005829) is also annotated. Accept as a valid, if broad, localization.
+    supported_by:
+    - reference_id: file:human/MMADHC/MMADHC-uniprot.txt
+      supporting_text: Cytoplasm {ECO:0000269|PubMed:23270877}.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (UniProt SubCell mapping) annotation to mitochondrion, matching the
+      predicted N-terminal mitochondrial transit peptide and the experimentally observed
+      mitochondrial pool.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Mitochondrial localization is real and supported (transit peptide; IDA; HTP), but
+      secondary to the cytosolic branch-point activity, so kept as non-core.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO electronic annotation (IPR019362, the MMADHC family) to cobalamin
+      metabolic process. The InterPro family is specific to this cobalamin-trafficking
+      protein, so the mapping is accurate.
+    action: ACCEPT
+    reason: &gt;-
+      Correct biological process, redundant with the well-supported IBA/IDA annotations to
+      the same term. Represents a core process.
+    supported_by:
+    - reference_id: PMID:22156578
+      supporting_text: supporting the role of cblD protein as a branch point in
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare protein binding from a large-scale binary interactome map (HuRI), with
+      high-throughput yeast two-hybrid interactors (CREB5, POU4F2, TBC1D7, CINP) that are
+      not part of the established cobalamin-trafficking machinery and are of unclear
+      biological relevance to MMADHC function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation guidance, bare &#34;protein binding&#34; is uninformative and this comes from a
+      genome-scale two-hybrid screen whose hits are not the biologically meaningful partners
+      (MMACHC, MTR, MTRR). Not removed (experimental IPI), but marked as over-annotated; the
+      informative partners are captured by the molecular carrier activity and cobalamin
+      metabolic process terms.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &gt;-
+        we present a human &#39;all-by-all&#39; reference interactome map of human binary protein
+        interactions, or &#39;HuRI&#39;.
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9759218
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome pathway annotation (Cobalamin metabolism) placing MMADHC in cobalamin
+      metabolic process. Consistent with all other evidence for this gene.
+    action: ACCEPT
+    reason: &gt;-
+      Traceable author statement from Reactome for a core biological process; concordant
+      with the IBA/IDA/IEA annotations to the same term.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC acts as a branch point for vitamin B(12) delivery to
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput detection of MMADHC in a high-confidence human mitochondrial proteome,
+      corroborating the mitochondrial pool identified by immunofluorescence/fractionation
+      and the predicted mitochondrial transit peptide.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Confirms mitochondrial localization but this compartment is secondary to the cytosolic
+      branch-point activity; kept as non-core localization.
+    supported_by:
+    - reference_id: PMID:34800366
+      supporting_text: high-confidence human mitochondrial proteome
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+- term:
+    id: GO:0140104
+    label: molecular carrier activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3149563
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome TAS annotation (MMADHC targets transport of cytosolic cob(II)alamin to
+      mitochondria) to molecular carrier activity, capturing MMADHC&#39;s cobalamin
+      carrier/routing role.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the branch-point/adaptor function; molecular carrier activity is the
+      appropriate non-enzymatic MF term. Redundant with the IBA/IDA/EXP annotations to the
+      same term.
+    supported_by:
+    - reference_id: PMID:23415655
+      supporting_text: an adapter function for CblD
+- term:
+    id: GO:0140104
+    label: molecular carrier activity
+  evidence_type: EXP
+  original_reference_id: PMID:21071249
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Experimental support (via Reactome) for cobalamin carrier/adaptor activity, based on
+      the demonstrated direct interaction of MMADHC with MMACHC, the partner that hands off
+      the cobalamin cofactor.
+    action: ACCEPT
+    reason: &gt;-
+      The MMACHC-MMADHC interaction underpins MMADHC&#39;s role as a downstream cobalamin
+      carrier/adaptor; molecular carrier activity is the correct MF term.
+    supported_by:
+    - reference_id: PMID:21071249
+      supporting_text: MMADHC was confirmed as a binding
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: PMID:23270877
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental (immunofluorescence and subcellular fractionation) localization of
+      MMADHC to the cytosol, the compartment where it acts downstream of MMACHC as a
+      cobalamin branch point.
+    action: ACCEPT
+    reason: &gt;-
+      Well-supported specific cytosolic localization; this is the primary site of MMADHC&#39;s
+      branch-point/adaptor activity and is retained as a core location.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:22156578
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: &gt;-
+      Direct experimental evidence (complementation of cblD patient fibroblasts; mutation
+      position correlating with biochemical phenotype) that MMADHC acts within cobalamin
+      metabolism as a branch point balancing cytosolic MeCbl and mitochondrial AdoCbl
+      synthesis.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, directly demonstrated. The acts_upstream_of_or_within
+      qualifier reflects the regulatory branch-point role.
+    supported_by:
+    - reference_id: PMID:22156578
+      supporting_text: supporting the role of cblD protein as a branch point in
+    - reference_id: PMID:22156578
+      supporting_text: correlate with the biochemical phenotype
+- term:
+    id: GO:0140104
+    label: molecular carrier activity
+  evidence_type: IDA
+  original_reference_id: PMID:22156578
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental support for MMADHC&#39;s cobalamin carrier/branch-point activity:
+      a single protein with two functional domains that partition cobalamin between the
+      cytosolic MeCbl and mitochondrial AdoCbl routes.
+    action: ACCEPT
+    reason: &gt;-
+      Molecular carrier activity is the appropriate non-enzymatic MF term for this
+      cofactor-partitioning adaptor; directly supported by the phenotype/rescue data.
+    supported_by:
+    - reference_id: PMID:22156578
+      supporting_text: supporting the role of cblD protein as a branch point in
+- term:
+    id: GO:0140104
+    label: molecular carrier activity
+  evidence_type: IDA
+  original_reference_id: PMID:32871076
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental evidence that CblD/MMADHC provides a Cys261 thiolate ligand to
+      cob(II)alamin bound to CblC/MMACHC, forming an interprotein Co-S coordination complex
+      used for cofactor translocation in the trafficking pathway - a molecular carrier/handoff
+      activity.
+    action: ACCEPT
+    reason: &gt;-
+      Biochemical/structural demonstration of direct cobalamin coordination by MMADHC in the
+      trafficking pathway strongly supports molecular carrier activity as its MF.
+    supported_by:
+    - reference_id: PMID:32871076
+      supporting_text: CblD provides a sulfur ligand to cob(II)alamin bound to CblC
+    - reference_id: PMID:32871076
+      supporting_text: Cys-261 on CblD as the sulfur donor
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: PMID:23270877
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence that MMADHC is active in the cytosol, where it functions
+      downstream of MMACHC as the cobalamin branch point (and in complex with MMACHC, MTR
+      and MTRR).
+    action: ACCEPT
+    reason: &gt;-
+      Cytosol is the primary site of MMADHC&#39;s branch-point/adaptor activity; the is_active_in
+      qualifier is appropriate and this is a core location for the molecular function.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:22156578
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental involvement in cobalamin metabolic process (branch-point control
+      of MeCbl/AdoCbl synthesis), demonstrated by expression/complementation of cblD patient
+      fibroblasts.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, directly supported; duplicates the acts_upstream_of_or_within
+      annotation from the same paper with an involved_in qualifier, both valid.
+    supported_by:
+    - reference_id: PMID:22156578
+      supporting_text: supporting the role of cblD protein as a branch point in
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:27771510
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Protein binding annotation from co-IP/proximity-ligation demonstrating MMADHC
+      interactions with methionine synthase (MTR/Q99707), methionine synthase reductase
+      (MTRR/Q9UBK8) and MMACHC (Q9Y4U1) as part of a cytosolic multiprotein cobalamin-handling
+      complex. These are biologically meaningful partners, but the term itself is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare &#34;protein binding&#34; does not convey function; the meaningful interactions
+      (MMACHC/MTR/MTRR) reflect the cytosolic cobalamin-carrier complex and are captured by
+      the molecular carrier activity MF and cobalamin metabolic process BP terms. Experimental
+      IPI, so not removed, but marked over-annotated.
+    supported_by:
+    - reference_id: PMID:27771510
+      supporting_text: &gt;-
+        processing of Cbl in cytoplasm occurs in a multiprotein complex composed of at least
+        MS, MSR, MMACHC and MMADHC
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23415655
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Protein binding annotation for the MMADHC (CblD)-MMACHC (CblC, Q9Y4U1) interaction,
+      shown biochemically to isolate a CblC-CblD complex that partitions cobalamin between
+      the AdoCbl and MeCbl assimilation pathways.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The MMACHC interaction is central to MMADHC biology, but &#34;protein binding&#34; is
+      uninformative; the functional consequence (adaptor/branch-point cobalamin carrier) is
+      captured by molecular carrier activity and cobalamin metabolic process. Experimental
+      IPI, not removed.
+    supported_by:
+    - reference_id: PMID:23415655
+      supporting_text: an adapter function for CblD
+    - reference_id: PMID:23415655
+      supporting_text: functions downstream of CblC in the cofactor assimilation pathway
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:23270877
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental cytoplasmic localization of MMADHC (immunofluorescence/subcellular
+      fractionation), consistent with its cytosolic branch-point activity.
+    action: ACCEPT
+    reason: &gt;-
+      Correct but more general than the concurrently annotated cytosol (GO:0005829) term.
+      Accept as valid localization.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:23270877
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence that MMADHC has a mitochondrial pool in addition to its
+      cytoplasmic pool, consistent with its role in routing cobalamin toward the
+      mitochondrial AdoCbl branch and with its predicted mitochondrial transit peptide.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Genuine mitochondrial localization, but the decisive branch-point/adaptor activity is
+      cytosolic; retained as non-core.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+- term:
+    id: GO:0009235
+    label: cobalamin metabolic process
+  evidence_type: IDA
+  original_reference_id: PMID:24722857
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental involvement in cobalamin metabolism, from domain-mapping/rescue
+      experiments showing that specific MMADHC regions differentially regulate AdoCbl and
+      MeCbl synthesis (mapping to the three cblD phenotypes).
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process, directly demonstrated by functional-domain characterization.
+    supported_by:
+    - reference_id: PMID:24722857
+      supporting_text: specific regions of MMADHC are
+    - reference_id: PMID:24722857
+      supporting_text: must be converted into two coenzyme
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3318571
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation localizing MMADHC to the cytosol, consistent with the
+      experimental cytosolic localization and its cytosolic branch-point function.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with the IDA cytosol annotation; retained as a core location.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3149494
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation (MMACHC:cob(II)alamin binds MMADHC) localizing MMADHC to the
+      cytosol, the compartment where it receives cobalamin from MMACHC.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with experimental cytosol localization; retained as a core location.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3149563
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation localizing MMADHC to the cytosol, matching the experimental
+      cytosolic localization and function.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with the IDA cytosol annotation; retained as a core location.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3204318
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation (cob(II)alamin transferred from MMACHC:MMADHC:cob(II)alamin to
+      MTRR:MTR) localizing MMADHC to the cytosol, consistent with its cytosolic
+      cobalamin-handoff role within the MMACHC/MTR/MTRR complex.
+    action: ACCEPT
+    reason: &gt;-
+      Concordant with experimental cytosol localization; retained as a core location.
+    supported_by:
+    - reference_id: PMID:23270877
+      supporting_text: MMADHC is both mitochondrial and cytoplasmic
+    - reference_id: PMID:27771510
+      supporting_text: &gt;-
+        processing of Cbl in cytoplasm occurs in a multiprotein complex composed of at least
+        MS, MSR, MMACHC and MMADHC
+core_functions:
+- description: &gt;-
+    Cobalamin-trafficking branch-point/adaptor activity: acting downstream of MMACHC (cblC)
+    in the cytosol, MMADHC receives the common cob(II)alamin intermediate and partitions it
+    between the cytosolic methylcobalamin (MeCbl) branch supplying methionine synthase (MTR)
+    and the mitochondrial adenosylcobalamin (AdoCbl) branch supplying methylmalonyl-CoA
+    mutase (MMUT).
+  molecular_function:
+    id: GO:0140104
+    label: molecular carrier activity
+  directly_involved_in:
+  - id: GO:0009235
+    label: cobalamin metabolic process
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: PMID:22156578
+    supporting_text: supporting the role of cblD protein as a branch point in
+  - reference_id: PMID:23415655
+    supporting_text: an adapter function for CblD
+  - reference_id: PMID:23270877
+    supporting_text: MMADHC acts as a branch point for vitamin B(12) delivery to
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    What molecular signals determine the partitioning of MMADHC between its cytosolic and
+    mitochondrial pools, and does mitochondrial import of MMADHC itself carry cobalamin?
+- question: &gt;-
+    Is the Cys261-mediated interprotein Co-S coordination with MMACHC-bound cob(II)alamin the
+    general mechanism of cobalamin handoff, or only one of several transfer modes?
+suggested_experiments:
+- description: &gt;-
+    Structure/cryo-EM of the full cytosolic MMACHC-MMADHC-MTR-MTRR complex with bound
+    cobalamin to define the cofactor-handoff geometry and the basis of MeCbl-versus-AdoCbl
+    branch selection.
+- description: &gt;-
+    Quantitative flux measurements of MeCbl versus AdoCbl synthesis in cells expressing
+    domain-swapped or transit-peptide-modified MMADHC variants to test how localization and
+    domain boundaries set the branch point.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: file:human/MMADHC/MMADHC-uniprot.txt
+  title: UniProtKB entry Q9H3L0 (MMAD_HUMAN), Cobalamin trafficking protein CblD
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      UniProt record for MMADHC; supports cytoplasmic/mitochondrial localization, the
+      MMACHC heterodimer, and the coenzyme-partitioning function.
+- id: PMID:21071249
+  title: Interaction between MMACHC and MMADHC, two human proteins participating in
+    intracellular vitamin B₁₂ metabolism.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Confirms direct MMADHC-MMACHC interaction by SPR and bacterial two-hybrid; supports
+      the carrier/adaptor role downstream of MMACHC.
+- id: PMID:22156578
+  title: Molecular mechanisms leading to three different phenotypes in the cblD defect
+    of intracellular cobalamin metabolism.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes MMADHC as a branch point partitioning cytosolic MeCbl vs mitochondrial
+      AdoCbl synthesis; mutation position correlates with the three cblD phenotypes.
+- id: PMID:23270877
+  title: Subcellular location of MMACHC and MMADHC, two human proteins central to
+    intracellular vitamin B(12) metabolism.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Direct evidence (immunofluorescence/fractionation) that MMADHC is both cytosolic and
+      mitochondrial and acts as a branch point downstream of MMACHC.
+- id: PMID:23415655
+  title: The C-terminal domain of CblD interacts with CblC and influences intracellular
+    cobalamin partitioning.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Shows CblD functions downstream of CblC as an adapter controlling AdoCbl/MeCbl
+      partitioning; C-terminal domain mediates the CblC interaction.
+- id: PMID:24722857
+  title: Characterization of functional domains of the cblD (MMADHC) gene product.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Domain-mapping/rescue experiments defining regions of MMADHC that differentially
+      regulate AdoCbl vs MeCbl synthesis, matching the three cblD phenotypes.
+- id: PMID:27771510
+  title: Methionine synthase and methionine synthase reductase interact with MMACHC
+    and with MMADHC.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Demonstrates a cytosolic multiprotein complex (MMACHC, MMADHC, MTR, MTRR) that
+      shuttles cobalamin toward methionine synthase.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale HuRI binary-interactome map; source of the bare protein-binding IPIs
+      (CREB5, POU4F2, TBC1D7, CINP) that are not established MMADHC functional partners.
+- id: PMID:32871076
+  title: An Interprotein Co-S Coordination Complex in the B(12)-Trafficking Pathway.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Identifies Cys261 of CblD/MMADHC as a sulfur ligand to MMACHC-bound cob(II)alamin,
+      defining a molecular cobalamin-handoff mechanism.
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput mitochondrial proteome detecting MMADHC; corroborates the
+      mitochondrial pool.
+- id: Reactome:R-HSA-9759218
+  title: Cobalamin (Cbl) metabolism
+  findings: []
+- id: Reactome:R-HSA-3149494
+  title: MMACHC:cob(II)alamin binds MMADHC
+  findings: []
+- id: Reactome:R-HSA-3149563
+  title: MMADHC targets transport of cytosolic cob(II)alamin to mitochondria
+  findings: []
+- id: Reactome:R-HSA-3204318
+  title: cob(II)alamin is transferred from MMACHC:MMADHC:cob(II)alamin to MTRR:MTR
+  findings: []
+- id: Reactome:R-HSA-3318571
+  title: Defective MMADHC does not bind MMACHC:B12r
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGA/PIGA-ai-review.html
+++ b/genes/human/PIGA/PIGA-ai-review.html
@@ -1,0 +1,3971 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGA - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGA</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P37287" target="_blank" class="term-link">
+                        P37287
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGA";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P37287" data-a="DESCRIPTION: PIGA (phosphatidylinositol N-acetylglucosaminyltra..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGA (phosphatidylinositol N-acetylglucosaminyltransferase subunit A) is the catalytic subunit of the glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex, which catalyzes the first, committed step of glycosylphosphatidylinositol (GPI) anchor biosynthesis. PIGA transfers N-acetylglucosamine (GlcNAc) from UDP-N-acetylglucosamine (UDP-GlcNAc) onto phosphatidylinositol (PI) to form GlcNAc-PI (EC 2.4.1.198), a reaction occurring on the cytoplasmic face of the endoplasmic reticulum membrane. PIGA is a single-pass ER membrane protein with a large cytoplasmic catalytic domain (homologous to bacterial GlcNAc transferases, glycosyltransferase group 1 / GT4 family) and a small lumenal domain that mediates rough-ER localization. The GPI-GnT complex additionally contains PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2, with PIGA as the catalytic component. Somatic loss-of-function mutations of the X-linked PIGA gene in hematopoietic stem cells cause paroxysmal nocturnal hemoglobinuria (PNH), through loss of GPI-anchored complement regulators on blood cells; germline hypomorphic mutations cause X-linked recessive multiple congenital anomalies-hypotonia-seizures syndrome 2 (MCAHS2) and related neurodevelopmental disorders.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0000506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGA is a subunit of the GPI-GnT complex. This phylogenetically inferred complex membership is directly supported by experimental studies of the human complex and is a core aspect of PIGA biology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGA is the catalytic subunit of the GPI-GnT complex, which comprises at least PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2. The IBA call is corroborated by direct experimental identification of the human complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-A and PIG-H are subunits of the GPI GlcNAc transferase that transfers GlcNAc to PI on the cytoplasmic side of the ER.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGA catalyzes the first, committed step of GPI anchor biosynthesis, so involvement in the GPI anchor biosynthetic process is a core biological process annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The catalytic first step (GlcNAc transfer to PI) initiates the GPI biosynthesis pathway. This is well established experimentally and consistent with the phylogenetic inference.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by transfer of N-acetylglucosamine (GlcNAc) from UDP-GlcNAc to phosphatidylinositol (PI).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017176" target="_blank" class="term-link">
+                                    GO:0017176
+                                </a>
+                            </span>
+                            <span class="term-label">phosphatidylinositol N-acetylglucosaminyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0017176" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the exact, correct molecular function of PIGA - the catalytic subunit that transfers GlcNAc from UDP-GlcNAc to phosphatidylinositol (EC 2.4.1.198).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGA is the catalytic component of the GPI-GnT enzyme; this specific transferase activity is the core molecular function and is directly supported by biochemistry.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in vitro.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binding directly to the catalytic subunit PIG-A.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0000506" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based electronic annotation of GPI-GnT complex membership (via the PIG-A/GPI3 signature IPR039507). Correct and consistent with experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IEA mapping from the PIG-A/GPI3 InterPro entry to the GPI-GnT complex is biologically correct; PIGA is an experimentally verified complex member.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-A and PIG-H are subunits of the GPI GlcNAc transferase that transfers GlcNAc to PI on the cytoplasmic side of the ER.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro/UniPathway) annotation to the GPI anchor biosynthetic process, matching the experimentally established role of PIGA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The pathway mapping (UPA00196 GPI-anchor biosynthesis) is correct; PIGA initiates this pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by transfer of N-acetylglucosamine (GlcNAc) from UDP-GlcNAc to phosphatidylinositol (PI).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016757" target="_blank" class="term-link">
+                                    GO:0016757
+                                </a>
+                            </span>
+                            <span class="term-label">glycosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0016757" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic glycosyltransferase activity from the InterPro glycosyltransferase family 1 domain (IPR001296). Correct but a broad parent of the specific PIGA activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This term is a general ancestor of the specific and experimentally supported GO:0017176 (phosphatidylinositol N-acetylglucosaminyltransferase activity), which is annotated separately. The generic term is not informative for PIGA&#39;s core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in vitro.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017176" target="_blank" class="term-link">
+                                    GO:0017176
+                                </a>
+                            </span>
+                            <span class="term-label">phosphatidylinositol N-acetylglucosaminyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0017176" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation of the specific catalytic activity based on the RHEA/EC mapping (RHEA:14789, EC 2.4.1.198). This is the correct core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The EC/RHEA-derived assignment matches the experimentally established catalytic activity of PIGA and is the specific, informative molecular function term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six proteins.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGA/PIGA-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">EC=2.4.1.198</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030867" target="_blank" class="term-link">
+                                    GO:0030867
+                                </a>
+                            </span>
+                            <span class="term-label">rough endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0030867" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt subcellular-location keyword mapping to rough ER membrane. Correct and consistent with experimental localization data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGA localizes to the rough ER membrane; this specific location is experimentally verified (the small lumenal domain targets it to the rough ER).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">part of the small lumenal domain of PIG-A plays an essential functional role in targeting itself to the rough ER.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10944123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Initial enzyme for glycosylphosphatidylinositol biosynthesis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0005515" data-r="PMID:10944123" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated binary interactions of PIGA with GPI-GnT complex components (DPM2/O94777, PIGP/P57054, PIGH/Q14442, PIGQ/Q9BRB3). These reflect PIGA&#39;s role as a scaffolding/catalytic member of the GPI-GnT complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic &#39;protein binding&#39; term is uninformative. The underlying interactions are real and are the physical basis of the GPI-GnT complex, which is captured by the specific GO:0000506 (GPI-GnT complex) annotation. Per curation guidelines the bare protein binding IPI is not retained as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-P, a 134-amino acid protein having two hydrophobic domains, associates with PIG-A and GPI1.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DPM2, but not two other components of dolichol-phosphate-mannose synthase, associates with GPI-GnT through interactions with PIG-A, PIG-C and GPI1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0005515" data-r="PMID:16162815" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interactions of PIGA with GPI-GnT complex components including the directly associated regulatory subunit PIGY (Q3MUY2), plus DPM2, PIGP, PIGH, PIGQ. Real interactions underpinning complex assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#39;protein binding&#39; is uninformative and is subsumed by the specific GPI-GnT complex (GO:0000506) annotation. The interactions themselves are genuine.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-Y appeared to be directly associated with PIG-A.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput BioPlex 3.0 AP-MS interactions of PIGA (recovering PIGP and PIGH). Consistent with GPI-GnT complex membership but low information content.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic &#39;protein binding&#39; from a proteome-scale AP-MS screen; not a core function term. The recovered partners are GPI-GnT complex members captured by GO:0000506.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">BioPlex suggests function, localization, and complex membership for thousands of proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8900170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-A and PIG-H, which participate in glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0005515" data-r="PMID:8900170" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction of PIGA with PIGH (Q14442), the earliest characterized binary interaction within the GPI-GnT complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The PIGA-PIGH interaction is real and foundational to the complex, but the generic &#39;protein binding&#39; term is uninformative and is captured by the specific GPI-GnT complex (GO:0000506) annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">they form a protein complex.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9463366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The first step of glycosylphosphatidylinositol biosynthesis ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0005515" data-r="PMID:9463366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-curated interaction of PIGA with PIGQ/GPI1 (Q9BRB3), a component of the four-subunit GPI-GnT complex characterized in this study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real interaction within the GPI-GnT complex, but the generic &#39;protein binding&#39; term is uninformative and subsumed by GO:0000506 (GPI-GnT complex).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162710
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0006506" data-r="Reactome:R-HSA-162710" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement placing PIGA in the GPI synthesis pathway. Matches PIGA&#39;s established role initiating GPI anchor biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGA catalyzes the first reaction of GPI anchor biosynthesis; the Reactome pathway assignment is correct and core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by transfer of N-acetylglucosamine (GlcNAc) from UDP-GlcNAc to phosphatidylinositol (PI).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030867" target="_blank" class="term-link">
+                                    GO:0030867
+                                </a>
+                            </span>
+                            <span class="term-label">rough endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8900170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-A and PIG-H, which participate in glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0030867" data-r="PMID:8900170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental demonstration that PIGA is an ER transmembrane protein localizing to the rough ER, with its small lumenal domain required for rough-ER targeting.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by experimental localization/topology work; the rough ER membrane is a verified, specific location for PIGA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-A is an ER transmembrane protein with a large cytoplasmic domain that has homology to a bacterial GlcNAc transferase and a small lumenal domain.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">part of the small lumenal domain of PIG-A plays an essential functional role in targeting itself to the rough ER.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-6502) assertion of PIGA as part of the GPI-GnT complex, based on the study identifying the seven-component complex including PIGY.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGA is an experimentally established member (catalytic subunit) of the GPI-GnT complex; complex membership is a core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0005789" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay localization of PIGA to the ER membrane, where the GPI-GnT complex assembles and functions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ER membrane is the verified site of PIGA action and GPI-GnT complex assembly; this is a core cellular component annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008194" target="_blank" class="term-link">
+                                    GO:0008194
+                                </a>
+                            </span>
+                            <span class="term-label">UDP-glycosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162730
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0008194" data-r="Reactome:R-HSA-162730" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome describes the reaction as using the UDP-sugar donor UDP-GlcNAc. The term correctly captures the UDP-sugar donor class but is less specific than the exact enzyme activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UDP-glycosyltransferase activity is a broad donor-class term. The specific, experimentally supported activity is phosphatidylinositol N-acetylglucosaminyltransferase activity (GO:0017176, EC 2.4.1.198), which uses UDP-GlcNAc as donor and PI as acceptor.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017176" target="_blank" class="term-link">
+                                    phosphatidylinositol N-acetylglucosaminyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by transfer of N-acetylglucosamine (GlcNAc) from UDP-GlcNAc to phosphatidylinositol (PI).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput identification of PIGA in an NK-cell membrane proteome. Only confirms membrane association without specifying the organelle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The &#39;membrane&#39; term is a very general location from a proteome-scale study; PIGA&#39;s informative location is the ER membrane (GO:0005789 / GO:0030867), which is annotated separately with direct evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">approximately 40% of the identified proteins were predicted as plausible membrane proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162730
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0005789" data-r="Reactome:R-HSA-162730" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement placing the GlcNAc-PI synthesis reaction (and PIGA) at the ER membrane. Consistent with direct experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ER membrane is the verified site of the PIGA-catalyzed reaction; a core cellular component annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-A is an ER transmembrane protein with a large cytoplasmic domain that has homology to a bacterial GlcNAc transferase and a small lumenal domain.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay identification of PIGA as a component of the seven-subunit GPI-GnT complex (adding PIGY as the seventh component directly associated with PIGA).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally established core complex membership; PIGA is the catalytic subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-Y appeared to be directly associated with PIG-A.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017176" target="_blank" class="term-link">
+                                    GO:0017176
+                                </a>
+                            </span>
+                            <span class="term-label">phosphatidylinositol N-acetylglucosaminyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P37287" data-a="GO:0017176" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement of PIGA&#39;s phosphatidylinositol N-acetylglucosaminyltransferase activity, from the study establishing catalytic activity and the seven-component complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the specific, experimentally supported core molecular function of PIGA (catalytic subunit; EC 2.4.1.198).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six proteins.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalytic subunit of the GPI-GnT complex that transfers N-acetylglucosamine from UDP-GlcNAc to phosphatidylinositol (EC 2.4.1.198), catalyzing the first committed step of GPI anchor biosynthesis at the ER membrane.</h3>
+                <span class="vote-buttons" data-g="P37287" data-a="FUNCTION: Catalytic subunit of the GPI-GnT complex that tran..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017176" target="_blank" class="term-link">
+                            phosphatidylinositol N-acetylglucosaminyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                            glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                PMID:16162815
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six proteins.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                PMID:9463366
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in vitro.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                            PMID:10944123
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-P and is regulated by DPM2.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GPI-GnT requires PIG-P as an essential component and is regulated by DPM2, which associates with the complex through interactions with PIG-A, PIG-C and GPI1 and enhances enzyme activity ~3-fold.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                            PMID:16162815
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-Y, a seventh component.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PIGA is the catalytic subunit of the GPI-GnT complex; PIG-Y is directly associated with PIG-A and regulates GPI-GnT activity. This study established the catalytic activity and seven-component complex (EC 2.4.1.198).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">High-throughput membrane proteome of the NK-like cell line YTS; supports only a generic membrane localization for PIGA.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">BioPlex 3.0 AP-MS interactome; recovers PIGA interactions with GPI-GnT complex members (PIGP, PIGH), supporting a generic protein-binding annotation.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                            PMID:8900170
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-A and PIG-H, which participate in glycosylphosphatidylinositol anchor biosynthesis, form a protein complex in the endoplasmic reticulum.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PIG-A is an ER transmembrane protein with a large cytoplasmic (catalytic) domain and a small lumenal domain that targets it to the rough ER; PIG-A and PIG-H form a complex and transfer GlcNAc to PI on the cytoplasmic side of the ER.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                            PMID:9463366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The first step of glycosylphosphatidylinositol biosynthesis is mediated by a complex of PIG-A, PIG-H, PIG-C and GPI1.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The first step of GPI biosynthesis (GlcNAc transfer from UDP-GlcNAc to PI) is mediated by an ER-membrane complex of PIG-A, PIG-H, PIG-C and GPI1 that has GPI-GnT activity in vitro.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162710
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Synthesis of glycosylphosphatidylinositol (GPI)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162730
+
+                    </span>
+                </div>
+
+                <div class="reference-title">phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI + UDP</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGA/PIGA-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB P37287 (PIGA_HUMAN) record</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Catalytic subunit of the GPI-GnT complex that catalyzes transfer of N-acetylglucosamine from UDP-N-acetylglucosamine to phosphatidylinositol (EC 2.4.1.198); rough ER membrane, single-pass membrane protein; complex composed of PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGA-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P37287" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="piga-p37287-review-notes">PIGA (P37287) review notes</h1>
+<p>Human PIGA / PIG-A / Phosphatidylinositol N-acetylglucosaminyltransferase subunit A.<br />
+HGNC:8957, X-linked (Xp22.2), 484 aa, EC 2.4.1.198. CAZy GT4 (glycosyltransferase group 1 family, GT4 subfamily).</p>
+<p>Deep research: falcon provider was OUT OF CREDITS (HTTP 402) at the time of review, so no<br />
+<code>-deep-research-falcon.md</code> was generated. This review is grounded in the UniProt record,<br />
+the seeded GOA, cached primary publications, and the two cached Reactome entries.</p>
+<h2 id="core-biology">Core biology</h2>
+<p>PIGA is the <strong>catalytic subunit</strong> of the <strong>GPI-GlcNAc transferase (GPI-GnT) complex</strong> that<br />
+catalyses the <strong>first, committed step of GPI (glycosylphosphatidylinositol) anchor biosynthesis</strong>:<br />
+transfer of N-acetylglucosamine (GlcNAc) from UDP-GlcNAc onto phosphatidylinositol (PI) to give<br />
+GlcNAc-PI, on the <strong>cytoplasmic face of the ER membrane</strong> [PMID:8900170; PMID:9463366; PMID:16162815].</p>
+<ul>
+<li>Reaction (RHEA:14789, EC 2.4.1.198): PI + UDP-GlcNAc -&gt; GlcNAc-PI + UDP + H+<br />
+  [file:human/PIGA/PIGA-uniprot.txt CATALYTIC ACTIVITY block].</li>
+<li>UniProt FUNCTION: "Catalytic subunit of the glycosylphosphatidylinositol-N-acetylglucosaminyltransferase<br />
+  (GPI-GnT) complex that catalyzes the transfer of N-acetylglucosamine from UDP-N-acetylglucosamine to<br />
+  phosphatidylinositol and participates in the first step of GPI biosynthesis" [ECO:0000305|PubMed:16162815].</li>
+</ul>
+<h2 id="gpi-gnt-complex-composition">GPI-GnT complex composition</h2>
+<p>At least PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2 (PIGA is the catalytic component)<br />
+[UniProt SUBUNIT; PMID:16162815]. Historical assembly picture:<br />
+- PMID:8900170 (1996): PIG-A + PIG-H form an ER complex; PIG-A is a transmembrane protein with a large<br />
+  cytoplasmic (catalytic) domain homologous to a bacterial GlcNAc transferase and a small lumenal domain;<br />
+  small lumenal domain targets it to the rough ER. GlcNAc-PI is made on the cytoplasmic side of the ER.<br />
+- PMID:9463366 (1998): four-component complex PIG-A/PIG-H/PIG-C/GPI1 (=PIGQ) in the ER membrane; complex<br />
+  has GPI-GlcNAc transferase (GPI-GnT) activity in vitro; PIG-L (2nd step, de-N-acetylation) not in complex.<br />
+- PMID:10944123 (2000): adds PIG-P as essential component; DPM2 associates and regulates (enhances activity<br />
+  ~3-fold), coupling GPI-GnT to Dol-P-Man synthase.<br />
+- PMID:16162815 (2005): adds PIG-Y (7th component); PIG-Y associates directly with catalytic PIG-A and<br />
+  regulates GPI-GnT activity. Establishes catalytic activity/function; assigns EC 2.4.1.198.</p>
+<p>IntAct/BioPlex interactors used in GOA GO:0005515 IPIs map to complex members:<br />
+O94777=DPM2, P57054=PIGP, Q14442=PIGH, Q9BRB3=PIGQ, Q3MUY2=PIGY (all confirmed in UniProt INTERACTION block).<br />
+PMID:33961781 = BioPlex 3.0 AP-MS (high-throughput interactome) — recovers PIGP, PIGH.</p>
+<h2 id="localization-topology">Localization / topology</h2>
+<p>Rough ER membrane; single-pass membrane protein. TOPO_DOM 1..421 cytoplasmic (catalytic), TRANSMEM<br />
+422..442, TOPO_DOM 443..484 lumenal; region 443..465 required for rough-ER localization <a href="https://pubmed.ncbi.nlm.nih.gov/8900170">PMID:8900170</a>.<br />
+GOA carries both GO:0030867 (rough ER membrane) and GO:0005789 (ER membrane); the latter is the general<br />
+parent and is the cleaner "located_in" for core functions.</p>
+<h2 id="disease">Disease</h2>
+<ul>
+<li><strong>PNH (paroxysmal nocturnal hemoglobinuria, PNH1, MIM:300818)</strong>: somatic PIGA loss-of-function in<br />
+  hematopoietic stem cells -&gt; GPI-anchor deficiency on blood cells (loss of CD55/CD59) -&gt; complement-<br />
+  mediated hemolysis. Many somatic variants in UniProt (e.g. S155F, N297D).</li>
+<li><strong>MCAHS2 (multiple congenital anomalies-hypotonia-seizures syndrome 2, MIM:300868)</strong>: X-linked recessive<br />
+  germline hypomorphic mutations; developmental disorder with seizures. Variants R77L, P93L, R119W, I206F,<br />
+  L355S, 412-484 del, etc.</li>
+<li><strong>NEDEPH (MIM:301072)</strong>: germline; epilepsy + juvenile hemochromatosis (failure to GPI-anchor hemojuvelin/HJV<br />
+  disrupts hepcidin/HAMP regulation).</li>
+</ul>
+<h2 id="goa-annotation-review-summary-32-goa-rows">GOA annotation review summary (32 GOA rows)</h2>
+<p>MF:<br />
+- GO:0017176 phosphatidylinositol N-acetylglucosaminyltransferase activity — CORE. IBA, IEA(EC 2.4.1.198/RHEA:14789),<br />
+  TAS(PMID:16162815). ACCEPT (the specific, correct catalytic activity).<br />
+- GO:0016757 glycosyltransferase activity (IEA InterPro) — parent of GO:0017176; MARK_AS_OVER_ANNOTATED<br />
+  (correct but less informative; the specific child is annotated).<br />
+- GO:0008194 UDP-glycosyltransferase activity (TAS Reactome) — describes UDP-sugar donor; less specific/slightly<br />
+  off-branch vs the exact EC. MODIFY -&gt; GO:0017176.<br />
+- GO:0005515 protein binding (IPI x several, partners = complex members) — bare "protein binding";<br />
+  MARK_AS_OVER_ANNOTATED (real interactions but uninformative MF; captured by GPI-GnT complex membership).</p>
+<p>BP:<br />
+- GO:0006506 GPI anchor biosynthetic process — CORE. IBA, IEA, TAS(Reactome). ACCEPT.</p>
+<p>CC:<br />
+- GO:0000506 GPI-GnT complex — CORE. IBA, IEA, IPI, IDA(PMID:16162815). ACCEPT (part_of).<br />
+- GO:0005789 endoplasmic reticulum membrane — IDA(PMID:16162815), TAS(Reactome). ACCEPT (core location).<br />
+- GO:0030867 rough endoplasmic reticulum membrane — EXP(PMID:8900170), IEA. ACCEPT (specific location, verified).<br />
+- GO:0016020 membrane (HDA, PMID:19946888 NK membrane proteome) — MARK_AS_OVER_ANNOTATED (too general;<br />
+  high-throughput proteome; ER membrane is the informative location).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P37287
+gene_symbol: PIGA
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGA (phosphatidylinositol N-acetylglucosaminyltransferase subunit A)
+  is the catalytic subunit of the glycosylphosphatidylinositol-N-acetylglucosaminyltransferase
+  (GPI-GnT) complex, which catalyzes the first, committed step of glycosylphosphatidylinositol
+  (GPI) anchor biosynthesis. PIGA transfers N-acetylglucosamine (GlcNAc) from UDP-N-acetylglucosamine
+  (UDP-GlcNAc) onto phosphatidylinositol (PI) to form GlcNAc-PI (EC 2.4.1.198), a reaction
+  occurring on the cytoplasmic face of the endoplasmic reticulum membrane. PIGA is a
+  single-pass ER membrane protein with a large cytoplasmic catalytic domain (homologous
+  to bacterial GlcNAc transferases, glycosyltransferase group 1 / GT4 family) and a small
+  lumenal domain that mediates rough-ER localization. The GPI-GnT complex additionally
+  contains PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2, with PIGA as the catalytic component.
+  Somatic loss-of-function mutations of the X-linked PIGA gene in hematopoietic stem cells
+  cause paroxysmal nocturnal hemoglobinuria (PNH), through loss of GPI-anchored complement
+  regulators on blood cells; germline hypomorphic mutations cause X-linked recessive
+  multiple congenital anomalies-hypotonia-seizures syndrome 2 (MCAHS2) and related
+  neurodevelopmental disorders.
+alternative_products:
+- name: &#39;1&#39;
+  id: P37287-1
+- name: &#39;2&#39;
+  id: P37287-2
+  sequence_note: VSP_001802
+- name: &#39;3&#39;
+  id: P37287-3
+  sequence_note: VSP_043366, VSP_043367
+existing_annotations:
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: PIGA is a subunit of the GPI-GnT complex. This phylogenetically inferred
+      complex membership is directly supported by experimental studies of the human
+      complex and is a core aspect of PIGA biology.
+    action: ACCEPT
+    reason: PIGA is the catalytic subunit of the GPI-GnT complex, which comprises at
+      least PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2. The IBA call is corroborated
+      by direct experimental identification of the human complex.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: PIG-A and PIG-H are subunits of the GPI GlcNAc transferase that
+        transfers GlcNAc to PI on the cytoplasmic side of the ER.
+    - reference_id: PMID:9463366
+      supporting_text: four mammalian gene products form a protein complex in the endoplasmic
+        reticulum membrane.
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: PIGA catalyzes the first, committed step of GPI anchor biosynthesis, so
+      involvement in the GPI anchor biosynthetic process is a core biological process
+      annotation.
+    action: ACCEPT
+    reason: The catalytic first step (GlcNAc transfer to PI) initiates the GPI biosynthesis
+      pathway. This is well established experimentally and consistent with the phylogenetic
+      inference.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated
+        by transfer of N-acetylglucosamine (GlcNAc) from UDP-GlcNAc to phosphatidylinositol
+        (PI).
+- term:
+    id: GO:0017176
+    label: phosphatidylinositol N-acetylglucosaminyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: This is the exact, correct molecular function of PIGA - the catalytic subunit
+      that transfers GlcNAc from UDP-GlcNAc to phosphatidylinositol (EC 2.4.1.198).
+    action: ACCEPT
+    reason: PIGA is the catalytic component of the GPI-GnT enzyme; this specific transferase
+      activity is the core molecular function and is directly supported by biochemistry.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity
+        in vitro.
+    - reference_id: PMID:16162815
+      supporting_text: binding directly to the catalytic subunit PIG-A.
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: part_of
+  review:
+    summary: InterPro-based electronic annotation of GPI-GnT complex membership (via
+      the PIG-A/GPI3 signature IPR039507). Correct and consistent with experimental data.
+    action: ACCEPT
+    reason: The IEA mapping from the PIG-A/GPI3 InterPro entry to the GPI-GnT complex
+      is biologically correct; PIGA is an experimentally verified complex member.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: PIG-A and PIG-H are subunits of the GPI GlcNAc transferase that
+        transfers GlcNAc to PI on the cytoplasmic side of the ER.
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic (InterPro/UniPathway) annotation to the GPI anchor biosynthetic
+      process, matching the experimentally established role of PIGA.
+    action: ACCEPT
+    reason: The pathway mapping (UPA00196 GPI-anchor biosynthesis) is correct; PIGA initiates
+      this pathway.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated
+        by transfer of N-acetylglucosamine (GlcNAc) from UDP-GlcNAc to phosphatidylinositol
+        (PI).
+- term:
+    id: GO:0016757
+    label: glycosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: Generic glycosyltransferase activity from the InterPro glycosyltransferase
+      family 1 domain (IPR001296). Correct but a broad parent of the specific PIGA activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: This term is a general ancestor of the specific and experimentally supported
+      GO:0017176 (phosphatidylinositol N-acetylglucosaminyltransferase activity), which
+      is annotated separately. The generic term is not informative for PIGA&#39;s core function.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity
+        in vitro.
+- term:
+    id: GO:0017176
+    label: phosphatidylinositol N-acetylglucosaminyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic annotation of the specific catalytic activity based on the RHEA/EC
+      mapping (RHEA:14789, EC 2.4.1.198). This is the correct core molecular function.
+    action: ACCEPT
+    reason: The EC/RHEA-derived assignment matches the experimentally established catalytic
+      activity of PIGA and is the specific, informative molecular function term.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated
+        by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting
+        of at least six proteins.
+    - reference_id: file:human/PIGA/PIGA-uniprot.txt
+      supporting_text: &#34;EC=2.4.1.198&#34;
+- term:
+    id: GO:0030867
+    label: rough endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt subcellular-location keyword mapping to rough ER membrane. Correct
+      and consistent with experimental localization data.
+    action: ACCEPT
+    reason: PIGA localizes to the rough ER membrane; this specific location is experimentally
+      verified (the small lumenal domain targets it to the rough ER).
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: part of the small lumenal domain of PIG-A plays an essential functional
+        role in targeting itself to the rough ER.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:10944123
+  qualifier: enables
+  review:
+    summary: IntAct-curated binary interactions of PIGA with GPI-GnT complex components
+      (DPM2/O94777, PIGP/P57054, PIGH/Q14442, PIGQ/Q9BRB3). These reflect PIGA&#39;s role
+      as a scaffolding/catalytic member of the GPI-GnT complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The generic &#39;protein binding&#39; term is uninformative. The underlying interactions
+      are real and are the physical basis of the GPI-GnT complex, which is captured by
+      the specific GO:0000506 (GPI-GnT complex) annotation. Per curation guidelines the
+      bare protein binding IPI is not retained as a core function.
+    supported_by:
+    - reference_id: PMID:10944123
+      supporting_text: PIG-P, a 134-amino acid protein having two hydrophobic domains,
+        associates with PIG-A and GPI1.
+    - reference_id: PMID:10944123
+      supporting_text: DPM2, but not two other components of dolichol-phosphate-mannose
+        synthase, associates with GPI-GnT through interactions with PIG-A, PIG-C and GPI1.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: enables
+  review:
+    summary: IntAct-curated interactions of PIGA with GPI-GnT complex components including
+      the directly associated regulatory subunit PIGY (Q3MUY2), plus DPM2, PIGP, PIGH,
+      PIGQ. Real interactions underpinning complex assembly.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#39;protein binding&#39; is uninformative and is subsumed by the specific GPI-GnT
+      complex (GO:0000506) annotation. The interactions themselves are genuine.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: PIG-Y appeared to be directly associated with PIG-A.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: High-throughput BioPlex 3.0 AP-MS interactions of PIGA (recovering PIGP and
+      PIGH). Consistent with GPI-GnT complex membership but low information content.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic &#39;protein binding&#39; from a proteome-scale AP-MS screen; not a core function
+      term. The recovered partners are GPI-GnT complex members captured by GO:0000506.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: BioPlex suggests function, localization, and complex membership
+        for thousands of proteins.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:8900170
+  qualifier: enables
+  review:
+    summary: IntAct-curated interaction of PIGA with PIGH (Q14442), the earliest characterized
+      binary interaction within the GPI-GnT complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The PIGA-PIGH interaction is real and foundational to the complex, but the
+      generic &#39;protein binding&#39; term is uninformative and is captured by the specific
+      GPI-GnT complex (GO:0000506) annotation.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: they form a protein complex.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:9463366
+  qualifier: enables
+  review:
+    summary: IntAct-curated interaction of PIGA with PIGQ/GPI1 (Q9BRB3), a component of
+      the four-subunit GPI-GnT complex characterized in this study.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Real interaction within the GPI-GnT complex, but the generic &#39;protein binding&#39;
+      term is uninformative and subsumed by GO:0000506 (GPI-GnT complex).
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: four mammalian gene products form a protein complex in the endoplasmic
+        reticulum membrane.
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162710
+  qualifier: involved_in
+  review:
+    summary: Reactome traceable-author-statement placing PIGA in the GPI synthesis pathway.
+      Matches PIGA&#39;s established role initiating GPI anchor biosynthesis.
+    action: ACCEPT
+    reason: PIGA catalyzes the first reaction of GPI anchor biosynthesis; the Reactome
+      pathway assignment is correct and core.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated
+        by transfer of N-acetylglucosamine (GlcNAc) from UDP-GlcNAc to phosphatidylinositol
+        (PI).
+- term:
+    id: GO:0030867
+    label: rough endoplasmic reticulum membrane
+  evidence_type: EXP
+  original_reference_id: PMID:8900170
+  qualifier: located_in
+  review:
+    summary: Experimental demonstration that PIGA is an ER transmembrane protein localizing
+      to the rough ER, with its small lumenal domain required for rough-ER targeting.
+    action: ACCEPT
+    reason: Directly supported by experimental localization/topology work; the rough ER
+      membrane is a verified, specific location for PIGA.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: PIG-A is an ER transmembrane protein with a large cytoplasmic domain
+        that has homology to a bacterial GlcNAc transferase and a small lumenal domain.
+    - reference_id: PMID:8900170
+      supporting_text: part of the small lumenal domain of PIG-A plays an essential functional
+        role in targeting itself to the rough ER.
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: ComplexPortal (CPX-6502) assertion of PIGA as part of the GPI-GnT complex,
+      based on the study identifying the seven-component complex including PIGY.
+    action: ACCEPT
+    reason: PIGA is an experimentally established member (catalytic subunit) of the GPI-GnT
+      complex; complex membership is a core annotation.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated
+        by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting
+        of at least six proteins.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: located_in
+  review:
+    summary: Direct-assay localization of PIGA to the ER membrane, where the GPI-GnT complex
+      assembles and functions.
+    action: ACCEPT
+    reason: The ER membrane is the verified site of PIGA action and GPI-GnT complex assembly;
+      this is a core cellular component annotation.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: four mammalian gene products form a protein complex in the endoplasmic
+        reticulum membrane.
+- term:
+    id: GO:0008194
+    label: UDP-glycosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162730
+  qualifier: enables
+  review:
+    summary: Reactome describes the reaction as using the UDP-sugar donor UDP-GlcNAc. The
+      term correctly captures the UDP-sugar donor class but is less specific than the exact
+      enzyme activity.
+    action: MODIFY
+    reason: UDP-glycosyltransferase activity is a broad donor-class term. The specific,
+      experimentally supported activity is phosphatidylinositol N-acetylglucosaminyltransferase
+      activity (GO:0017176, EC 2.4.1.198), which uses UDP-GlcNAc as donor and PI as acceptor.
+    proposed_replacement_terms:
+    - id: GO:0017176
+      label: phosphatidylinositol N-acetylglucosaminyltransferase activity
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated
+        by transfer of N-acetylglucosamine (GlcNAc) from UDP-GlcNAc to phosphatidylinositol
+        (PI).
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: High-throughput identification of PIGA in an NK-cell membrane proteome. Only
+      confirms membrane association without specifying the organelle.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The &#39;membrane&#39; term is a very general location from a proteome-scale study;
+      PIGA&#39;s informative location is the ER membrane (GO:0005789 / GO:0030867), which is
+      annotated separately with direct evidence.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: approximately 40% of the identified proteins were predicted as plausible
+        membrane proteins.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162730
+  qualifier: located_in
+  review:
+    summary: Reactome traceable-author-statement placing the GlcNAc-PI synthesis reaction
+      (and PIGA) at the ER membrane. Consistent with direct experimental data.
+    action: ACCEPT
+    reason: The ER membrane is the verified site of the PIGA-catalyzed reaction; a core
+      cellular component annotation.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: PIG-A is an ER transmembrane protein with a large cytoplasmic domain
+        that has homology to a bacterial GlcNAc transferase and a small lumenal domain.
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: Direct-assay identification of PIGA as a component of the seven-subunit GPI-GnT
+      complex (adding PIGY as the seventh component directly associated with PIGA).
+    action: ACCEPT
+    reason: Experimentally established core complex membership; PIGA is the catalytic subunit.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: PIG-Y appeared to be directly associated with PIG-A.
+- term:
+    id: GO:0017176
+    label: phosphatidylinositol N-acetylglucosaminyltransferase activity
+  evidence_type: TAS
+  original_reference_id: PMID:16162815
+  qualifier: enables
+  review:
+    summary: Traceable-author-statement of PIGA&#39;s phosphatidylinositol N-acetylglucosaminyltransferase
+      activity, from the study establishing catalytic activity and the seven-component complex.
+    action: ACCEPT
+    reason: This is the specific, experimentally supported core molecular function of PIGA
+      (catalytic subunit; EC 2.4.1.198).
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated
+        by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting
+        of at least six proteins.
+core_functions:
+- description: Catalytic subunit of the GPI-GnT complex that transfers N-acetylglucosamine
+    from UDP-GlcNAc to phosphatidylinositol (EC 2.4.1.198), catalyzing the first committed
+    step of GPI anchor biosynthesis at the ER membrane.
+  molecular_function:
+    id: GO:0017176
+    label: phosphatidylinositol N-acetylglucosaminyltransferase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  supported_by:
+  - reference_id: PMID:16162815
+    supporting_text: Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated
+      by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting
+      of at least six proteins.
+  - reference_id: PMID:9463366
+    supporting_text: The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity
+      in vitro.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10944123
+  title: Initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-P
+    and is regulated by DPM2.
+  findings:
+  - statement: &#34;GPI-GnT requires PIG-P as an essential component and is regulated by DPM2, which associates with the complex through interactions with PIG-A, PIG-C and GPI1 and enhances enzyme activity ~3-fold.&#34;
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Establishes PIG-P and DPM2 as components/regulator of
+      the PIGA-containing GPI-GnT complex; supports the protein-binding IPI to DPM2/PIGP.
+- id: PMID:16162815
+  title: The initial enzyme for glycosylphosphatidylinositol biosynthesis requires
+    PIG-Y, a seventh component.
+  findings:
+  - statement: &#34;PIGA is the catalytic subunit of the GPI-GnT complex; PIG-Y is directly associated with PIG-A and regulates GPI-GnT activity. This study established the catalytic activity and seven-component complex (EC 2.4.1.198).&#34;
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Primary source for PIGA catalytic-subunit function,
+      EC 2.4.1.198, and the seven-component GPI-GnT complex.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings:
+  - statement: &#34;High-throughput membrane proteome of the NK-like cell line YTS; supports only a generic membrane localization for PIGA.&#34;
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: PubMed-verified proteomics survey; supports only the general membrane
+      annotation, not organelle specificity.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings:
+  - statement: &#34;BioPlex 3.0 AP-MS interactome; recovers PIGA interactions with GPI-GnT complex members (PIGP, PIGH), supporting a generic protein-binding annotation.&#34;
+    reference_section_type: DISCUSSION
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: PubMed-verified proteome-scale AP-MS; low information content for PIGA&#39;s
+      specific function beyond complex membership.
+- id: PMID:8900170
+  title: PIG-A and PIG-H, which participate in glycosylphosphatidylinositol anchor
+    biosynthesis, form a protein complex in the endoplasmic reticulum.
+  findings:
+  - statement: &#34;PIG-A is an ER transmembrane protein with a large cytoplasmic (catalytic) domain and a small lumenal domain that targets it to the rough ER; PIG-A and PIG-H form a complex and transfer GlcNAc to PI on the cytoplasmic side of the ER.&#34;
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Primary source for PIGA ER-membrane localization, topology,
+      and cytoplasmic-face catalysis.
+- id: PMID:9463366
+  title: The first step of glycosylphosphatidylinositol biosynthesis is mediated by
+    a complex of PIG-A, PIG-H, PIG-C and GPI1.
+  findings:
+  - statement: &#34;The first step of GPI biosynthesis (GlcNAc transfer from UDP-GlcNAc to PI) is mediated by an ER-membrane complex of PIG-A, PIG-H, PIG-C and GPI1 that has GPI-GnT activity in vitro.&#34;
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified. Establishes the multi-subunit GPI-GnT complex and its
+      in vitro GlcNAc-transferase activity.
+- id: Reactome:R-HSA-162710
+  title: Synthesis of glycosylphosphatidylinositol (GPI)
+  findings: []
+- id: Reactome:R-HSA-162730
+  title: phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI
+    + UDP
+  findings: []
+- id: file:human/PIGA/PIGA-uniprot.txt
+  title: UniProtKB P37287 (PIGA_HUMAN) record
+  findings:
+  - statement: &#34;Catalytic subunit of the GPI-GnT complex that catalyzes transfer of N-acetylglucosamine from UDP-N-acetylglucosamine to phosphatidylinositol (EC 2.4.1.198); rough ER membrane, single-pass membrane protein; complex composed of PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2.&#34;
+    reference_section_type: OTHER
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: UniProt curated record; primary source for EC number, catalytic activity,
+      subunit composition, and subcellular location.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGB/PIGB-ai-review.html
+++ b/genes/human/PIGB/PIGB-ai-review.html
@@ -1,0 +1,2853 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGB - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGB</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q92521" target="_blank" class="term-link">
+                        Q92521
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGB";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q92521" data-a="DESCRIPTION: PIGB (GPI alpha-1,2-mannosyltransferase 3; also ca..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGB (GPI alpha-1,2-mannosyltransferase 3; also called GPI mannosyltransferase III, GPI-MT-III) is a multi-pass endoplasmic reticulum membrane protein that acts in glycosylphosphatidylinositol (GPI) anchor biosynthesis. It is a dolichyl-phosphate-mannose (Dol-P-Man)-dependent alpha-1,2-mannosyltransferase that transfers the third mannose, via an alpha-1,2 linkage, onto the growing GPI intermediate (Man2 to Man3) in the ER lumen. This third mannose is the residue that subsequently receives the bridging ethanolamine-phosphate (added by PIGO) to which the mature protein is ultimately attached, so PIGB activity is required for building a functional protein-anchoring GPI. The catalytic domain faces the ER lumen. Biallelic loss-of-function variants cause an inherited GPI-deficiency presenting as developmental and epileptic encephalopathy (DEE80), with refractory seizures, developmental delay/intellectual disability, and variable axonal neuropathy.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGB is a multi-pass ER membrane protein and acts in the ER; the phylogenetic (IBA) is_active_in assertion of ER-membrane localization is correct and represents the core site of action.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with experimental localization of human PIG-B to the ER membrane and with UniProt subcellular location. This is the compartment where GPI-anchor mannosylation occurs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                        PMID:8861954
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ER transmembrane protein with an amino-terminal portion of approximately 60</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000026" target="_blank" class="term-link">
+                                    GO:0000026
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0000026" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGB is a Dol-P-Man-dependent alpha-1,2-mannosyltransferase; this IBA term correctly captures the alpha-1,2-mannosyltransferase molecular function at a general level. A more specific term (GO:0120564) is also present for the exact reaction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The alpha-1,2-mannosyltransferase activity is well supported experimentally and by the enzyme&#39;s Rhea catalytic activity. It is a correct, if less specific, parent of the characterized reaction; retained as a correct MF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Alpha-1,2-mannosyltransferase that catalyzes the transfer of</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the third mannose, via an alpha-1,2 bond, from a dolichol-phosphate-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGB catalyzes an essential mannosylation step in GPI-anchor biosynthesis; the phylogenetic involved_in assertion for GPI anchor biosynthetic process is correct and represents the core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by experimental characterization (transfer of the third mannose of the GPI anchor) and by the UniProt pathway assignment to glycosylphosphatidylinositol-anchor biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                        PMID:8861954
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is involved in transferring the third mannose of the GPI anchor</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping from the UniProtKB/Swiss-Prot subcellular-location vocabulary to ER membrane; matches the experimentally determined location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The UniProt SubCell mapping to endoplasmic reticulum membrane is consistent with the experimental IDA localization and with the protein&#39;s multi-pass ER topology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016757" target="_blank" class="term-link">
+                                    GO:0016757
+                                </a>
+                            </span>
+                            <span class="term-label">glycosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0016757" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-to-GO mapping (IPR005599, GPI mannosyltransferase) to the generic glycosyltransferase activity root term. Correct but uninformative relative to the specific mannosyltransferase terms already annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGB is a member of glycosyltransferase family 22 (GT22) and is a genuine glycosyltransferase, so the IEA mapping is not wrong; it is simply a broad parent of the more specific alpha-1,2-mannosyltransferase / GPI mannosyltransferase terms. Retained as a correct high-level MF (the specific terms carry the core function).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the glycosyltransferase 22 family. PIGB</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162710
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0006506" data-r="Reactome:R-HSA-162710" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable assertion that PIGB participates in GPI (glycosylphosphatidylinositol) synthesis; correct core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The Reactome pathway &#39;Synthesis of glycosylphosphatidylinositol (GPI)&#39; places PIGB in the GPI-anchor biosynthetic process, in agreement with the experimental and phylogenetic BP annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                        PMID:8861954
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is involved in transferring the third mannose of the GPI anchor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000041
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0006506" data-r="GO_REF:0000041" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniPathway (UPA00196) vocabulary mapping to GPI-anchor biosynthetic process; consistent with the UniProt pathway annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The UniPathway mapping to glycosylphosphatidylinositol-anchor biosynthesis is correct and corroborates the core biological process from multiple independent evidence lines.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004376" target="_blank" class="term-link">
+                                    GO:0004376
+                                </a>
+                            </span>
+                            <span class="term-label">GPI mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162821
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0004376" data-r="Reactome:R-HSA-162821" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable assertion (the reaction adding the third mannose of the GPI anchor) that PIGB has GPI mannosyltransferase activity; a correct family-level molecular-function term for this enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The Reactome reaction catalyzed by PIG-B (addition of the third mannose) corresponds to GPI mannosyltransferase activity. This is a correct MF, more specific than the glycosyltransferase root and consistent with the specific IDA term GO:0120564.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                        PMID:8861954
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is involved in transferring the third mannose of the GPI anchor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120564" target="_blank" class="term-link">
+                                    GO:0120564
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(2)GlcN-acyl-PI alpha-1,2-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8861954
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-B, a membrane protein of the endoplasmic reticulum with ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0120564" data-r="PMID:8861954" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported (IDA) specific molecular function - the Dol-P-Man-dependent alpha-1,2-mannosyltransferase that adds the third mannose to the Man2 GPI intermediate. This is the most precise MF term for PIGB and its core catalytic activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly matches the characterized reaction of human PIG-B (transfer of the third mannose, via an alpha-1,2 bond, from dolichol-phosphate-mannose to the GPI intermediate) and the corresponding UniProt catalytic activity (Rhea:RHEA:61004). This is the enzyme&#39;s defining function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                        PMID:8861954
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is involved in transferring the third mannose of the GPI anchor</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the third mannose, via an alpha-1,2 bond, from a dolichol-phosphate-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162821
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0005789" data-r="Reactome:R-HSA-162821" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable assertion of ER-membrane localization; consistent with the experimentally determined location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GPI-anchor mannosylation occurs at the ER membrane; the Reactome location matches the IDA and IBA ER-membrane annotations and UniProt subcellular location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8861954
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-B, a membrane protein of the endoplasmic reticulum with ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0005789" data-r="PMID:8861954" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally determined (IDA) ER-membrane localization; PIG-B is an ER transmembrane protein with its catalytic (lumenal) domain in the ER lumen. This is the core cellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Takahashi et al. showed PIG-B is an ER transmembrane protein whose functional site resides on the lumenal side of the ER membrane, directly supporting ER membrane localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                        PMID:8861954
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ER transmembrane protein with an amino-terminal portion of approximately 60</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                        PMID:8861954
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">lumenal side of the ER membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8861954
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-B, a membrane protein of the endoplasmic reticulum with ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0006506" data-r="PMID:8861954" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported (IDA) involvement in GPI-anchor biosynthesis - PIG-B was identified as the complementation-class-B gene required for transferring the third mannose of the GPI anchor. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The defining experimental finding of Takahashi et al. 1996 is that PIG-B is required for GPI-anchor biosynthesis (transfer of the third mannose), directly supporting this BP annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                        PMID:8861954
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is involved in transferring the third mannose of the GPI anchor</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                        PMID:8861954
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The GPI anchor precursor is synthesized in the endoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8861954
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-B, a membrane protein of the endoplasmic reticulum with ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92521" data-a="GO:0016020" data-r="PMID:8861954" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic &#39;membrane&#39; localization asserted (NAS) from the 1996 paper. Not wrong, but it is an uninformative parent of the specific ER-membrane annotations already present.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGB is a multi-pass ER membrane protein, so &#39;membrane&#39; is technically correct but redundant and less informative than the endoplasmic reticulum membrane (GO:0005789) annotations supported by the same and other evidence. Marked as over-annotated rather than removed because the NAS assertion is not incorrect.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                        PMID:8861954
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ER transmembrane protein with an amino-terminal portion of approximately 60</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGB/PIGB-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Dolichyl-phosphate-mannose (Dol-P-Man)-dependent alpha-1,2-mannosyltransferase (GPI mannosyltransferase III) that transfers the third mannose onto the GPI intermediate (Man2 to Man3) during GPI-anchor biosynthesis in the ER lumen.</h3>
+                <span class="vote-buttons" data-g="Q92521" data-a="FUNCTION: Dolichyl-phosphate-mannose (Dol-P-Man)-dependent a..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120564" target="_blank" class="term-link">
+                            dol-P-Man:Man(2)GlcN-acyl-PI alpha-1,2-mannosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                                PMID:8861954
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">is involved in transferring the third mannose of the GPI anchor</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGB/PIGB-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">the third mannose, via an alpha-1,2 bond, from a dolichol-phosphate-</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000041.md" target="_blank" class="term-link">
+                            GO_REF:0000041
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniPathway vocabulary mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" target="_blank" class="term-link">
+                            PMID:8861954
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-B, a membrane protein of the endoplasmic reticulum with a large lumenal domain, is involved in transferring the third mannose of the GPI anchor.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162710
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Synthesis of glycosylphosphatidylinositol (GPI)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162821
+
+                    </span>
+                </div>
+
+                <div class="reference-title">mannose (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI + dolichol phosphate D-mannose -&gt; mannose (a1-2) mannose (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI + dolichol phosphate</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGB/PIGB-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q92521 (PIGB_HUMAN)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGB-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q92521" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigb-q92521-review-notes">PIGB (Q92521) review notes</h1>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>HGNC:8959, PIGB = GPI alpha-1,2-mannosyltransferase 3; AltName GPI mannosyltransferase III (GPI-MT-III); "Phosphatidylinositol-glycan biosynthesis class B protein" (PIG-B).</li>
+<li>554 aa, multi-pass ER membrane protein. Belongs to glycosyltransferase family 22 (CAZy GT22), PIGB subfamily; Pfam PF03901 (Glyco_transf_22), InterPro IPR005599 (GPI_mannosylTrfase).</li>
+</ul>
+<h2 id="verified-function">Verified function</h2>
+<ul>
+<li>GPI mannosyltransferase III: transfers the <strong>third mannose</strong> (alpha-1,2 linked) from dolichyl-phosphate-mannose (Dol-P-Man) onto the GPI intermediate (Man2 -&gt; Man3) in the ER lumen during GPI-anchor biosynthesis.</li>
+<li>This third mannose is the residue that receives the bridging ethanolamine-phosphate (added by PIGO) to which the mature protein is ultimately attached.</li>
+<li>Original cloning/characterization: Takahashi et al. 1996 <a href="https://pubmed.ncbi.nlm.nih.gov/8861954" title="PIG-B ... is involved in transferring the third mannose of the GPI anchor">PMID:8861954</a>; abstract-only in cache (full_text_available: false). Establishes: ER transmembrane protein, ~60-aa N-terminal cytoplasmic portion, large ~470-aa C-terminal lumenal (catalytic) domain; functional site on lumenal side.</li>
+<li>UniProt CATALYTIC ACTIVITY (Rhea:RHEA:61004 and RHEA:61000): Dol-P-Man + Man2-GPI intermediate -&gt; Man3-GPI intermediate + Dol-P + H+. EC 2.4.1.- (ECO:0000305 from PubMed:17311586, 8861954).</li>
+<li>Yeast ortholog is Gpi10p (SGD:S000003110); PMID:17311586 (Wiedman et al., mcd4) provides supporting in vivo characterization of the assembly step.</li>
+</ul>
+<h2 id="goa-mf-term">GOA MF term</h2>
+<ul>
+<li>GOA carries MF terms: GO:0000026 (alpha-1,2-mannosyltransferase activity, IBA), GO:0004376 (GPI mannosyltransferase activity, TAS/Reactome), and GO:0120564 (dol-P-Man:Man(2)GlcN-acyl-PI alpha-1,2-mannosyltransferase activity, IDA PMID:8861954). GO:0120564 is the most specific and exactly matches the characterized reaction -&gt; used as the core MF in core_functions.</li>
+</ul>
+<h2 id="location">Location</h2>
+<ul>
+<li>ER membrane (GO:0005789), multi-pass. Confirmed by PMID:8861954 (IDA) and UniProt SubCell.</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>Biallelic loss-of-function causes inherited GPI-deficiency: Developmental and epileptic encephalopathy 80 (DEE80, MIM:618580) [PMID:31256876 Murakami et al. 2019] — refractory seizures, global developmental delay/ID, +/- axonal (poly)neuropathy, metabolic abnormality in severe cases. Consistent with reduced cell-surface GPI-anchored proteins.</li>
+</ul>
+<h2 id="annotation-dispositions-summary">Annotation dispositions (summary)</h2>
+<ul>
+<li>MF GO:0120564 (IDA) -&gt; ACCEPT (core).</li>
+<li>MF GO:0000026 (IBA, alpha-1,2-mannosyltransferase) -&gt; ACCEPT (correct, less specific parent of the reaction).</li>
+<li>MF GO:0004376 (TAS/Reactome, GPI mannosyltransferase) -&gt; ACCEPT (correct family-level MF).</li>
+<li>MF GO:0016757 (IEA InterPro, glycosyltransferase activity) -&gt; ACCEPT (correct but generic root MF).</li>
+<li>BP GO:0006506 x4 (IBA, TAS, IEA-UniPathway, IDA) -&gt; ACCEPT (core BP).</li>
+<li>CC GO:0005789 x4 (IBA is_active_in, IEA-SubCell, TAS, IDA) -&gt; ACCEPT (core location).</li>
+<li>CC GO:0016020 membrane (NAS PMID:8861954) -&gt; MARK_AS_OVER_ANNOTATED (subsumed by ER membrane; uninformative generic parent).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q92521
+gene_symbol: PIGB
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGB (GPI alpha-1,2-mannosyltransferase 3; also called GPI mannosyltransferase
+  III, GPI-MT-III) is a multi-pass endoplasmic reticulum membrane protein that acts
+  in glycosylphosphatidylinositol (GPI) anchor biosynthesis. It is a dolichyl-phosphate-mannose
+  (Dol-P-Man)-dependent alpha-1,2-mannosyltransferase that transfers the third mannose,
+  via an alpha-1,2 linkage, onto the growing GPI intermediate (Man2 to Man3) in the
+  ER lumen. This third mannose is the residue that subsequently receives the bridging
+  ethanolamine-phosphate (added by PIGO) to which the mature protein is ultimately
+  attached, so PIGB activity is required for building a functional protein-anchoring
+  GPI. The catalytic domain faces the ER lumen. Biallelic loss-of-function variants
+  cause an inherited GPI-deficiency presenting as developmental and epileptic encephalopathy
+  (DEE80), with refractory seizures, developmental delay/intellectual disability, and
+  variable axonal neuropathy.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000041
+  title: Gene Ontology annotation based on UniPathway vocabulary mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:8861954
+  title: PIG-B, a membrane protein of the endoplasmic reticulum with a large lumenal
+    domain, is involved in transferring the third mannose of the GPI anchor.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Original cloning and functional characterization of human PIG-B;
+      establishes ER transmembrane topology with a large lumenal (catalytic) domain
+      and its role in transferring the third mannose of the GPI anchor. Cached record
+      is abstract-only (full_text_available false), but the abstract directly supports
+      the MF, BP, and CC annotations attributed to it.
+- id: Reactome:R-HSA-162710
+  title: Synthesis of glycosylphosphatidylinositol (GPI)
+  findings: []
+- id: Reactome:R-HSA-162821
+  title: mannose (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI + dolichol
+    phosphate D-mannose -&gt; mannose (a1-2) mannose (a1-6) (ethanolamineP) mannose (a1-4)
+    glucosaminyl-acyl-PI + dolichol phosphate
+  findings: []
+- id: file:human/PIGB/PIGB-uniprot.txt
+  title: UniProtKB entry Q92521 (PIGB_HUMAN)
+  findings: []
+existing_annotations:
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: PIGB is a multi-pass ER membrane protein and acts in the ER; the phylogenetic
+      (IBA) is_active_in assertion of ER-membrane localization is correct and represents
+      the core site of action.
+    action: ACCEPT
+    reason: Consistent with experimental localization of human PIG-B to the ER membrane
+      and with UniProt subcellular location. This is the compartment where GPI-anchor
+      mannosylation occurs.
+    supported_by:
+    - reference_id: PMID:8861954
+      supporting_text: ER transmembrane protein with an amino-terminal portion of
+        approximately 60
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0000026
+    label: alpha-1,2-mannosyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: PIGB is a Dol-P-Man-dependent alpha-1,2-mannosyltransferase; this IBA
+      term correctly captures the alpha-1,2-mannosyltransferase molecular function
+      at a general level. A more specific term (GO:0120564) is also present for the
+      exact reaction.
+    action: ACCEPT
+    reason: The alpha-1,2-mannosyltransferase activity is well supported experimentally
+      and by the enzyme&#39;s Rhea catalytic activity. It is a correct, if less specific,
+      parent of the characterized reaction; retained as a correct MF.
+    supported_by:
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: Alpha-1,2-mannosyltransferase that catalyzes the transfer of
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: the third mannose, via an alpha-1,2 bond, from a dolichol-phosphate-
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: PIGB catalyzes an essential mannosylation step in GPI-anchor biosynthesis;
+      the phylogenetic involved_in assertion for GPI anchor biosynthetic process is
+      correct and represents the core biological process.
+    action: ACCEPT
+    reason: Directly supported by experimental characterization (transfer of the third
+      mannose of the GPI anchor) and by the UniProt pathway assignment to glycosylphosphatidylinositol-anchor
+      biosynthesis.
+    supported_by:
+    - reference_id: PMID:8861954
+      supporting_text: is involved in transferring the third mannose of the GPI anchor
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic mapping from the UniProtKB/Swiss-Prot subcellular-location
+      vocabulary to ER membrane; matches the experimentally determined location.
+    action: ACCEPT
+    reason: The UniProt SubCell mapping to endoplasmic reticulum membrane is consistent
+      with the experimental IDA localization and with the protein&#39;s multi-pass ER
+      topology.
+    supported_by:
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: Multi-pass membrane protein
+- term:
+    id: GO:0016757
+    label: glycosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro-to-GO mapping (IPR005599, GPI mannosyltransferase) to the generic
+      glycosyltransferase activity root term. Correct but uninformative relative to
+      the specific mannosyltransferase terms already annotated.
+    action: ACCEPT
+    reason: PIGB is a member of glycosyltransferase family 22 (GT22) and is a genuine
+      glycosyltransferase, so the IEA mapping is not wrong; it is simply a broad parent
+      of the more specific alpha-1,2-mannosyltransferase / GPI mannosyltransferase
+      terms. Retained as a correct high-level MF (the specific terms carry the core
+      function).
+    supported_by:
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: Belongs to the glycosyltransferase 22 family. PIGB
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162710
+  qualifier: involved_in
+  review:
+    summary: Reactome-traceable assertion that PIGB participates in GPI (glycosylphosphatidylinositol)
+      synthesis; correct core biological process.
+    action: ACCEPT
+    reason: The Reactome pathway &#39;Synthesis of glycosylphosphatidylinositol (GPI)&#39;
+      places PIGB in the GPI-anchor biosynthetic process, in agreement with the experimental
+      and phylogenetic BP annotations.
+    supported_by:
+    - reference_id: PMID:8861954
+      supporting_text: is involved in transferring the third mannose of the GPI anchor
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000041
+  qualifier: involved_in
+  review:
+    summary: UniPathway (UPA00196) vocabulary mapping to GPI-anchor biosynthetic process;
+      consistent with the UniProt pathway annotation.
+    action: ACCEPT
+    reason: The UniPathway mapping to glycosylphosphatidylinositol-anchor biosynthesis
+      is correct and corroborates the core biological process from multiple independent
+      evidence lines.
+    supported_by:
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor
+- term:
+    id: GO:0004376
+    label: GPI mannosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162821
+  qualifier: enables
+  review:
+    summary: Reactome-traceable assertion (the reaction adding the third mannose of
+      the GPI anchor) that PIGB has GPI mannosyltransferase activity; a correct family-level
+      molecular-function term for this enzyme.
+    action: ACCEPT
+    reason: The Reactome reaction catalyzed by PIG-B (addition of the third mannose)
+      corresponds to GPI mannosyltransferase activity. This is a correct MF, more
+      specific than the glycosyltransferase root and consistent with the specific
+      IDA term GO:0120564.
+    supported_by:
+    - reference_id: PMID:8861954
+      supporting_text: is involved in transferring the third mannose of the GPI anchor
+- term:
+    id: GO:0120564
+    label: dol-P-Man:Man(2)GlcN-acyl-PI alpha-1,2-mannosyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:8861954
+  qualifier: enables
+  review:
+    summary: Experimentally supported (IDA) specific molecular function - the Dol-P-Man-dependent
+      alpha-1,2-mannosyltransferase that adds the third mannose to the Man2 GPI intermediate.
+      This is the most precise MF term for PIGB and its core catalytic activity.
+    action: ACCEPT
+    reason: Directly matches the characterized reaction of human PIG-B (transfer of
+      the third mannose, via an alpha-1,2 bond, from dolichol-phosphate-mannose to
+      the GPI intermediate) and the corresponding UniProt catalytic activity (Rhea:RHEA:61004).
+      This is the enzyme&#39;s defining function.
+    supported_by:
+    - reference_id: PMID:8861954
+      supporting_text: is involved in transferring the third mannose of the GPI anchor
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: the third mannose, via an alpha-1,2 bond, from a dolichol-phosphate-
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162821
+  qualifier: located_in
+  review:
+    summary: Reactome-traceable assertion of ER-membrane localization; consistent
+      with the experimentally determined location.
+    action: ACCEPT
+    reason: GPI-anchor mannosylation occurs at the ER membrane; the Reactome location
+      matches the IDA and IBA ER-membrane annotations and UniProt subcellular location.
+    supported_by:
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:8861954
+  qualifier: located_in
+  review:
+    summary: Experimentally determined (IDA) ER-membrane localization; PIG-B is an
+      ER transmembrane protein with its catalytic (lumenal) domain in the ER lumen.
+      This is the core cellular location.
+    action: ACCEPT
+    reason: Takahashi et al. showed PIG-B is an ER transmembrane protein whose functional
+      site resides on the lumenal side of the ER membrane, directly supporting ER
+      membrane localization.
+    supported_by:
+    - reference_id: PMID:8861954
+      supporting_text: ER transmembrane protein with an amino-terminal portion of
+        approximately 60
+    - reference_id: PMID:8861954
+      supporting_text: lumenal side of the ER membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:8861954
+  qualifier: involved_in
+  review:
+    summary: Experimentally supported (IDA) involvement in GPI-anchor biosynthesis
+      - PIG-B was identified as the complementation-class-B gene required for transferring
+      the third mannose of the GPI anchor. Core biological process.
+    action: ACCEPT
+    reason: The defining experimental finding of Takahashi et al. 1996 is that PIG-B
+      is required for GPI-anchor biosynthesis (transfer of the third mannose), directly
+      supporting this BP annotation.
+    supported_by:
+    - reference_id: PMID:8861954
+      supporting_text: is involved in transferring the third mannose of the GPI anchor
+    - reference_id: PMID:8861954
+      supporting_text: The GPI anchor precursor is synthesized in the endoplasmic
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: NAS
+  original_reference_id: PMID:8861954
+  qualifier: located_in
+  review:
+    summary: Generic &#39;membrane&#39; localization asserted (NAS) from the 1996 paper. Not
+      wrong, but it is an uninformative parent of the specific ER-membrane annotations
+      already present.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIGB is a multi-pass ER membrane protein, so &#39;membrane&#39; is technically
+      correct but redundant and less informative than the endoplasmic reticulum membrane
+      (GO:0005789) annotations supported by the same and other evidence. Marked as
+      over-annotated rather than removed because the NAS assertion is not incorrect.
+    supported_by:
+    - reference_id: PMID:8861954
+      supporting_text: ER transmembrane protein with an amino-terminal portion of
+        approximately 60
+    - reference_id: file:human/PIGB/PIGB-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+core_functions:
+- description: Dolichyl-phosphate-mannose (Dol-P-Man)-dependent alpha-1,2-mannosyltransferase
+    (GPI mannosyltransferase III) that transfers the third mannose onto the GPI intermediate
+    (Man2 to Man3) during GPI-anchor biosynthesis in the ER lumen.
+  molecular_function:
+    id: GO:0120564
+    label: dol-P-Man:Man(2)GlcN-acyl-PI alpha-1,2-mannosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:8861954
+    supporting_text: is involved in transferring the third mannose of the GPI anchor
+  - reference_id: file:human/PIGB/PIGB-uniprot.txt
+    supporting_text: the third mannose, via an alpha-1,2 bond, from a dolichol-phosphate-
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGC/PIGC-ai-review.html
+++ b/genes/human/PIGC/PIGC-ai-review.html
@@ -1,0 +1,3356 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGC - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGC</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q92535" target="_blank" class="term-link">
+                        Q92535
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGC";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q92535" data-a="DESCRIPTION: PIGC (phosphatidylinositol N-acetylglucosaminyltra..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGC (phosphatidylinositol N-acetylglucosaminyltransferase subunit C; also known as GPI2) is a multi-pass endoplasmic reticulum membrane protein that is a required, non-catalytic subunit of the glycosylphosphatidylinositol N-acetylglucosaminyltransferase (GPI-GnT) complex. This complex catalyzes the first committed step of GPI-anchor biosynthesis: transfer of N-acetylglucosamine from UDP-N-acetylglucosamine onto phosphatidylinositol to form GlcNAc-PI. Within the complex the catalytic subunit is PIGA; PIGC is one of the accessory/structural subunits, alongside PIGH, PIGP, PIGQ (GPI1), PIGY and the regulatory factor DPM2. PIGC is the human homologue of Saccharomyces cerevisiae Gpi2. Loss-of-function variants in PIGC cause an autosomal recessive inherited GPI-deficiency disorder (glycosylphosphatidylinositol biosynthesis defect 16, GPIBD16) presenting as a developmental and epileptic encephalopathy with global developmental delay, intellectual disability and seizures, reflecting reduced cell-surface expression of GPI-anchored proteins.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GPI anchor biosynthetic process is the core biological process of PIGC as a subunit of the GPI-GnT complex that performs the first step of GPI-anchor biosynthesis. The IBA (phylogenetic) call is consistent with the experimental literature and with the well-conserved role of the yeast orthologue GPI2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by the demonstrated role of PIG-C in the first, committed step of GPI biosynthesis and conserved across the PIGC/GPI2 family. This is the core function of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8806613" target="_blank" class="term-link">
+                                        PMID:8806613
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mediated by at least three genes in mammalian cells (PIG-A, PIG-H and PIG-C)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0000506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGC is a component of the GPI-GnT complex. The IBA assignment of complex membership is well supported by direct experimental evidence in human cells and by conservation of the complex across eukaryotes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Complex membership is directly demonstrated experimentally (see PMID:9463366, PMID:10944123, PMID:16162815) and the phylogenetic inference is consistent with this. This is a core aspect of PIGC&#39;s biology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGC localizes to the endoplasmic reticulum membrane, where the GPI-GnT complex operates. This IEA call (from the UniProt subcellular-location mapping) agrees with direct experimental evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ER-membrane localization is experimentally established (PMID:8806613, PMID:16162815) and matches the UniProt subcellular location; the mapping is correct and specific.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGC/PIGC-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic assignment (InterPro IPR009450 / UniPathway UPA00196) of the core GPI-anchor biosynthetic process. Consistent with the experimental and IBA evidence; correct and appropriately specific.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro/UniPathway-driven mapping correctly reflects PIGC&#39;s role in the first step of GPI biosynthesis. This is a duplicate of the core BP call from other evidence sources.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8806613" target="_blank" class="term-link">
+                                        PMID:8806613
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mediated by at least three genes in mammalian cells (PIG-A, PIG-H and PIG-C)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic &#34;membrane&#34; localization from the InterPro-to-GO mapping. Not wrong (PIGC is a multi-pass membrane protein) but far less informative than the specific and experimentally supported endoplasmic reticulum membrane term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by the more specific and better-supported GO:0005789 (endoplasmic reticulum membrane). The bare &#34;membrane&#34; term adds no specificity beyond what the ER-membrane annotation already conveys.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGC/PIGC-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10944123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Initial enzyme for glycosylphosphatidylinositol biosynthesis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0005515" data-r="PMID:10944123" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI annotation recording a physical interaction between PIGC and DPM2 (UniProtKB:O94777). This reflects PIGC&#39;s participation in the GPI-GnT complex, where DPM2 associates through interactions with PIG-A, PIG-C and GPI1, but the bare &#34;protein binding&#34; term is uninformative about molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, GO:0005515 &#34;protein binding&#34; is too generic to convey function. The biologically meaningful content of this interaction (membership of the GPI-GnT complex) is already captured by GO:0000506. Retained but marked as over-annotated rather than removed, as the IntAct interaction itself is valid.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">associates with GPI-GnT through interactions with PIG-A, PIG-C and</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9463366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The first step of glycosylphosphatidylinositol biosynthesis ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0005515" data-r="PMID:9463366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct IPI annotation recording a physical interaction between PIGC and PIGQ (GPI1; UniProtKB:Q9BRB3). Consistent with PIGC and GPI1 co-assembling in the GPI-GnT complex, but the bare &#34;protein binding&#34; term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic &#34;protein binding&#34; is discouraged as uninformative. The functional significance (PIGC&#39;s assembly into the GPI-GnT complex with PIGA, PIGH, PIGC and GPI1) is already represented by the GPI-GnT complex annotation (GO:0000506).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal assignment of PIGC to the GPI-GnT complex based on the seven-component complex characterized in this study. Core, well-supported cellular-component annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PMID:16162815 defines the GPI-GnT complex composition (PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY, DPM2) with PIG-A as the catalytic subunit; PIGC is a bona fide component. Core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the catalytic subunit PIG-A</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0005789" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence places PIGC (with the GPI-GnT complex) in the endoplasmic reticulum membrane. Core, well-supported localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GPI-GnT complex containing PIGC is an ER-membrane complex; ER-membrane localization is directly demonstrated and is the site of PIGC function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (co-precipitation / reconstitution) that PIGC is part of the GPI-GnT complex. Duplicate of the ComplexPortal and IBA complex calls; core cellular-component annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally demonstrated membership of the seven-component GPI-GnT complex. This is a core aspect of PIGC&#39;s biology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the catalytic subunit PIG-A</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0006506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence for PIGC&#39;s involvement in GPI-anchor biosynthesis via the GPI-GnT complex that performs the first step of the pathway. Core BP.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGC is required for the initial GPI-GnT reaction; loss of complex components abolishes surface GPI-anchored protein expression. Core function of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in vitro</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27694521" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27694521
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in the phosphatidylinositol glycan C (PIGC) gene a...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0006506" data-r="PMID:27694521" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Patient-derived and engineered PIGC variants (L189W; L212P/R21X) reduce surface expression of GPI-anchored proteins, providing mutational (IMP) evidence that PIGC is required for GPI-anchor biosynthesis. Core BP.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Loss-of-function PIGC variants cause a GPI-deficiency disorder (GPIBD16) with reduced surface GPI-anchored protein expression, directly supporting PIGC&#39;s requirement for the GPI-anchor biosynthetic process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27694521" target="_blank" class="term-link">
+                                        PMID:27694521
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGC joins the list of genes in which mutations result in defective</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27694521" target="_blank" class="term-link">
+                                        PMID:27694521
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">reduction of surface expression of GPI-anchored proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162730
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0005789" data-r="Reactome:R-HSA-162730" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author statement placing the first-step GPI reaction (and its multimeric enzyme, including PIGC) in the endoplasmic reticulum membrane. Consistent with the direct experimental localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicate of the experimentally supported ER-membrane localization; correct and specific. Core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10944123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Initial enzyme for glycosylphosphatidylinositol biosynthesis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0000506" data-r="PMID:10944123" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that PIGC is part of the GPI-GnT complex, here characterized as consisting of at least PIG-A, PIG-H, PIG-C and GPI1 (plus PIG-P and the regulator DPM2). Core cellular-component annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PMID:10944123 experimentally defines the GPI-GnT complex including PIG-C. Consistent with all other complex-membership annotations; core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-A, PIG-H, PIG-C and GPI1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003824" target="_blank" class="term-link">
+                                    GO:0003824
+                                </a>
+                            </span>
+                            <span class="term-label">catalytic activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8806613" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8806613
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-C, one of the three human genes involved in the first st...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0003824" data-r="PMID:8806613" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Legacy TAS (ProtInc, 2003) annotation of the very general term &#34;catalytic activity&#34;. The catalytic activity of the GPI-GnT complex resides in the PIG-A subunit; PIGC is a required accessory/structural subunit and is not itself the catalytic component. The broad &#34;catalytic activity&#34; term is therefore an over-annotation for this subunit and is uninformative even as a complex-level statement.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGC is a non-catalytic subunit: PMID:16162815 explicitly identifies PIG-A as &#34;the catalytic subunit&#34;. Assigning the root-level &#34;catalytic activity&#34; molecular function to PIGC overstates and mis-locates the enzymatic activity, which belongs to PIGA / the complex as a whole. The GOA carries no PIGC-specific glycosyltransferase MF, so no replacement molecular-function term is proposed for this subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the catalytic subunit PIG-A</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8806613" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8806613
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-C, one of the three human genes involved in the first st...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0005789" data-r="PMID:8806613" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author statement (original cloning paper) that PIG-C is an ER membrane protein. Consistent with the direct experimental and IEA localization. Core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The original characterization describes PIG-C as a 297-residue membrane protein in the endoplasmic reticulum, matching all other localization evidence. Core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8806613" target="_blank" class="term-link">
+                                        PMID:8806613
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mediated by at least three genes in mammalian cells (PIG-A, PIG-H and PIG-C)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8806613" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8806613
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-C, one of the three human genes involved in the first st...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q92535" data-a="GO:0006506" data-r="PMID:8806613" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author statement that PIG-C is one of the genes involved in the first step of GPI-anchor biosynthesis. Core BP; duplicate of the other GPI-anchor biosynthesis annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cloning study assigns PIG-C to the first step of GPI biosynthesis, matching the IBA, IEA, IDA and IMP evidence. This is the core function of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8806613" target="_blank" class="term-link">
+                                        PMID:8806613
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mediated by at least three genes in mammalian cells (PIG-A, PIG-H and PIG-C)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Non-catalytic subunit of the GPI-GnT complex that is required for the first committed step of GPI-anchor biosynthesis (GlcNAc transfer from UDP-GlcNAc onto phosphatidylinositol), acting in the endoplasmic reticulum membrane. The catalytic activity resides in the PIGA subunit, so no independent catalytic molecular function is assigned to PIGC.</h3>
+                <span class="vote-buttons" data-g="Q92535" data-a="FUNCTION: Non-catalytic subunit of the GPI-GnT complex that ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                            glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGC/PIGC-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">acetylglucosaminyltransferase (GPI-GnT) complex that catalyzes the</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                PMID:9463366
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in vitro</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                PMID:16162815
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the catalytic subunit PIG-A</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                            PMID:10944123
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-P and is regulated by DPM2.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                            PMID:16162815
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-Y, a seventh component.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27694521" target="_blank" class="term-link">
+                            PMID:27694521
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in the phosphatidylinositol glycan C (PIGC) gene are associated with epilepsy and intellectual disability.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8806613" target="_blank" class="term-link">
+                            PMID:8806613
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-C, one of the three human genes involved in the first step of glycosylphosphatidylinositol biosynthesis is a homologue of Saccharomyces cerevisiae GPI2.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                            PMID:9463366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The first step of glycosylphosphatidylinositol biosynthesis is mediated by a complex of PIG-A, PIG-H, PIG-C and GPI1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162730
+
+                    </span>
+                </div>
+
+                <div class="reference-title">phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI + UDP</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGC/PIGC-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry PIGC_HUMAN (Q92535)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGC-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q92535" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigc-q92535-review-notes">PIGC (Q92535) review notes</h1>
+<p>Human PIGC / phosphatidylinositol N-acetylglucosaminyltransferase subunit C (HGNC:8960; synonym GPI2).<br />
+297 aa, multi-pass ER membrane protein (8 predicted TM helices per UniProt FT).</p>
+<h2 id="core-biology">Core biology</h2>
+<p>PIGC is a required, <strong>non-catalytic accessory subunit</strong> of the GPI-GlcNAc transferase<br />
+(GPI-GnT) complex, which catalyses the <strong>first committed step of GPI-anchor biosynthesis</strong>:<br />
+transfer of GlcNAc from UDP-GlcNAc onto phosphatidylinositol (PI) to give GlcNAc-PI, in the<br />
+ER membrane. PIGA is the catalytic subunit; the complex also contains PIGH, PIGP, PIGQ (GPI1),<br />
+PIGY and DPM2.</p>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/8806613" title="The first step of the biosynthesis, the transfer of N-acetylglucosamine from UDP-N-acetylglucosamine to phosphatidylinositol, is mediated by at least three genes in mammalian cells (PIG-A, PIG-H and PIG-C)">PMID:8806613</a> — cloning of PIG-C as a human homologue of yeast GPI2; "PIG-C protein is a 297 amino-acid membrane protein in the endoplasmic reticulum".</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/9463366" title="four mammalian gene products form a protein complex in the endoplasmic reticulum membrane. ... The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in vitro">PMID:9463366</a> — PIG-A, PIG-H, PIG-C and GPI1 (PIGQ) form the ER-membrane complex with GPI-GnT activity. IntAct IPI here is PIGC–PIGQ (Q9BRB3).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/10944123" title="GPI-GnT ... consisting of at least four proteins, PIG-A, PIG-H, PIG-C and GPI1 ... DPM2 ... associates with GPI-GnT through interactions with PIG-A, PIG-C and GPI1">PMID:10944123</a> — adds PIG-P and DPM2. IntAct IPI here is PIGC–DPM2 (O94777).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16162815" title="human GPI-GnT requires another component, termed PIG-Y ... A complex of six components was formed without PIG-Y ... PIG-A ... the catalytic subunit PIG-A">PMID:16162815</a> — seventh component PIG-Y; explicitly names PIG-A as the catalytic subunit (so PIGC is accessory, not catalytic).</li>
+</ul>
+<h2 id="molecular-function-in-goa">Molecular function in GOA</h2>
+<p>GOA carries only <strong>GO:0005515 protein binding</strong> (IPI, IntAct, x2: DPM2 and PIGQ) and a legacy<br />
+<strong>GO:0003824 catalytic activity</strong> (TAS, ProtInc, from PMID:8806613, dated 2003). There is NO<br />
+specific glycosyltransferase MF term for PIGC in the GOA. Given PIGA is the catalytic subunit<br />
+and PIGC is an accessory/structural subunit, the broad "catalytic activity" is an<br />
+over-annotation for this subunit (the catalytic activity belongs to the complex/PIGA). Per<br />
+project policy I do not invent a catalytic MF; core_functions omits <code>function</code> and records the<br />
+BP + location + complex membership.</p>
+<h2 id="localization">Localization</h2>
+<p>ER membrane, multi-pass. <a href="https://pubmed.ncbi.nlm.nih.gov/8806613" title="membrane protein in the endoplasmic reticulum">PMID:8806613</a>;<br />
+UniProt SUBCELLULAR LOCATION "Endoplasmic reticulum membrane ... Multi-pass membrane protein".</p>
+<h2 id="disease">Disease</h2>
+<p>Autosomal recessive GPI biosynthesis defect 16 (GPIBD16; MIM 617816): global developmental<br />
+delay, intellectual disability, drug-responsive seizures — an inherited GPI-deficiency /<br />
+epileptic-encephalopathy phenotype.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/27694521" title="PIGC joins the list of genes in which mutations result in defective biosynthesis of GPI anchoring, manifesting by global developmental delay and seizure disorder">PMID:27694521</a>; patient variants (L189W; L212P/R21X) reduce surface expression of GPI-anchored proteins (IMP for GPI anchor biosynthetic process).</p>
+<h2 id="annotation-dispositions-summary">Annotation dispositions (summary)</h2>
+<ul>
+<li>GPI anchor biosynthetic process (GO:0006506): core BP. Kept across IBA/IEA/IDA/IMP/TAS.</li>
+<li>GPI-GnT complex (GO:0000506): core CC. Kept across IBA/IPI/IDA.</li>
+<li>ER membrane (GO:0005789): core CC. Kept across IEA/IDA/TAS.</li>
+<li>membrane (GO:0016020, IEA InterPro): correct but generic vs ER membrane -&gt; MARK_AS_OVER_ANNOTATED.</li>
+<li>protein binding (GO:0005515, IPI x2): uninformative bare term -&gt; MARK_AS_OVER_ANNOTATED (real content is complex membership, captured by GO:0000506).</li>
+<li>catalytic activity (GO:0003824, TAS): over-annotation for accessory subunit (PIGA is catalytic) -&gt; MARK_AS_OVER_ANNOTATED.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q92535
+gene_symbol: PIGC
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PIGC (phosphatidylinositol N-acetylglucosaminyltransferase subunit C; also known
+  as GPI2) is a multi-pass endoplasmic reticulum membrane protein that is a required,
+  non-catalytic subunit of the glycosylphosphatidylinositol N-acetylglucosaminyltransferase
+  (GPI-GnT) complex. This complex catalyzes the first committed step of GPI-anchor
+  biosynthesis: transfer of N-acetylglucosamine from UDP-N-acetylglucosamine onto
+  phosphatidylinositol to form GlcNAc-PI. Within the complex the catalytic subunit
+  is PIGA; PIGC is one of the accessory/structural subunits, alongside PIGH, PIGP,
+  PIGQ (GPI1), PIGY and the regulatory factor DPM2. PIGC is the human homologue of
+  Saccharomyces cerevisiae Gpi2. Loss-of-function variants in PIGC cause an autosomal
+  recessive inherited GPI-deficiency disorder (glycosylphosphatidylinositol biosynthesis
+  defect 16, GPIBD16) presenting as a developmental and epileptic encephalopathy with
+  global developmental delay, intellectual disability and seizures, reflecting reduced
+  cell-surface expression of GPI-anchored proteins.
+existing_annotations:
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      GPI anchor biosynthetic process is the core biological process of PIGC as a
+      subunit of the GPI-GnT complex that performs the first step of GPI-anchor
+      biosynthesis. The IBA (phylogenetic) call is consistent with the experimental
+      literature and with the well-conserved role of the yeast orthologue GPI2.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by the demonstrated role of PIG-C in the first, committed
+      step of GPI biosynthesis and conserved across the PIGC/GPI2 family. This is
+      the core function of the gene.
+    supported_by:
+    - reference_id: PMID:8806613
+      supporting_text: mediated by at least three genes in mammalian cells (PIG-A, PIG-H and PIG-C)
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      PIGC is a component of the GPI-GnT complex. The IBA assignment of complex
+      membership is well supported by direct experimental evidence in human cells
+      and by conservation of the complex across eukaryotes.
+    action: ACCEPT
+    reason: &gt;-
+      Complex membership is directly demonstrated experimentally (see PMID:9463366,
+      PMID:10944123, PMID:16162815) and the phylogenetic inference is consistent
+      with this. This is a core aspect of PIGC&#39;s biology.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: four mammalian gene products form a protein complex in the endoplasmic reticulum membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      PIGC localizes to the endoplasmic reticulum membrane, where the GPI-GnT complex
+      operates. This IEA call (from the UniProt subcellular-location mapping) agrees
+      with direct experimental evidence.
+    action: ACCEPT
+    reason: &gt;-
+      The ER-membrane localization is experimentally established (PMID:8806613,
+      PMID:16162815) and matches the UniProt subcellular location; the mapping is
+      correct and specific.
+    supported_by:
+    - reference_id: file:human/PIGC/PIGC-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic assignment (InterPro IPR009450 / UniPathway UPA00196) of the core
+      GPI-anchor biosynthetic process. Consistent with the experimental and IBA
+      evidence; correct and appropriately specific.
+    action: ACCEPT
+    reason: &gt;-
+      The InterPro/UniPathway-driven mapping correctly reflects PIGC&#39;s role in the
+      first step of GPI biosynthesis. This is a duplicate of the core BP call from
+      other evidence sources.
+    supported_by:
+    - reference_id: PMID:8806613
+      supporting_text: mediated by at least three genes in mammalian cells (PIG-A, PIG-H and PIG-C)
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Generic &#34;membrane&#34; localization from the InterPro-to-GO mapping. Not wrong
+      (PIGC is a multi-pass membrane protein) but far less informative than the
+      specific and experimentally supported endoplasmic reticulum membrane term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Subsumed by the more specific and better-supported GO:0005789 (endoplasmic
+      reticulum membrane). The bare &#34;membrane&#34; term adds no specificity beyond what
+      the ER-membrane annotation already conveys.
+    supported_by:
+    - reference_id: file:human/PIGC/PIGC-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:10944123
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI annotation recording a physical interaction between PIGC and DPM2
+      (UniProtKB:O94777). This reflects PIGC&#39;s participation in the GPI-GnT complex,
+      where DPM2 associates through interactions with PIG-A, PIG-C and GPI1, but the
+      bare &#34;protein binding&#34; term is uninformative about molecular function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Per curation guidelines, GO:0005515 &#34;protein binding&#34; is too generic to convey
+      function. The biologically meaningful content of this interaction (membership
+      of the GPI-GnT complex) is already captured by GO:0000506. Retained but marked
+      as over-annotated rather than removed, as the IntAct interaction itself is valid.
+    supported_by:
+    - reference_id: PMID:10944123
+      supporting_text: associates with GPI-GnT through interactions with PIG-A, PIG-C and
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:9463366
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IntAct IPI annotation recording a physical interaction between PIGC and PIGQ
+      (GPI1; UniProtKB:Q9BRB3). Consistent with PIGC and GPI1 co-assembling in the
+      GPI-GnT complex, but the bare &#34;protein binding&#34; term is uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic &#34;protein binding&#34; is discouraged as uninformative. The functional
+      significance (PIGC&#39;s assembly into the GPI-GnT complex with PIGA, PIGH, PIGC
+      and GPI1) is already represented by the GPI-GnT complex annotation (GO:0000506).
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: four mammalian gene products form a protein complex in the endoplasmic reticulum membrane
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      ComplexPortal assignment of PIGC to the GPI-GnT complex based on the seven-component
+      complex characterized in this study. Core, well-supported cellular-component
+      annotation.
+    action: ACCEPT
+    reason: &gt;-
+      PMID:16162815 defines the GPI-GnT complex composition (PIGA, PIGC, PIGH, PIGP,
+      PIGQ, PIGY, DPM2) with PIG-A as the catalytic subunit; PIGC is a bona fide
+      component. Core function.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: the catalytic subunit PIG-A
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence places PIGC (with the GPI-GnT complex) in the
+      endoplasmic reticulum membrane. Core, well-supported localization.
+    action: ACCEPT
+    reason: &gt;-
+      The GPI-GnT complex containing PIGC is an ER-membrane complex; ER-membrane
+      localization is directly demonstrated and is the site of PIGC function.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: four mammalian gene products form a protein complex in the endoplasmic reticulum membrane
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct experimental evidence (co-precipitation / reconstitution) that PIGC is
+      part of the GPI-GnT complex. Duplicate of the ComplexPortal and IBA complex
+      calls; core cellular-component annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally demonstrated membership of the seven-component GPI-GnT complex.
+      This is a core aspect of PIGC&#39;s biology.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: the catalytic subunit PIG-A
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence for PIGC&#39;s involvement in GPI-anchor biosynthesis
+      via the GPI-GnT complex that performs the first step of the pathway. Core BP.
+    action: ACCEPT
+    reason: &gt;-
+      PIGC is required for the initial GPI-GnT reaction; loss of complex components
+      abolishes surface GPI-anchored protein expression. Core function of the gene.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in vitro
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:27694521
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Patient-derived and engineered PIGC variants (L189W; L212P/R21X) reduce surface
+      expression of GPI-anchored proteins, providing mutational (IMP) evidence that
+      PIGC is required for GPI-anchor biosynthesis. Core BP.
+    action: ACCEPT
+    reason: &gt;-
+      Loss-of-function PIGC variants cause a GPI-deficiency disorder (GPIBD16) with
+      reduced surface GPI-anchored protein expression, directly supporting PIGC&#39;s
+      requirement for the GPI-anchor biosynthetic process.
+    supported_by:
+    - reference_id: PMID:27694521
+      supporting_text: PIGC joins the list of genes in which mutations result in defective
+    - reference_id: PMID:27694521
+      supporting_text: reduction of surface expression of GPI-anchored proteins
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162730
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author statement placing the first-step GPI reaction (and
+      its multimeric enzyme, including PIGC) in the endoplasmic reticulum membrane.
+      Consistent with the direct experimental localization.
+    action: ACCEPT
+    reason: &gt;-
+      Duplicate of the experimentally supported ER-membrane localization; correct
+      and specific. Core localization.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: four mammalian gene products form a protein complex in the endoplasmic reticulum membrane
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IDA
+  original_reference_id: PMID:10944123
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct experimental evidence that PIGC is part of the GPI-GnT complex, here
+      characterized as consisting of at least PIG-A, PIG-H, PIG-C and GPI1 (plus
+      PIG-P and the regulator DPM2). Core cellular-component annotation.
+    action: ACCEPT
+    reason: &gt;-
+      PMID:10944123 experimentally defines the GPI-GnT complex including PIG-C.
+      Consistent with all other complex-membership annotations; core function.
+    supported_by:
+    - reference_id: PMID:10944123
+      supporting_text: PIG-A, PIG-H, PIG-C and GPI1
+- term:
+    id: GO:0003824
+    label: catalytic activity
+  evidence_type: TAS
+  original_reference_id: PMID:8806613
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Legacy TAS (ProtInc, 2003) annotation of the very general term &#34;catalytic
+      activity&#34;. The catalytic activity of the GPI-GnT complex resides in the PIG-A
+      subunit; PIGC is a required accessory/structural subunit and is not itself the
+      catalytic component. The broad &#34;catalytic activity&#34; term is therefore an
+      over-annotation for this subunit and is uninformative even as a complex-level
+      statement.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      PIGC is a non-catalytic subunit: PMID:16162815 explicitly identifies PIG-A as
+      &#34;the catalytic subunit&#34;. Assigning the root-level &#34;catalytic activity&#34; molecular
+      function to PIGC overstates and mis-locates the enzymatic activity, which belongs
+      to PIGA / the complex as a whole. The GOA carries no PIGC-specific glycosyltransferase
+      MF, so no replacement molecular-function term is proposed for this subunit.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: the catalytic subunit PIG-A
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: PMID:8806613
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Traceable-author statement (original cloning paper) that PIG-C is an ER membrane
+      protein. Consistent with the direct experimental and IEA localization. Core.
+    action: ACCEPT
+    reason: &gt;-
+      The original characterization describes PIG-C as a 297-residue membrane protein
+      in the endoplasmic reticulum, matching all other localization evidence. Core
+      localization.
+    supported_by:
+    - reference_id: PMID:8806613
+      supporting_text: mediated by at least three genes in mammalian cells (PIG-A, PIG-H and PIG-C)
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: TAS
+  original_reference_id: PMID:8806613
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Traceable-author statement that PIG-C is one of the genes involved in the first
+      step of GPI-anchor biosynthesis. Core BP; duplicate of the other GPI-anchor
+      biosynthesis annotations.
+    action: ACCEPT
+    reason: &gt;-
+      The cloning study assigns PIG-C to the first step of GPI biosynthesis, matching
+      the IBA, IEA, IDA and IMP evidence. This is the core function of the gene.
+    supported_by:
+    - reference_id: PMID:8806613
+      supporting_text: mediated by at least three genes in mammalian cells (PIG-A, PIG-H and PIG-C)
+core_functions:
+- description: &gt;-
+    Non-catalytic subunit of the GPI-GnT complex that is required for the first
+    committed step of GPI-anchor biosynthesis (GlcNAc transfer from UDP-GlcNAc onto
+    phosphatidylinositol), acting in the endoplasmic reticulum membrane. The catalytic
+    activity resides in the PIGA subunit, so no independent catalytic molecular function
+    is assigned to PIGC.
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  supported_by:
+  - reference_id: file:human/PIGC/PIGC-uniprot.txt
+    supporting_text: acetylglucosaminyltransferase (GPI-GnT) complex that catalyzes the
+  - reference_id: PMID:9463366
+    supporting_text: The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in vitro
+  - reference_id: PMID:16162815
+    supporting_text: the catalytic subunit PIG-A
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10944123
+  title: Initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-P
+    and is regulated by DPM2.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache. Defines the GPI-GnT complex as PIG-A, PIG-H, PIG-C and
+      GPI1 plus PIG-P, with DPM2 associating through PIG-A, PIG-C and GPI1; supports
+      PIGC complex membership and the PIGC-DPM2 IntAct interaction.
+- id: PMID:16162815
+  title: The initial enzyme for glycosylphosphatidylinositol biosynthesis requires
+    PIG-Y, a seventh component.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache. Characterizes the seven-component GPI-GnT complex and
+      explicitly names PIG-A as the catalytic subunit, confirming PIGC is an accessory
+      (non-catalytic) subunit.
+- id: PMID:27694521
+  title: Mutations in the phosphatidylinositol glycan C (PIGC) gene are associated
+    with epilepsy and intellectual disability.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache. Patient and engineered PIGC variants reduce surface
+      expression of GPI-anchored proteins, establishing PIGC deficiency as a GPI
+      biosynthesis defect (GPIBD16) with developmental delay and seizures.
+- id: PMID:8806613
+  title: PIG-C, one of the three human genes involved in the first step of glycosylphosphatidylinositol
+    biosynthesis is a homologue of Saccharomyces cerevisiae GPI2.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only cache. Original cloning of human PIG-C as a homologue of yeast
+      GPI2; places PIG-C in the first step of GPI biosynthesis and as an ER membrane
+      protein.
+- id: PMID:9463366
+  title: The first step of glycosylphosphatidylinositol biosynthesis is mediated by
+    a complex of PIG-A, PIG-H, PIG-C and GPI1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full abstract cached. Demonstrates that PIG-A, PIG-H, PIG-C and GPI1 form an
+      ER-membrane complex with GPI-GlcNAc transferase activity; supports PIGC complex
+      membership and the PIGC-PIGQ(GPI1) interaction.
+- id: Reactome:R-HSA-162730
+  title: phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI
+    + UDP
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reactome reaction for the first GPI step in the ER membrane, catalyzed by the
+      multimeric enzyme that includes PIGC. Supports the ER-membrane localization.
+- id: file:human/PIGC/PIGC-uniprot.txt
+  title: UniProtKB entry PIGC_HUMAN (Q92535)
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      UniProt record: FUNCTION (part of the GPI-GnT complex catalyzing GlcNAc transfer
+      to PI, first step of GPI biosynthesis), SUBCELLULAR LOCATION (ER membrane,
+      multi-pass), SUBUNIT (PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY, DPM2) and disease
+      (GPIBD16).
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGH/PIGH-ai-review.html
+++ b/genes/human/PIGH/PIGH-ai-review.html
@@ -1,0 +1,3609 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGH - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGH</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q14442" target="_blank" class="term-link">
+                        Q14442
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGH";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q14442" data-a="DESCRIPTION: PIGH (phosphatidylinositol N-acetylglucosaminyltra..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGH (phosphatidylinositol N-acetylglucosaminyltransferase subunit H, PIG-H) is a non-catalytic subunit of the glycosylphosphatidylinositol N-acetylglucosaminyltransferase (GPI-GnT) complex, the endoplasmic reticulum enzyme that carries out the first committed step of GPI-anchor biosynthesis. In this step the complex transfers N-acetylglucosamine from UDP-GlcNAc onto phosphatidylinositol to generate GlcNAc-PI on the cytoplasmic face of the ER. The catalytic subunit is PIGA; PIGH is one of the required accessory subunits, and the assembled complex contains at least PIGA, PIGC, PIGH, PIGP, PIGQ (GPI1), PIGY and DPM2. PIGH is an endoplasmic reticulum membrane protein. Biallelic loss-of-function variants in PIGH cause an inherited glycosylphosphatidylinositol-deficiency disorder (GPI biosynthesis defect 17, GPIBD17), a developmental and epileptic encephalopathy featuring developmental delay, seizures, microcephaly and autistic features.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0000506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGH is a subunit of the GPI-GnT complex. This phylogenetically inferred annotation matches the extensive experimental evidence that PIGH is a component of the multi-subunit GPI-GlcNAc transferase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, well-supported cellular component. PIGH is one of the accessory subunits of the GPI-GnT complex, consistent with the IBA inference and with the experimental complex-membership annotations below.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGH participates in GPI anchor biosynthesis as a subunit of the GPI-GnT complex that catalyzes the first step (GlcNAc transfer to phosphatidylinositol).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process. The phylogenetic inference agrees with the experimental evidence that the PIGH-containing complex performs the first step of GPI-anchor biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">N-acetylglucosamine (GlcNAc) to PI from UDP-GlcNAc to generate GlcNAc-PI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0000506" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO maps the PIG-H InterPro signature (IPR044215) to the GPI-GnT complex. This is consistent with PIGH being a dedicated subunit of that complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct electronic inference; PIGH&#39;s family signature is specific to the GPI-GnT complex subunit, so the CC mapping is appropriate and redundant with the experimental annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation from the UniProt subcellular-location vocabulary places PIGH at the ER membrane, matching the curated UniProt location and the experimental EXP/IDA annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization. PIGH is an ER membrane protein (UniProt models it as a multi-pass ER membrane protein); this IEA is redundant with the experimental ER-membrane annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGH/PIGH-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Combined automated methods (InterPro/UniPathway UPA00196) assign PIGH to GPI-anchor biosynthesis, matching its curated role as a GPI-GnT complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct electronic inference, redundant with the experimental and phylogenetic BP annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">N-acetylglucosamine (GlcNAc) to PI from UDP-GlcNAc to generate GlcNAc-PI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10944123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Initial enzyme for glycosylphosphatidylinositol biosynthesis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005515" data-r="PMID:10944123" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-derived binding annotation (with PIGA, UniProtKB:P37287). The biologically meaningful content is that PIGH is a subunit of the GPI-GnT complex, which is already captured by the GPI-GnT complex CC term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative as a molecular function. The underlying interaction reflects PIGH&#39;s membership in the GPI-GnT complex, which is better represented by the complex CC annotation (GO:0000506). Retained per policy (not removed) but flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-GnT is a uniquely complex glycosyltransferase, consisting of at least four</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005515" data-r="PMID:16162815" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct-derived binding annotation (with PIGA, UniProtKB:P37287) supporting PIGH&#39;s membership in the GPI-GnT complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative; the interaction reflects GPI-GnT complex membership captured by GO:0000506. Retained per policy, flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consisting of at least six</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput AP-MS interactome (BioPlex) annotation, capturing interactions of PIGH with GPI-GnT complex members (UniProtKB:P37287 PIGA and UniProtKB:Q9BRB3 PIGQ).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; from a proteome-scale interactome screen is uninformative as a molecular function; the biologically meaningful content (GPI-GnT complex membership) is captured by GO:0000506. Retained per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">complex membership for thousands of proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Multimodal cell-map (AP-MS + imaging) interaction annotation (with PIGQ, UniProtKB:Q9BRB3), consistent with PIGH being part of the GPI-GnT assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; from a proteome-scale mapping study is uninformative; the interaction reflects GPI-GnT complex membership captured by GO:0000506. Retained per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                                        PMID:40205054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">yielding structures for 111</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8900170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-A and PIG-H, which participate in glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005515" data-r="PMID:8900170" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction annotation from the study demonstrating PIGH forms a complex with PIGA (UniProtKB:P37287) in the ER, underpinning GPI-GnT complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative. The specific, informative claim (PIGH-PIGA complex / GPI-GnT membership) is captured by GO:0000506. Retained per policy, flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cytoplasmically oriented, ER-associated protein; and 3) that they form a protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9463366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The first step of glycosylphosphatidylinositol biosynthesis ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005515" data-r="PMID:9463366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction annotation (with PIGQ, UniProtKB:Q9BRB3) from the study showing the four-component GPI-GnT complex; supports PIGH&#39;s complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative; the interaction reflects GPI-GnT complex membership captured by GO:0000506. Retained per policy.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8900170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-A and PIG-H, which participate in glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005789" data-r="PMID:8900170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental localization of PIGH to the ER membrane, from the study that characterized PIG-H as an ER-associated component of the GPI GlcNAc transferase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization, experimentally supported. PIGH resides in the ER membrane where the GPI-GnT complex acts.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cytoplasmically oriented, ER-associated protein; and 3) that they form a protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal-curated membership of PIGH in the GPI-GnT complex, based on the study defining the seven-component complex (PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY, DPM2).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, experimentally supported complex membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consisting of at least six</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005789" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct localization of PIGH (as part of the GPI-GnT complex) to the ER membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization, experimentally supported and consistent with the other ER-membrane annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consisting of at least six</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that PIGH is a component of the GPI-GnT complex (UniProt-curated from the seven-component study).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, experimentally supported complex membership; duplicate term/reference with different assigning source, which is acceptable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">consisting of at least six</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0006506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence linking PIGH (via the GPI-GnT complex) to the GPI-anchor biosynthetic process, in which the complex catalyzes the first step of GPI synthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, experimentally supported. The PIG-Y study functionally characterized the PIGH-containing GPI-GnT complex that initiates GPI biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binding directly to the catalytic subunit PIG-A.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162730
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005789" data-r="Reactome:R-HSA-162730" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (traceable author statement) places the GPI-GnT reaction, and hence PIGH, at the ER membrane, where the first step of GPI synthesis occurs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization, consistent with experimental ER-membrane annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162730
+
+                                </span>
+
+                                <div class="support-text">N-acetylglucosamine from cytosolic UDP-N-acetylglucosamine to phosphatidyl inositol (PI) in the endoplasmic</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10944123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Initial enzyme for glycosylphosphatidylinositol biosynthesis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0000506" data-r="PMID:10944123" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (MGI-assigned) that PIGH is a subunit of the GPI-GnT complex, from the study identifying PIG-P and DPM2 as additional components.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, experimentally supported complex membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-GnT is a uniquely complex glycosyltransferase, consisting of at least four</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8900170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-A and PIG-H, which participate in glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0005783" data-r="PMID:8900170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement localizing PIGH to the endoplasmic reticulum. This is a less specific (parent) term relative to the ER membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but less specific than &#34;endoplasmic reticulum membrane&#34;. Retained as an accurate broader localization; the ER-membrane annotations provide the precise compartment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cytoplasmically oriented, ER-associated protein; and 3) that they form a protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8900170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-A and PIG-H, which participate in glycosylphosphatidylin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q14442" data-a="GO:0006506" data-r="PMID:8900170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement that PIGH participates in GPI-anchor biosynthesis via the first step, transfer of GlcNAc to phosphatidylinositol.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process, consistent with all other BP annotations and the literature.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                        PMID:8900170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">N-acetylglucosamine (GlcNAc) to PI from UDP-GlcNAc to generate GlcNAc-PI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As a non-catalytic accessory subunit of the GPI-GlcNAc transferase (GPI-GnT) complex, PIGH contributes to the first committed step of GPI-anchor biosynthesis, in which the complex transfers N-acetylglucosamine from UDP-GlcNAc onto phosphatidylinositol to form GlcNAc-PI on the cytoplasmic face of the ER membrane. The catalytic subunit is PIGA; PIGH is required for complex activity.</h3>
+                <span class="vote-buttons" data-g="Q14442" data-a="FUNCTION: As a non-catalytic accessory subunit of the GPI-Gl..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                            glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                                PMID:8900170
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PIG-A and PIG-H are subunits of the GPI GlcNAc transferase that transfers GlcNAc</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                PMID:16162815
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">binding directly to the catalytic subunit PIG-A.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                            PMID:10944123
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-P and is regulated by DPM2.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                            PMID:16162815
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-Y, a seventh component.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8900170" target="_blank" class="term-link">
+                            PMID:8900170
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-A and PIG-H, which participate in glycosylphosphatidylinositol anchor biosynthesis, form a protein complex in the endoplasmic reticulum.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                            PMID:9463366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The first step of glycosylphosphatidylinositol biosynthesis is mediated by a complex of PIG-A, PIG-H, PIG-C and GPI1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162730
+
+                    </span>
+                </div>
+
+                <div class="reference-title">phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI + UDP</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGH/PIGH-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q14442 (PIGH_HUMAN)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGH-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q14442" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigh-q14442-review-notes">PIGH (Q14442) review notes</h1>
+<p>Human PIGH — Phosphatidylinositol N-acetylglucosaminyltransferase subunit H (PIG-H).<br />
+188 aa, ER membrane protein (UniProt: multi-pass; two predicted TM helices 40-60 and<br />
+63-83). HGNC:8964. Chromosome 14. Gene MIM 600154; disease MIM 618010 (GPIBD17).</p>
+<p>Deep research: falcon provider was OUT OF CREDITS (HTTP 402) at review time, so no<br />
+<code>-deep-research-falcon.md</code> was generated. This review is grounded in the UniProt record<br />
+(<code>PIGH-uniprot.txt</code>), the seeded GOA (<code>PIGH-goa.tsv</code>), the cached primary publications,<br />
+and the Reactome entry.</p>
+<h2 id="core-biology-verified">Core biology (verified)</h2>
+<p>PIGH is a <strong>non-catalytic (accessory) subunit of the GPI-GlcNAc transferase (GPI-GnT)<br />
+complex</strong>, the multi-subunit ER enzyme that catalyzes the <strong>first committed step of<br />
+GPI-anchor biosynthesis</strong>: transfer of GlcNAc from UDP-GlcNAc onto phosphatidylinositol<br />
+(PI) to yield GlcNAc-PI, on the cytoplasmic face of the ER.</p>
+<ul>
+<li>The <strong>catalytic subunit is PIGA</strong> (homologous to a bacterial GlcNAc transferase); PIGH<br />
+  is one of the required accessory subunits.</li>
+<li>The complex comprises at least PIGA, PIGC, PIGH, PIGP, PIGQ (GPI1), PIGY and DPM2.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16162815" title="consisting of at least six proteins ... requires another component, termed PIG-Y">PMID:16162815</a><br />
+  [UniProt SUBUNIT: "composed at least by PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2"]</li>
+</ul>
+<h3 id="provenance-of-key-claims">Provenance of key claims</h3>
+<ul>
+<li><strong>First step / GlcNAc transfer / complex</strong>:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8900170" title="The first step is the transfer of N-acetylglucosamine (GlcNAc) to PI from UDP-GlcNAc to generate GlcNAc-PI">PMID:8900170</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8900170" title="PIG-A and PIG-H are subunits of the GPI GlcNAc transferase that transfers GlcNAc to PI on the cytoplasmic side of the ER">PMID:8900170</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9463366" title="The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in vitro">PMID:9463366</a></li>
+<li><strong>PIG-H is ER-associated, cytoplasmically oriented; forms complex with PIG-A</strong>:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8900170" title="PIG-H is a cytoplasmically oriented, ER-associated protein; and 3) that they form a protein complex">PMID:8900170</a><br />
+  (UniProt models the mature protein as a multi-pass ER membrane protein; GOA carries<br />
+  ER membrane EXP/IDA. I defer to GOA/UniProt for the ER-membrane CC.)</li>
+<li><strong>Interactions</strong>: PIGH interacts with PIGA (P37287) and PIGQ (Q9BRB3) within the complex.<br />
+  [UniProt INTERACTION: "Q14442; P37287: PIGA" and "Q14442; Q9BRB3: PIGQ"]</li>
+<li><strong>PIG-P / DPM2 components</strong>: <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" title="GPI-GnT requires another component, termed PIG-P, and that DPM2 ... also regulates GPI-GnT">PMID:10944123</a></li>
+</ul>
+<h3 id="molecular-function">Molecular function</h3>
+<p>The GOA carries <strong>no catalytic MF term</strong> for PIGH — only <code>GO:0005515 protein binding</code><br />
+(IPI, from complex/interactome studies). This is consistent with PIGH being a<br />
+non-catalytic subunit; the GlcNAc-transferase catalytic activity belongs to the complex<br />
+(and specifically to PIGA). I therefore do NOT assign a catalytic MF in core_functions;<br />
+I record PIGH's contribution via <code>directly_involved_in</code> the BP and <code>in_complex</code> the<br />
+GPI-GnT complex, plus ER-membrane location.</p>
+<h3 id="disease">Disease</h3>
+<p>Biallelic PIGH variants cause <strong>GPI biosynthesis defect 17 (GPIBD17)</strong> [MIM:618010], an<br />
+autosomal-recessive inherited GPI-deficiency disorder (developmental/epileptic<br />
+encephalopathy): developmental delay, epilepsy/seizures, microcephaly, autistic features,<br />
+skeletal manifestations. Variants: start-codon disruption (PMID:29573052),<br />
+p.Ser103Pro (PMID:29603516, PMID:33156547 — reduced GPI-anchored protein surface<br />
+expression), p.Arg163Trp (PMID:33156547, PMID:35445667). Disease refs are not in the<br />
+GOA and are used only for the top-level <code>description</code>/context (no supporting_text quotes<br />
+needed since they are not cached).</p>
+<h2 id="goa-annotation-inventory-21-lines-20-review-entries">GOA annotation inventory (21 lines -&gt; 20 review entries)</h2>
+<p>MF: GO:0005515 protein binding (IPI) x6 references (7 GOA lines; two PMID:33961781 lines<br />
+  with different partners P37287/Q9BRB3 collapse to one review entry).<br />
+CC: GO:0000506 GPI-GnT complex (IBA, IEA, IPI, IDA x2) ; GO:0005789 ER membrane<br />
+  (IEA, EXP, IDA, TAS) ; GO:0005783 ER (TAS).<br />
+BP: GO:0006506 GPI anchor biosynthetic process (IBA, IEA, IDA, TAS).</p>
+<h3 id="curation-decisions-summary">Curation decisions summary</h3>
+<ul>
+<li>CC GPI-GnT complex (all evidence): ACCEPT — core, well-supported.</li>
+<li>CC ER membrane / ER (all evidence): ACCEPT — core localization.</li>
+<li>BP GPI anchor biosynthetic process (all evidence): ACCEPT — core.</li>
+<li>MF protein binding (all IPI): MARK_AS_OVER_ANNOTATED — uninformative bare<br />
+<code>protein binding</code>; the real informative content (subunit of GPI-GnT) is captured by the<br />
+  complex CC term. Per policy, do NOT REMOVE bare protein-binding IPIs.<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q14442
+gene_symbol: PIGH
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGH (phosphatidylinositol N-acetylglucosaminyltransferase subunit H,
+  PIG-H) is a non-catalytic subunit of the glycosylphosphatidylinositol
+  N-acetylglucosaminyltransferase (GPI-GnT) complex, the endoplasmic reticulum enzyme
+  that carries out the first committed step of GPI-anchor biosynthesis. In this step
+  the complex transfers N-acetylglucosamine from UDP-GlcNAc onto phosphatidylinositol
+  to generate GlcNAc-PI on the cytoplasmic face of the ER. The catalytic subunit is
+  PIGA; PIGH is one of the required accessory subunits, and the assembled complex
+  contains at least PIGA, PIGC, PIGH, PIGP, PIGQ (GPI1), PIGY and DPM2. PIGH is an
+  endoplasmic reticulum membrane protein. Biallelic loss-of-function variants in PIGH
+  cause an inherited glycosylphosphatidylinositol-deficiency disorder (GPI biosynthesis
+  defect 17, GPIBD17), a developmental and epileptic encephalopathy featuring
+  developmental delay, seizures, microcephaly and autistic features.
+existing_annotations:
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: PIGH is a subunit of the GPI-GnT complex. This phylogenetically inferred
+      annotation matches the extensive experimental evidence that PIGH is a component
+      of the multi-subunit GPI-GlcNAc transferase.
+    action: ACCEPT
+    reason: Core, well-supported cellular component. PIGH is one of the accessory
+      subunits of the GPI-GnT complex, consistent with the IBA inference and with the
+      experimental complex-membership annotations below.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity
+        in
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: PIGH participates in GPI anchor biosynthesis as a subunit of the GPI-GnT
+      complex that catalyzes the first step (GlcNAc transfer to phosphatidylinositol).
+    action: ACCEPT
+    reason: Core biological process. The phylogenetic inference agrees with the
+      experimental evidence that the PIGH-containing complex performs the first step
+      of GPI-anchor biosynthesis.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: N-acetylglucosamine (GlcNAc) to PI from UDP-GlcNAc to generate
+        GlcNAc-PI
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: part_of
+  review:
+    summary: InterPro2GO maps the PIG-H InterPro signature (IPR044215) to the GPI-GnT
+      complex. This is consistent with PIGH being a dedicated subunit of that complex.
+    action: ACCEPT
+    reason: Correct electronic inference; PIGH&#39;s family signature is specific to the
+      GPI-GnT complex subunit, so the CC mapping is appropriate and redundant with the
+      experimental annotations.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity
+        in
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic annotation from the UniProt subcellular-location vocabulary
+      places PIGH at the ER membrane, matching the curated UniProt location and the
+      experimental EXP/IDA annotations.
+    action: ACCEPT
+    reason: Correct localization. PIGH is an ER membrane protein (UniProt models it as
+      a multi-pass ER membrane protein); this IEA is redundant with the experimental
+      ER-membrane annotations.
+    supported_by:
+    - reference_id: file:human/PIGH/PIGH-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Combined automated methods (InterPro/UniPathway UPA00196) assign PIGH to
+      GPI-anchor biosynthesis, matching its curated role as a GPI-GnT complex subunit.
+    action: ACCEPT
+    reason: Correct electronic inference, redundant with the experimental and
+      phylogenetic BP annotations.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: N-acetylglucosamine (GlcNAc) to PI from UDP-GlcNAc to generate
+        GlcNAc-PI
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:10944123
+  qualifier: enables
+  review:
+    summary: IntAct-derived binding annotation (with PIGA, UniProtKB:P37287). The
+      biologically meaningful content is that PIGH is a subunit of the GPI-GnT complex,
+      which is already captured by the GPI-GnT complex CC term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative as a molecular function. The
+      underlying interaction reflects PIGH&#39;s membership in the GPI-GnT complex, which
+      is better represented by the complex CC annotation (GO:0000506). Retained per
+      policy (not removed) but flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:10944123
+      supporting_text: GPI-GnT is a uniquely complex glycosyltransferase, consisting
+        of at least four
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: enables
+  review:
+    summary: IntAct-derived binding annotation (with PIGA, UniProtKB:P37287) supporting
+      PIGH&#39;s membership in the GPI-GnT complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative; the interaction reflects GPI-GnT
+      complex membership captured by GO:0000506. Retained per policy, flagged as
+      over-annotation.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: consisting of at least six
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: High-throughput AP-MS interactome (BioPlex) annotation, capturing
+      interactions of PIGH with GPI-GnT complex members (UniProtKB:P37287 PIGA and
+      UniProtKB:Q9BRB3 PIGQ).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; from a proteome-scale interactome screen is
+      uninformative as a molecular function; the biologically meaningful content
+      (GPI-GnT complex membership) is captured by GO:0000506. Retained per policy.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: complex membership for thousands of proteins
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: Multimodal cell-map (AP-MS + imaging) interaction annotation (with PIGQ,
+      UniProtKB:Q9BRB3), consistent with PIGH being part of the GPI-GnT assembly.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; from a proteome-scale mapping study is uninformative;
+      the interaction reflects GPI-GnT complex membership captured by GO:0000506.
+      Retained per policy.
+    supported_by:
+    - reference_id: PMID:40205054
+      supporting_text: yielding structures for 111
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:8900170
+  qualifier: enables
+  review:
+    summary: Interaction annotation from the study demonstrating PIGH forms a complex
+      with PIGA (UniProtKB:P37287) in the ER, underpinning GPI-GnT complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative. The specific, informative claim
+      (PIGH-PIGA complex / GPI-GnT membership) is captured by GO:0000506. Retained per
+      policy, flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: cytoplasmically oriented, ER-associated protein; and 3) that
+        they form a protein
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:9463366
+  qualifier: enables
+  review:
+    summary: Interaction annotation (with PIGQ, UniProtKB:Q9BRB3) from the study
+      showing the four-component GPI-GnT complex; supports PIGH&#39;s complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; is uninformative; the interaction reflects GPI-GnT
+      complex membership captured by GO:0000506. Retained per policy.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity
+        in
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: EXP
+  original_reference_id: PMID:8900170
+  qualifier: located_in
+  review:
+    summary: Experimental localization of PIGH to the ER membrane, from the study that
+      characterized PIG-H as an ER-associated component of the GPI GlcNAc transferase.
+    action: ACCEPT
+    reason: Core localization, experimentally supported. PIGH resides in the ER
+      membrane where the GPI-GnT complex acts.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: cytoplasmically oriented, ER-associated protein; and 3) that
+        they form a protein
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: ComplexPortal-curated membership of PIGH in the GPI-GnT complex, based on
+      the study defining the seven-component complex (PIGA, PIGC, PIGH, PIGP, PIGQ,
+      PIGY, DPM2).
+    action: ACCEPT
+    reason: Core, experimentally supported complex membership.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: consisting of at least six
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: located_in
+  review:
+    summary: Direct localization of PIGH (as part of the GPI-GnT complex) to the ER
+      membrane.
+    action: ACCEPT
+    reason: Core localization, experimentally supported and consistent with the other
+      ER-membrane annotations.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: consisting of at least six
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: Direct experimental evidence that PIGH is a component of the GPI-GnT
+      complex (UniProt-curated from the seven-component study).
+    action: ACCEPT
+    reason: Core, experimentally supported complex membership; duplicate term/reference
+      with different assigning source, which is acceptable.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: consisting of at least six
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence linking PIGH (via the GPI-GnT complex) to
+      the GPI-anchor biosynthetic process, in which the complex catalyzes the first
+      step of GPI synthesis.
+    action: ACCEPT
+    reason: Core biological process, experimentally supported. The PIG-Y study
+      functionally characterized the PIGH-containing GPI-GnT complex that initiates
+      GPI biosynthesis.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: binding directly to the catalytic subunit PIG-A.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162730
+  qualifier: located_in
+  review:
+    summary: Reactome (traceable author statement) places the GPI-GnT reaction, and
+      hence PIGH, at the ER membrane, where the first step of GPI synthesis occurs.
+    action: ACCEPT
+    reason: Core localization, consistent with experimental ER-membrane annotations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162730
+      supporting_text: N-acetylglucosamine from cytosolic UDP-N-acetylglucosamine to
+        phosphatidyl inositol (PI) in the endoplasmic
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IDA
+  original_reference_id: PMID:10944123
+  qualifier: part_of
+  review:
+    summary: Direct experimental evidence (MGI-assigned) that PIGH is a subunit of the
+      GPI-GnT complex, from the study identifying PIG-P and DPM2 as additional
+      components.
+    action: ACCEPT
+    reason: Core, experimentally supported complex membership.
+    supported_by:
+    - reference_id: PMID:10944123
+      supporting_text: GPI-GnT is a uniquely complex glycosyltransferase, consisting
+        of at least four
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: TAS
+  original_reference_id: PMID:8900170
+  qualifier: located_in
+  review:
+    summary: Traceable author statement localizing PIGH to the endoplasmic reticulum.
+      This is a less specific (parent) term relative to the ER membrane annotations.
+    action: ACCEPT
+    reason: Correct but less specific than &#34;endoplasmic reticulum membrane&#34;. Retained
+      as an accurate broader localization; the ER-membrane annotations provide the
+      precise compartment.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: cytoplasmically oriented, ER-associated protein; and 3) that
+        they form a protein
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: TAS
+  original_reference_id: PMID:8900170
+  qualifier: involved_in
+  review:
+    summary: Traceable author statement that PIGH participates in GPI-anchor
+      biosynthesis via the first step, transfer of GlcNAc to phosphatidylinositol.
+    action: ACCEPT
+    reason: Core biological process, consistent with all other BP annotations and the
+      literature.
+    supported_by:
+    - reference_id: PMID:8900170
+      supporting_text: N-acetylglucosamine (GlcNAc) to PI from UDP-GlcNAc to generate
+        GlcNAc-PI
+core_functions:
+- description: As a non-catalytic accessory subunit of the GPI-GlcNAc transferase
+    (GPI-GnT) complex, PIGH contributes to the first committed step of GPI-anchor
+    biosynthesis, in which the complex transfers N-acetylglucosamine from UDP-GlcNAc
+    onto phosphatidylinositol to form GlcNAc-PI on the cytoplasmic face of the ER
+    membrane. The catalytic subunit is PIGA; PIGH is required for complex activity.
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  in_complex:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:8900170
+    supporting_text: PIG-A and PIG-H are subunits of the GPI GlcNAc transferase that
+      transfers GlcNAc
+  - reference_id: PMID:16162815
+    supporting_text: binding directly to the catalytic subunit PIG-A.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10944123
+  title: Initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-P
+    and is regulated by DPM2.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Identifies PIG-P and DPM2 as GPI-GnT components; establishes PIGH as
+      part of the multi-subunit GPI-GnT complex.
+- id: PMID:16162815
+  title: The initial enzyme for glycosylphosphatidylinositol biosynthesis requires
+    PIG-Y, a seventh component.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Defines the seven-component GPI-GnT complex (PIGA, PIGC, PIGH, PIGP,
+      PIGQ, PIGY, DPM2) and identifies PIGA as the catalytic subunit; supports PIGH
+      complex membership and BP.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Proteome-scale AP-MS interactome (BioPlex); source of high-throughput
+      protein-binding IPI annotations, not gene-specific functional characterization.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Proteome-scale multimodal cell-mapping study; source of a
+      high-throughput protein-binding IPI annotation, not gene-specific
+      characterization of PIGH.
+- id: PMID:8900170
+  title: PIG-A and PIG-H, which participate in glycosylphosphatidylinositol anchor
+    biosynthesis, form a protein complex in the endoplasmic reticulum.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Primary characterization of PIG-H as an ER-associated subunit of the
+      GPI GlcNAc transferase that complexes with PIG-A; supports ER localization,
+      complex membership and BP.
+- id: PMID:9463366
+  title: The first step of glycosylphosphatidylinositol biosynthesis is mediated by
+    a complex of PIG-A, PIG-H, PIG-C and GPI1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Demonstrates the PIGA/PIGH/PIGC/GPI1 complex has GPI-GnT activity in
+      vitro; supports PIGH complex membership and the first-step BP.
+- id: Reactome:R-HSA-162730
+  title: phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI
+    + UDP
+  findings: []
+- id: file:human/PIGH/PIGH-uniprot.txt
+  title: UniProtKB entry Q14442 (PIGH_HUMAN)
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGL/PIGL-ai-review.html
+++ b/genes/human/PIGL/PIGL-ai-review.html
@@ -1,0 +1,3174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGL - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGL</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9Y2B2" target="_blank" class="term-link">
+                        Q9Y2B2
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGL";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9Y2B2" data-a="DESCRIPTION: PIGL is the N-acetylglucosaminyl-phosphatidylinosi..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGL is the N-acetylglucosaminyl-phosphatidylinositol de-N-acetylase (PIG-L, EC 3.5.1.89) that catalyzes the second step of glycosylphosphatidylinositol (GPI) anchor biosynthesis. It hydrolyzes N-acetylglucosaminyl-phosphatidylinositol (GlcNAc-PI) to glucosaminyl-phosphatidylinositol (GlcN-PI) plus acetate, a de-N-acetylation that is a prerequisite for the subsequent inositol acylation and mannosylation steps of GPI assembly. It is a single-pass type I endoplasmic reticulum membrane protein with a large cytoplasmic domain and belongs to the PIGL/LmbE-like deacetylase family. Biallelic loss-of-function or hypomorphic PIGL variants cause CHIME syndrome (Zeman-Sheard syndrome), an inherited GPI-deficiency disorder characterized by coloboma, congenital heart disease, ichthyosiform dermatosis, impaired intellectual development, and ear anomalies.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000225" target="_blank" class="term-link">
+                                    GO:0000225
+                                </a>
+                            </span>
+                            <span class="term-label">N-acetylglucosaminylphosphatidylinositol deacetylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0000225" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (PAN-GO) inference of the core catalytic function, GlcNAc-PI de-N-acetylase activity. This is the correct and experimentally supported molecular function for PIGL and matches the enzyme identity (EC 3.5.1.89).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GlcNAc-PI de-N-acetylase activity is the defining function of PIGL and is directly supported by experimental work; the IBA inference across the conserved PIGL family (including yeast Gpi12p) is well founded.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link">
+                                        PMID:10085243
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The second step of GPI biosynthesis is</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link">
+                                        PMID:14742432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyzed by N-acetylglucosaminylphosphatidylinositol deacetylase (PIG-L).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0005783" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference that PIGL is active in the endoplasmic reticulum. This is correct but is the broader compartment term; the more informative cellular component is the ER membrane (GO:0005789), where PIGL is experimentally localized.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization but less specific than the experimentally supported ER membrane annotation. Retained as a valid, broader is_active_in statement while the ER membrane term captures the informative location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link">
+                                        PMID:14742432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">activity is localized to the endoplasmic reticulum (ER) but enriched in a</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGL/PIGL-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000225" target="_blank" class="term-link">
+                                    GO:0000225
+                                </a>
+                            </span>
+                            <span class="term-label">N-acetylglucosaminylphosphatidylinositol deacetylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0000225" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation of the deacetylase molecular function via UniRule/ARBA, RHEA:11660 and EC:3.5.1.89. Correct and consistent with the experimental evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The IEA mapping to GO:0000225 (EC 3.5.1.89 / RHEA:11660) is the correct catalytic term and agrees with experimental and phylogenetic evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGL/PIGL-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Catalyzes the second step of glycosylphosphatidylinositol</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0005789" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (ARBA / UniProtKB-SubCell SL-0097) placing PIGL in the ER membrane. Correct and matches the experimental IDA/EXP localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ER membrane location is experimentally established for human PIGL, a single-pass type I ER membrane protein; the IEA is consistent and correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGL/PIGL-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link">
+                                        PMID:14742432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We show that human PIG-L is a type I membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (ARBA / UniPathway UPA00196) placing PIGL in GPI anchor biosynthesis. PIGL performs the second, obligatory step of this pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GPI anchor biosynthetic process is the core biological process for PIGL; the de-N-acetylation it catalyzes is a required step of GPI assembly.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGL/PIGL-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link">
+                                        PMID:10085243
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The second step of GPI biosynthesis is</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162710
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0006506" data-r="Reactome:R-HSA-162710" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable annotation to the overall GPI synthesis pathway. Correct; PIGL catalyzes the second reaction of this ER pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGL is a bona fide component of the GPI anchor biosynthetic pathway curated by Reactome (Synthesis of glycosylphosphatidylinositol).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162710
+
+                                </span>
+
+                                <div class="support-text">GPI is synthesized in the endoplasmic reticulum.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162857
+
+                                </span>
+
+                                <div class="support-text">In the second step of GPI synthesis, N-acetylglucosaminyl-PI is hydrolyzed to yield glucosaminyl-PI and acetate.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000225" target="_blank" class="term-link">
+                                    GO:0000225
+                                </a>
+                            </span>
+                            <span class="term-label">N-acetylglucosaminylphosphatidylinositol deacetylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162857
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0000225" data-r="Reactome:R-HSA-162857" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable annotation of the second-step deacetylase reaction (N-acetylglucosaminyl-PI + H2O -&gt; glucosaminyl-PI + acetate) catalyzed by PIG-L. Correct core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The Reactome reaction curation directly attributes the GlcNAc-PI de-N-acetylase activity to PIG-L, matching the experimental and phylogenetic evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162857
+
+                                </span>
+
+                                <div class="support-text">as is the PIG-L enzyme that catalyzes it</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000225" target="_blank" class="term-link">
+                                    GO:0000225
+                                </a>
+                            </span>
+                            <span class="term-label">N-acetylglucosaminylphosphatidylinositol deacetylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14742432
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subcellular localization and targeting of N-acetylglucosamin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0000225" data-r="PMID:14742432" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental demonstration of GlcNAc-PI de-N-acetylase activity for human PIG-L (Pottekat &amp; Menon 2004), which characterized the activity and its ER localization. This is the strongest, experiment-based support for the core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence in human cells that PIG-L catalyzes GlcNAc-PI de-N-acetylation; represents the core catalytic function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link">
+                                        PMID:14742432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">catalyzed by N-acetylglucosaminylphosphatidylinositol deacetylase (PIG-L).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10085243
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mammalian PIG-L and its yeast homologue Gpi12p are N-acetylg...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0005789" data-r="PMID:10085243" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ER membrane localization supported in the original PIG-L characterization; the de-N-acetylation step and its enzyme are components of the ER GPI machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ER membrane localization is correct and independently confirmed by the experimental study of Pottekat &amp; Menon (PMID:14742432); PIGL is a single-pass ER membrane protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link">
+                                        PMID:14742432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We show that human PIG-L is a type I membrane protein</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGL/PIGL-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000225" target="_blank" class="term-link">
+                                    GO:0000225
+                                </a>
+                            </span>
+                            <span class="term-label">N-acetylglucosaminylphosphatidylinositol deacetylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0000225" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer (from mouse ortholog O35790) of the deacetylase molecular function. Correct and redundant with the experimental evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ISS transfer of GO:0000225 from the conserved rodent ortholog is correct and matches the experimentally established human activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link">
+                                        PMID:10085243
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">has GlcNAc-PI de-N-acetylase activity in vitro</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14742432
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subcellular localization and targeting of N-acetylglucosamin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0005789" data-r="PMID:14742432" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assay localizing human PIG-L and its GlcNAc-PI de-N-acetylase activity to the ER membrane (Pottekat &amp; Menon 2004), including identification of ER retention signals. Core cellular component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental evidence that PIG-L is an ER membrane protein; the most informative and best-supported cellular component annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link">
+                                        PMID:14742432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">activity is localized to the endoplasmic reticulum (ER) but enriched in a</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link">
+                                        PMID:14742432
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We show that human PIG-L is a type I membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10085243
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mammalian PIG-L and its yeast homologue Gpi12p are N-acetylg...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0006506" data-r="PMID:10085243" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Functional/complementation evidence (Watanabe et al. 1999) that PIG-L is required for GPI biosynthesis - the rat gene was cloned by complementing a CHO mutant defective in the second step, and its yeast homologue Gpi12p is essential for GPI and cell viability. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Loss/restoration of GlcNAc-PI de-N-acetylase activity and cell-surface GPI-anchored protein expression on manipulating PIG-L/Gpi12p demonstrates PIGL&#39;s required role in GPI anchor biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link">
+                                        PMID:10085243
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cell-surface expression of GPI-anchored proteins and GlcNAc-PI</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link">
+                                        PMID:10085243
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indispensable in yeasts</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162857
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0005789" data-r="Reactome:R-HSA-162857" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable annotation placing the PIG-L enzyme and its substrates in the ER membrane for the second-step reaction. Correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimental ER membrane localization; Reactome curates the reaction as occurring in the ER membrane with PIG-L as the catalyst.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162857
+
+                                </span>
+
+                                <div class="support-text">as is the PIG-L enzyme that catalyzes it</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000225" target="_blank" class="term-link">
+                                    GO:0000225
+                                </a>
+                            </span>
+                            <span class="term-label">N-acetylglucosaminylphosphatidylinositol deacetylase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10085243
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mammalian PIG-L and its yeast homologue Gpi12p are N-acetylg...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0000225" data-r="PMID:10085243" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-traceable/author-statement annotation of the deacetylase molecular function from the original PIG-L paper (Watanabe et al. 1999), which established GlcNAc-PI de-N-acetylase activity for recombinant PIG-L. Correct core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The molecular function is correct and is directly supported by the enzymatic assays in this reference and by later human EXP evidence (PMID:14742432).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link">
+                                        PMID:10085243
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">has GlcNAc-PI de-N-acetylase activity in vitro</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10085243
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mammalian PIG-L and its yeast homologue Gpi12p are N-acetylg...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y2B2" data-a="GO:0006506" data-r="PMID:10085243" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-statement annotation of involvement in GPI biosynthesis from the original PIG-L characterization. Correct core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIG-L catalyzes the essential second step of GPI biosynthesis; the process annotation is well supported by the same reference and by disease genetics (CHIME/GPI-deficiency).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link">
+                                        PMID:10085243
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The second step of GPI biosynthesis is</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link">
+                                        PMID:10085243
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indispensable in yeasts</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>N-acetylglucosaminyl-phosphatidylinositol de-N-acetylase (EC 3.5.1.89) catalyzing the second step of GPI anchor biosynthesis in the ER membrane - hydrolysis of GlcNAc-PI to GlcN-PI plus acetate.</h3>
+                <span class="vote-buttons" data-g="Q9Y2B2" data-a="FUNCTION: N-acetylglucosaminyl-phosphatidylinositol de-N-ace..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000225" target="_blank" class="term-link">
+                            N-acetylglucosaminylphosphatidylinositol deacetylase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link">
+                                PMID:14742432
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">catalyzed by N-acetylglucosaminylphosphatidylinositol deacetylase (PIG-L).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link">
+                                PMID:10085243
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The second step of GPI biosynthesis is</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGL/PIGL-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Catalyzes the second step of glycosylphosphatidylinositol</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10085243" target="_blank" class="term-link">
+                            PMID:10085243
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mammalian PIG-L and its yeast homologue Gpi12p are N-acetylglucosaminylphosphatidylinositol de-N-acetylases essential in glycosylphosphatidylinositol biosynthesis.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Recombinant PIG-L has GlcNAc-PI de-N-acetylase activity in vitro, and the de-N-acetylation second step of GPI biosynthesis is conserved and essential from yeast (Gpi12p) to mammals.</div>
+
+                        <div class="finding-text">"has GlcNAc-PI de-N-acetylase activity in vitro"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14742432" target="_blank" class="term-link">
+                            PMID:14742432
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Subcellular localization and targeting of N-acetylglucosaminyl phosphatidylinositol de-N-acetylase, the second enzyme in the glycosylphosphatidylinositol biosynthetic pathway.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human PIG-L is a single-pass type I ER membrane protein whose GlcNAc-PI de-N-acetylase activity is localized to the endoplasmic reticulum, retained there by a multi-component localization signal.</div>
+
+                        <div class="finding-text">"We show that human PIG-L is a type I membrane protein"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162710
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Synthesis of glycosylphosphatidylinositol (GPI)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">GPI is synthesized in the endoplasmic reticulum via a pathway of nine reactions; PIGL contributes the second reaction.</div>
+
+                        <div class="finding-text">"GPI is synthesized in the endoplasmic reticulum."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162857
+
+                    </span>
+                </div>
+
+                <div class="reference-title">N-acetylglucosaminyl-PI + H2O -&gt; glucosaminyl-PI + acetate</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The second GPI-synthesis reaction hydrolyzes N-acetylglucosaminyl-PI to glucosaminyl-PI and acetate in the ER membrane, catalyzed by PIG-L.</div>
+
+                        <div class="finding-text">"as is the PIG-L enzyme that catalyzes it"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGL/PIGL-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB Q9Y2B2 (PIGL_HUMAN)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PIGL catalyzes the second step of GPI biosynthesis (de-N-acetylation of GlcNAc-PI) and is an ER membrane, single-pass type I membrane protein of the PIGL family; variants cause CHIME syndrome.</div>
+
+                        <div class="finding-text">"Catalyzes the second step of glycosylphosphatidylinositol"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGL-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9Y2B2" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigl-q9y2b2-review-notes">PIGL (Q9Y2B2) — review notes</h1>
+<p>Human PIGL, N-acetylglucosaminyl-phosphatidylinositol de-N-acetylase (PIG-L; EC 3.5.1.89).<br />
+HGNC:8966, GeneID 9487, chromosome 17. 252 aa. Reference proteome UP000005640.</p>
+<h2 id="core-biology">Core biology</h2>
+<p>PIGL catalyses the <strong>second step of glycosylphosphatidylinositol (GPI) anchor biosynthesis</strong>:<br />
+the <strong>de-N-acetylation of N-acetylglucosaminyl-phosphatidylinositol (GlcNAc-PI) to<br />
+glucosaminyl-phosphatidylinositol (GlcN-PI)</strong>, releasing acetate. This deacetylation is a<br />
+prerequisite for the downstream inositol acylation and mannosylation steps of GPI assembly.</p>
+<ul>
+<li>UniProt FUNCTION: "Catalyzes the second step of glycosylphosphatidylinositol (GPI)<br />
+  biosynthesis, which is the de-N-acetylation of N-acetylglucosaminyl-phosphatidylinositol."<br />
+  [file:human/PIGL/PIGL-uniprot.txt]</li>
+<li>Reaction (RHEA:11660, EC 3.5.1.89): 6-(N-acetyl-alpha-D-glucosaminyl)-PI + H2O =<br />
+  6-(alpha-D-glucosaminyl)-PI + acetate. [file:human/PIGL/PIGL-uniprot.txt]</li>
+<li>GOA MF term carried: <strong>GO:0000225 N-acetylglucosaminylphosphatidylinositol deacetylase<br />
+  activity</strong> (confirmed in PIGL-goa.tsv, all MF rows).</li>
+</ul>
+<h2 id="enzyme-activity-experimental">Enzyme activity — experimental</h2>
+<p>[PMID:10085243 Watanabe et al. 1999 "The second step of GPI biosynthesis is<br />
+de-N-acetylation of N-acetylglucosaminylphosphatidylinositol (GlcNAc-PI)"] — recombinant<br />
+rat PIG-L purified from E. coli "has GlcNAc-PI de-N-acetylase activity in vitro"; yeast<br />
+homologue Gpi12p (YMR281W) complements PIG-L-deficient mammalian cells and its disruption is<br />
+lethal in S. cerevisiae; "the de-N-acetylation step is also indispensable in yeasts". This<br />
+is the original cloning/functional paper (rat gene by expression cloning complementing a CHO<br />
+mutant defective in this step). Human GOA cites it as NAS (function) and IMP (BP), likely<br />
+via the CHO-complementation / cross-species functional identity.</p>
+<p>[PMID:14742432 Pottekat &amp; Menon 2004] — "We show that human PIG-L is a type I membrane<br />
+protein with a large cytoplasmic domain"; GlcNAc-PI de-N-acetylase activity "is localized to<br />
+the endoplasmic reticulum (ER)"; PIG-L retained in the ER by a multi-component signal (a<br />
+retention signal in the cytoplasmic domain residues 60–88, plus a weak luminal/TM signal).<br />
+This is the human enzyme-activity + ER-localization paper (EXP for MF; EXP/IDA for ER<br />
+membrane).</p>
+<h2 id="localization">Localization</h2>
+<p>ER membrane (GO:0005789). UniProt SUBCELLULAR LOCATION: "Endoplasmic reticulum membrane ...<br />
+Single-pass type I membrane protein." Features: TRANSMEM 2..22 (helical), TOPO_DOM 23..252<br />
+cytoplasmic (large cytoplasmic domain). Consistent with GlcNAc-PI de-N-acetylation on the<br />
+cytoplasmic face of the ER, matching the topology of early GPI assembly.</p>
+<p>Reactome R-HSA-162857 (second-step reaction): "In the second step of GPI synthesis,<br />
+N-acetylglucosaminyl-PI is hydrolyzed to yield glucosaminyl-PI and acetate. The<br />
+phosphatidylinositol (PI) derivatives involved in this reaction are located in the<br />
+endoplasmic reticulum membrane, as is the PIG-L enzyme that catalyzes it." Reactome<br />
+R-HSA-162710 (whole GPI pathway): "GPI is synthesized in the endoplasmic reticulum."</p>
+<h2 id="disease">Disease</h2>
+<p>Biallelic loss-of-function / hypomorphic PIGL variants cause <strong>CHIME syndrome (Zeman-Sheard<br />
+syndrome; Coloboma, congenital Heart disease, Ichthyosiform dermatosis, intellectual<br />
+disability / Mental retardation, Ear anomalies; MIM:280000)</strong>, an inherited GPI-deficiency<br />
+disorder. Recurrent variant p.Leu167Pro. [UniProt DISEASE; PMID:22444671, PMID:29473937,<br />
+PMID:35258128, PMID:39641205 — not needed as review citations for the function/localization<br />
+annotations, but establish the biology.]</p>
+<h2 id="domain-family">Domain / family</h2>
+<p>Belongs to the PIGL family; Pfam PF02585 (PIG-L), LmbE-like fold (Gene3D 3.40.50.10320,<br />
+SUPFAM SSF102588; InterPro IPR003737 GlcNAc_PI_deacetylase-related, IPR024078 LmbE-like).<br />
+PANTHER PTHR12993:SF11. Consistent with the deacetylase MF.</p>
+<h2 id="annotation-review-decisions-summary">Annotation-review decisions (summary)</h2>
+<p>MF GO:0000225 (deacetylase): all 5 rows (IBA, IEA, TAS-Reactome, EXP, ISS, NAS) ACCEPT —<br />
+core catalytic function, experimentally established (PMID:14742432 EXP; PMID:10085243). One<br />
+EXP + others accepted as core; NAS/ISS/IEA/TAS accepted (correct term, redundant support).</p>
+<p>BP GO:0006506 (GPI anchor biosynthetic process): rows (IEA, TAS-Reactome, IMP, NAS) ACCEPT —<br />
+core biological process; second step of GPI assembly.</p>
+<p>CC: GO:0005789 ER membrane (IEA, EXP, IDA, TAS-Reactome) ACCEPT — experimentally localized<br />
+(PMID:14742432), single-pass type I ER membrane protein. GO:0005783 endoplasmic reticulum<br />
+(IBA, is_active_in) ACCEPT as non-core parent — the more specific ER membrane is the<br />
+informative CC; ER is the broader IBA "is_active_in" term, correct but less specific.</p>
+<p>No REMOVE actions: every annotation is correct for this well-characterized enzyme.</p>
+<p>core_functions: GO:0000225 (MF) directly_involved_in GO:0006506, located_in GO:0005789.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9Y2B2
+gene_symbol: PIGL
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGL is the N-acetylglucosaminyl-phosphatidylinositol de-N-acetylase (PIG-L,
+  EC 3.5.1.89) that catalyzes the second step of glycosylphosphatidylinositol (GPI) anchor
+  biosynthesis. It hydrolyzes N-acetylglucosaminyl-phosphatidylinositol (GlcNAc-PI) to
+  glucosaminyl-phosphatidylinositol (GlcN-PI) plus acetate, a de-N-acetylation that is a
+  prerequisite for the subsequent inositol acylation and mannosylation steps of GPI
+  assembly. It is a single-pass type I endoplasmic reticulum membrane protein with a large
+  cytoplasmic domain and belongs to the PIGL/LmbE-like deacetylase family. Biallelic
+  loss-of-function or hypomorphic PIGL variants cause CHIME syndrome (Zeman-Sheard syndrome),
+  an inherited GPI-deficiency disorder characterized by coloboma, congenital heart disease,
+  ichthyosiform dermatosis, impaired intellectual development, and ear anomalies.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q9Y2B2-1
+- name: &#39;2&#39;
+  id: Q9Y2B2-2
+  sequence_note: VSP_056886
+existing_annotations:
+- term:
+    id: GO:0000225
+    label: N-acetylglucosaminylphosphatidylinositol deacetylase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (PAN-GO) inference of the core catalytic function, GlcNAc-PI
+      de-N-acetylase activity. This is the correct and experimentally supported molecular
+      function for PIGL and matches the enzyme identity (EC 3.5.1.89).
+    action: ACCEPT
+    reason: The GlcNAc-PI de-N-acetylase activity is the defining function of PIGL and is
+      directly supported by experimental work; the IBA inference across the conserved PIGL
+      family (including yeast Gpi12p) is well founded.
+    supported_by:
+    - reference_id: PMID:10085243
+      supporting_text: The second step of GPI biosynthesis is
+    - reference_id: PMID:14742432
+      supporting_text: catalyzed by N-acetylglucosaminylphosphatidylinositol deacetylase (PIG-L).
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic inference that PIGL is active in the endoplasmic reticulum. This
+      is correct but is the broader compartment term; the more informative cellular
+      component is the ER membrane (GO:0005789), where PIGL is experimentally localized.
+    action: KEEP_AS_NON_CORE
+    reason: Correct localization but less specific than the experimentally supported ER
+      membrane annotation. Retained as a valid, broader is_active_in statement while the
+      ER membrane term captures the informative location.
+    supported_by:
+    - reference_id: PMID:14742432
+      supporting_text: activity is localized to the endoplasmic reticulum (ER) but enriched in a
+    - reference_id: file:human/PIGL/PIGL-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0000225
+    label: N-acetylglucosaminylphosphatidylinositol deacetylase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic annotation of the deacetylase molecular function via UniRule/ARBA,
+      RHEA:11660 and EC:3.5.1.89. Correct and consistent with the experimental evidence.
+    action: ACCEPT
+    reason: The IEA mapping to GO:0000225 (EC 3.5.1.89 / RHEA:11660) is the correct catalytic
+      term and agrees with experimental and phylogenetic evidence.
+    supported_by:
+    - reference_id: file:human/PIGL/PIGL-uniprot.txt
+      supporting_text: Catalyzes the second step of glycosylphosphatidylinositol
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Electronic annotation (ARBA / UniProtKB-SubCell SL-0097) placing PIGL in the ER
+      membrane. Correct and matches the experimental IDA/EXP localization.
+    action: ACCEPT
+    reason: The ER membrane location is experimentally established for human PIGL, a
+      single-pass type I ER membrane protein; the IEA is consistent and correct.
+    supported_by:
+    - reference_id: file:human/PIGL/PIGL-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+    - reference_id: PMID:14742432
+      supporting_text: We show that human PIG-L is a type I membrane protein
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic annotation (ARBA / UniPathway UPA00196) placing PIGL in GPI anchor
+      biosynthesis. PIGL performs the second, obligatory step of this pathway.
+    action: ACCEPT
+    reason: GPI anchor biosynthetic process is the core biological process for PIGL; the
+      de-N-acetylation it catalyzes is a required step of GPI assembly.
+    supported_by:
+    - reference_id: file:human/PIGL/PIGL-uniprot.txt
+      supporting_text: Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor
+    - reference_id: PMID:10085243
+      supporting_text: The second step of GPI biosynthesis is
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162710
+  qualifier: involved_in
+  review:
+    summary: Reactome traceable annotation to the overall GPI synthesis pathway. Correct;
+      PIGL catalyzes the second reaction of this ER pathway.
+    action: ACCEPT
+    reason: PIGL is a bona fide component of the GPI anchor biosynthetic pathway curated by
+      Reactome (Synthesis of glycosylphosphatidylinositol).
+    supported_by:
+    - reference_id: Reactome:R-HSA-162710
+      supporting_text: GPI is synthesized in the endoplasmic reticulum.
+    - reference_id: Reactome:R-HSA-162857
+      supporting_text: In the second step of GPI synthesis, N-acetylglucosaminyl-PI is hydrolyzed
+        to yield glucosaminyl-PI and acetate.
+- term:
+    id: GO:0000225
+    label: N-acetylglucosaminylphosphatidylinositol deacetylase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162857
+  qualifier: enables
+  review:
+    summary: Reactome traceable annotation of the second-step deacetylase reaction
+      (N-acetylglucosaminyl-PI + H2O -&gt; glucosaminyl-PI + acetate) catalyzed by PIG-L.
+      Correct core molecular function.
+    action: ACCEPT
+    reason: The Reactome reaction curation directly attributes the GlcNAc-PI de-N-acetylase
+      activity to PIG-L, matching the experimental and phylogenetic evidence.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162857
+      supporting_text: as is the PIG-L enzyme that catalyzes it
+- term:
+    id: GO:0000225
+    label: N-acetylglucosaminylphosphatidylinositol deacetylase activity
+  evidence_type: EXP
+  original_reference_id: PMID:14742432
+  qualifier: enables
+  review:
+    summary: Experimental demonstration of GlcNAc-PI de-N-acetylase activity for human PIG-L
+      (Pottekat &amp; Menon 2004), which characterized the activity and its ER localization.
+      This is the strongest, experiment-based support for the core molecular function.
+    action: ACCEPT
+    reason: Direct experimental evidence in human cells that PIG-L catalyzes GlcNAc-PI
+      de-N-acetylation; represents the core catalytic function.
+    supported_by:
+    - reference_id: PMID:14742432
+      supporting_text: catalyzed by N-acetylglucosaminylphosphatidylinositol deacetylase (PIG-L).
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: EXP
+  original_reference_id: PMID:10085243
+  qualifier: located_in
+  review:
+    summary: ER membrane localization supported in the original PIG-L characterization; the
+      de-N-acetylation step and its enzyme are components of the ER GPI machinery.
+    action: ACCEPT
+    reason: ER membrane localization is correct and independently confirmed by the
+      experimental study of Pottekat &amp; Menon (PMID:14742432); PIGL is a single-pass ER
+      membrane protein.
+    supported_by:
+    - reference_id: PMID:14742432
+      supporting_text: We show that human PIG-L is a type I membrane protein
+    - reference_id: file:human/PIGL/PIGL-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0000225
+    label: N-acetylglucosaminylphosphatidylinositol deacetylase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: Sequence-similarity transfer (from mouse ortholog O35790) of the deacetylase
+      molecular function. Correct and redundant with the experimental evidence.
+    action: ACCEPT
+    reason: The ISS transfer of GO:0000225 from the conserved rodent ortholog is correct and
+      matches the experimentally established human activity.
+    supported_by:
+    - reference_id: PMID:10085243
+      supporting_text: has GlcNAc-PI de-N-acetylase activity in vitro
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:14742432
+  qualifier: located_in
+  review:
+    summary: Direct assay localizing human PIG-L and its GlcNAc-PI de-N-acetylase activity
+      to the ER membrane (Pottekat &amp; Menon 2004), including identification of ER retention
+      signals. Core cellular component.
+    action: ACCEPT
+    reason: Direct experimental evidence that PIG-L is an ER membrane protein; the most
+      informative and best-supported cellular component annotation.
+    supported_by:
+    - reference_id: PMID:14742432
+      supporting_text: activity is localized to the endoplasmic reticulum (ER) but enriched in a
+    - reference_id: PMID:14742432
+      supporting_text: We show that human PIG-L is a type I membrane protein
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:10085243
+  qualifier: involved_in
+  review:
+    summary: Functional/complementation evidence (Watanabe et al. 1999) that PIG-L is
+      required for GPI biosynthesis - the rat gene was cloned by complementing a CHO mutant
+      defective in the second step, and its yeast homologue Gpi12p is essential for GPI and
+      cell viability. Core biological process.
+    action: ACCEPT
+    reason: Loss/restoration of GlcNAc-PI de-N-acetylase activity and cell-surface
+      GPI-anchored protein expression on manipulating PIG-L/Gpi12p demonstrates PIGL&#39;s
+      required role in GPI anchor biosynthesis.
+    supported_by:
+    - reference_id: PMID:10085243
+      supporting_text: the cell-surface expression of GPI-anchored proteins and GlcNAc-PI
+    - reference_id: PMID:10085243
+      supporting_text: indispensable in yeasts
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162857
+  qualifier: located_in
+  review:
+    summary: Reactome traceable annotation placing the PIG-L enzyme and its substrates in
+      the ER membrane for the second-step reaction. Correct.
+    action: ACCEPT
+    reason: Consistent with the experimental ER membrane localization; Reactome curates the
+      reaction as occurring in the ER membrane with PIG-L as the catalyst.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162857
+      supporting_text: as is the PIG-L enzyme that catalyzes it
+- term:
+    id: GO:0000225
+    label: N-acetylglucosaminylphosphatidylinositol deacetylase activity
+  evidence_type: NAS
+  original_reference_id: PMID:10085243
+  qualifier: enables
+  review:
+    summary: Non-traceable/author-statement annotation of the deacetylase molecular function
+      from the original PIG-L paper (Watanabe et al. 1999), which established GlcNAc-PI
+      de-N-acetylase activity for recombinant PIG-L. Correct core function.
+    action: ACCEPT
+    reason: The molecular function is correct and is directly supported by the enzymatic
+      assays in this reference and by later human EXP evidence (PMID:14742432).
+    supported_by:
+    - reference_id: PMID:10085243
+      supporting_text: has GlcNAc-PI de-N-acetylase activity in vitro
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: NAS
+  original_reference_id: PMID:10085243
+  qualifier: involved_in
+  review:
+    summary: Author-statement annotation of involvement in GPI biosynthesis from the
+      original PIG-L characterization. Correct core biological process.
+    action: ACCEPT
+    reason: PIG-L catalyzes the essential second step of GPI biosynthesis; the process
+      annotation is well supported by the same reference and by disease genetics
+      (CHIME/GPI-deficiency).
+    supported_by:
+    - reference_id: PMID:10085243
+      supporting_text: The second step of GPI biosynthesis is
+    - reference_id: PMID:10085243
+      supporting_text: indispensable in yeasts
+core_functions:
+- description: N-acetylglucosaminyl-phosphatidylinositol de-N-acetylase (EC 3.5.1.89)
+    catalyzing the second step of GPI anchor biosynthesis in the ER membrane - hydrolysis of
+    GlcNAc-PI to GlcN-PI plus acetate.
+  molecular_function:
+    id: GO:0000225
+    label: N-acetylglucosaminylphosphatidylinositol deacetylase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:14742432
+    supporting_text: catalyzed by N-acetylglucosaminylphosphatidylinositol deacetylase (PIG-L).
+  - reference_id: PMID:10085243
+    supporting_text: The second step of GPI biosynthesis is
+  - reference_id: file:human/PIGL/PIGL-uniprot.txt
+    supporting_text: Catalyzes the second step of glycosylphosphatidylinositol
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10085243
+  title: Mammalian PIG-L and its yeast homologue Gpi12p are N-acetylglucosaminylphosphatidylinositol
+    de-N-acetylases essential in glycosylphosphatidylinositol biosynthesis.
+  findings:
+  - statement: Recombinant PIG-L has GlcNAc-PI de-N-acetylase activity in vitro, and the
+      de-N-acetylation second step of GPI biosynthesis is conserved and essential from yeast
+      (Gpi12p) to mammals.
+    supporting_text: has GlcNAc-PI de-N-acetylase activity in vitro
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Original cloning/functional paper for PIG-L (rat gene complementing a CHO
+      mutant defective in the second step); abstract-only in cache but directly establishes
+      the deacetylase activity and its essential role in GPI biosynthesis. Cited by GOA as
+      NAS (MF) and IMP (BP).
+- id: PMID:14742432
+  title: Subcellular localization and targeting of N-acetylglucosaminyl phosphatidylinositol
+    de-N-acetylase, the second enzyme in the glycosylphosphatidylinositol biosynthetic
+    pathway.
+  findings:
+  - statement: Human PIG-L is a single-pass type I ER membrane protein whose GlcNAc-PI
+      de-N-acetylase activity is localized to the endoplasmic reticulum, retained there by a
+      multi-component localization signal.
+    supporting_text: We show that human PIG-L is a type I membrane protein
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Human enzyme-activity and ER-membrane localization/topology paper;
+      abstract-only in cache but explicitly assays human PIG-L. Supports the EXP MF and
+      EXP/IDA ER membrane annotations.
+- id: Reactome:R-HSA-162710
+  title: Synthesis of glycosylphosphatidylinositol (GPI)
+  findings:
+  - statement: GPI is synthesized in the endoplasmic reticulum via a pathway of nine
+      reactions; PIGL contributes the second reaction.
+    supporting_text: GPI is synthesized in the endoplasmic reticulum.
+- id: Reactome:R-HSA-162857
+  title: N-acetylglucosaminyl-PI + H2O -&gt; glucosaminyl-PI + acetate
+  findings:
+  - statement: The second GPI-synthesis reaction hydrolyzes N-acetylglucosaminyl-PI to
+      glucosaminyl-PI and acetate in the ER membrane, catalyzed by PIG-L.
+    supporting_text: as is the PIG-L enzyme that catalyzes it
+- id: file:human/PIGL/PIGL-uniprot.txt
+  title: UniProtKB Q9Y2B2 (PIGL_HUMAN)
+  findings:
+  - statement: PIGL catalyzes the second step of GPI biosynthesis (de-N-acetylation of
+      GlcNAc-PI) and is an ER membrane, single-pass type I membrane protein of the PIGL
+      family; variants cause CHIME syndrome.
+    supporting_text: Catalyzes the second step of glycosylphosphatidylinositol
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGM/PIGM-ai-review.html
+++ b/genes/human/PIGM/PIGM-ai-review.html
@@ -1,0 +1,3558 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGM - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGM</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9H3S5" target="_blank" class="term-link">
+                        Q9H3S5
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGM";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9H3S5" data-a="DESCRIPTION: PIGM is the catalytic subunit of GPI mannosyltrans..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGM is the catalytic subunit of GPI mannosyltransferase I (GPI-MT-I), the enzyme that transfers the first mannose, in an alpha-1,4 linkage, from dolichyl-phosphate-mannose (Dol-P-Man) onto the glucosaminyl-(acyl)phosphatidylinositol (GlcN-(acyl)PI) intermediate during glycosylphosphatidylinositol (GPI) anchor biosynthesis. It is a multi-pass endoplasmic reticulum membrane protein whose catalytic DXD motif faces the ER lumen, so this mannosylation step occurs on the lumenal side of the ER membrane. PIGM acts together with the stabilizing subunit PIGX to form the GPI-MT-I complex. Loss of PIGM function causes an inherited GPI deficiency (GPI biosynthesis defect); a hypomorphic PIGM promoter mutation is associated with portal and cerebral vein thrombosis and atypical absence seizures.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000030" target="_blank" class="term-link">
+                                    GO:0000030
+                                </a>
+                            </span>
+                            <span class="term-label">mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0000030" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> General mannosyltransferase activity, assigned by phylogenetic inference. This is correct but far less specific than PIGM&#39;s characterized activity (transfer of the first GPI mannose via an alpha-1,4 bond from Dol-P-Man), which is captured by GO:0180041.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation is in the right molecular-function branch but is too general. PIGM is a specific GPI alpha-1,4-mannosyltransferase (GPI-MT-I); the specific term GO:0180041 (also present in GOA with IDA support) should be preferred.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180041" target="_blank" class="term-link">
+                                    dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGM and PIGV are GPI-mannosyltransferase (MT) I and II, respectively</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990529" target="_blank" class="term-link">
+                                    GO:1990529
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-mannosyltransferase I complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:1990529" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGM is part of the GPI-mannosyltransferase I complex, which in mammals comprises the catalytic subunit PIGM and the stabilizing subunit PIGX. This is the correct complex assignment for PIGM.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The GPI-MT-I complex membership is well established; PIGM is its catalytic subunit and PIGX stabilizes it.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGM functions in association with PIGX, which stabilizes PIGM</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">complex that is composed of PIGM and PIGX</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGM catalyzes step 6 of GPI-anchor biosynthesis (addition of the first mannose), so involvement in the GPI anchor biosynthetic process is the core biological process for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported core biological process; consistent with the experimental IDA annotation to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link">
+                                        PMID:11226175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-M transfers the first mannose to glycosylphosphatidylinositol on the lumenal</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004376" target="_blank" class="term-link">
+                                    GO:0004376
+                                </a>
+                            </span>
+                            <span class="term-label">GPI mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0004376" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based (IPR007704, PIG-M) electronic annotation to GPI mannosyltransferase activity. This is accurate for PIGM but less specific than the characterized dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity (GO:0180041).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct branch and biologically accurate, but the specific characterized activity term (GO:0180041) is preferable as the representative molecular function.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180041" target="_blank" class="term-link">
+                                    dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link">
+                                        PMID:11226175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-M transfers the first mannose to glycosylphosphatidylinositol on the lumenal</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation from UniProt Subcellular Location mapping to ER membrane, consistent with the experimental IDA localization (PMID:11226175) and the multi-pass ER membrane topology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization, corroborated by experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (InterPro/UniPathway) to GPI anchor biosynthetic process, redundant with and consistent with the IBA and IDA annotations to the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process; supported by experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link">
+                                        PMID:11226175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-M transfers the first mannose to glycosylphosphatidylinositol on the lumenal</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic membrane localization from InterPro. PIGM is a multi-pass ER membrane protein, so this is correct but uninformatively broad relative to the ER membrane annotation (GO:0005789).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong, but subsumed by the more specific and experimentally supported GO:0005789 (endoplasmic reticulum membrane); the bare &#39;membrane&#39; term adds little.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051751" target="_blank" class="term-link">
+                                    GO:0051751
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,4-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0051751" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based annotation to alpha-1,4-mannosyltransferase activity. PIGM does form an alpha-1,4 mannosidic bond, so this is accurate, but it is more general than the specific GPI substrate reaction (GO:0180041).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct linkage-level activity but less specific than the characterized dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity; GO:0180041 is preferred.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180041" target="_blank" class="term-link">
+                                    dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">transfer of the first mannose, via an alpha-1,4 bond from a dolichol-phosphate-mannose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180041" target="_blank" class="term-link">
+                                    GO:0180041
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000116
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0180041" data-r="GO_REF:0000116" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Rhea-based electronic annotation (RHEA:60500) to the specific catalytic activity of PIGM. This exactly matches the UniProt catalytic activity and the experimental IDA annotation to the same term, and is the representative molecular function of PIGM.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the precise, correct molecular function of PIGM and is independently supported by experimental evidence (PMID:11226175) and the UniProt Rhea reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link">
+                                        PMID:11226175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-M transfers the first mannose to glycosylphosphatidylinositol on the lumenal</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">transfer of the first mannose, via an alpha-1,4 bond from a dolichol-phosphate-mannose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28514442
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Architecture of the human interactome defines protein commun...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput AP-MS interaction (BioPlex 2.0) recording binding to STARD7 (UniProtKB:Q9NQZ5). &#39;Protein binding&#39; is uninformative and the partner captured here is not the functional GPI-MT-I subunit (PIGX); STARD7 is a phosphatidylcholine transfer protein, so this is most likely an incidental proteome-scale co-purification.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#39;protein binding&#39; from a genome-scale interactome screen does not convey a specific molecular function and the STARD7 interaction is not the biologically characterized GPI-MT-I partnership; retained but flagged rather than removed, per policy on experimental IPIs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Q9NQZ5: STARD7; NbExp=2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput AP-MS interaction (BioPlex 3.0) again recording binding to STARD7 (UniProtKB:Q9NQZ5). As with the BioPlex 2.0 annotation, &#39;protein binding&#39; is uninformative and STARD7 is not the functional GPI-MT-I partner.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicate uninformative bare &#39;protein binding&#39; from a proteome-scale interactome; does not represent a specific molecular function. Retained but flagged rather than removed, per policy on experimental IPIs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Q9NQZ5: STARD7; NbExp=2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32156170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Biosynthesis and biology of mammalian GPI-anchored proteins.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0005789" data-r="PMID:32156170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-2697) assertion that PIGM localizes to the ER membrane, where GPI biosynthesis takes place. Consistent with experimental and electronic ER-membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization; GPI is assembled on the ER membrane and PIGM is a multi-pass ER membrane protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGM and PIGV are GPI-mannosyltransferase (MT) I and II, respectively</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990529" target="_blank" class="term-link">
+                                    GO:1990529
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-mannosyltransferase I complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32156170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Biosynthesis and biology of mammalian GPI-anchored proteins.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:1990529" data-r="PMID:32156170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-2697) assertion of PIGM membership in the GPI-mannosyltransferase I complex (PIGM + PIGX). Correct and consistent with the IBA and ISS annotations to the same complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-supported complex membership; PIGM is the catalytic subunit of GPI-MT-I.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGM functions in association with PIGX, which stabilizes PIGM</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11226175
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-M transfers the first mannose to glycosylphosphatidylino...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0005789" data-r="PMID:11226175" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental localization of PIG-M to the ER membrane; the catalytic DXD motif faces the ER lumen, showing that PIGM is an ER membrane protein acting on the lumenal side.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IDA) ER membrane localization, corroborated by the multi-pass ER membrane topology; this is the core localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link">
+                                        PMID:11226175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-M has a functionally important DXD motif, a characteristic of many</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11226175
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-M transfers the first mannose to glycosylphosphatidylino...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0006506" data-r="PMID:11226175" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental demonstration that PIG-M is required for and catalyzes the addition of the first mannose in GPI biosynthesis (identified via a GPI-MT-I-defective human cell line rescued by PIG-M). This is the core biological process of PIGM.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strong experimental (IDA) support for the core GPI-anchor biosynthetic role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link">
+                                        PMID:11226175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-M transfers the first mannose to glycosylphosphatidylinositol on the lumenal</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180041" target="_blank" class="term-link">
+                                    GO:0180041
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11226175
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-M transfers the first mannose to glycosylphosphatidylino...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0180041" data-r="PMID:11226175" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence for the specific catalytic activity of PIG-M, transfer of the first mannose via an alpha-1,4 bond from Dol-P-Man to GlcN-(acyl)PI, on the lumenal side of the ER; mutation of the DXD motif (D49/D51) abolishes activity. This is the representative molecular function of PIGM.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Precise, experimentally established (IDA) molecular function; the DXD-motif mutagenesis confirms catalytic requirement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link">
+                                        PMID:11226175
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-M has a functionally important DXD motif, a characteristic of many</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">transfer of the first mannose, via an alpha-1,4 bond from a dolichol-phosphate-mannose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990529" target="_blank" class="term-link">
+                                    GO:1990529
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-mannosyltransferase I complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:1990529" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer (from mouse Pigm, UniProtKB:Q9EQY6) of membership in the GPI-MT-I complex. Consistent with the IBA and NAS annotations to the same complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct complex membership, corroborated by orthology and by ComplexPortal.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGM/PIGM-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">complex that is composed of PIGM and PIGX</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162830
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9H3S5" data-a="GO:0005789" data-r="Reactome:R-HSA-162830" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable assertion placing the PIG-M/PIG-X-catalyzed first-mannose addition (step 6 of GPI synthesis) at the lumenal surface of the ER membrane. Consistent with the experimental ER-membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization from an authoritative pathway resource; matches experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162830
+
+                                </span>
+
+                                <div class="support-text">In the fifth step of GPI synthesis, a mannose residue is added to glucosaminyl-acyl-PI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PIGM is the catalytic subunit of GPI mannosyltransferase I; it transfers the first mannose in an alpha-1,4 linkage from dolichyl-phosphate-mannose (Dol-P-Man) onto the GlcN-(acyl)PI intermediate during GPI-anchor biosynthesis, acting on the lumenal side of the ER membrane.</h3>
+                <span class="vote-buttons" data-g="Q9H3S5" data-a="FUNCTION: PIGM is the catalytic subunit of GPI mannosyltrans..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0180041" target="_blank" class="term-link">
+                            dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990529" target="_blank" class="term-link">
+                            glycosylphosphatidylinositol-mannosyltransferase I complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link">
+                                PMID:11226175
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PIG-M transfers the first mannose to glycosylphosphatidylinositol on the lumenal</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGM/PIGM-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">transfer of the first mannose, via an alpha-1,4 bond from a dolichol-phosphate-mannose</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000116.md" target="_blank" class="term-link">
+                            GO_REF:0000116
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic Gene Ontology annotation based on Rhea mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11226175" target="_blank" class="term-link">
+                            PMID:11226175
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-M transfers the first mannose to glycosylphosphatidylinositol on the lumenal side of the ER.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PIG-M is the catalytic mannosyltransferase that adds the first mannose to GPI via an alpha-1,4 bond on the lumenal side of the ER, using a lumen-facing DXD motif essential for activity.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
+                            PMID:28514442
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                            PMID:32156170
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis and biology of mammalian GPI-anchored proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PIGM and PIGV are GPI-mannosyltransferases I and II; PIGM adds Man1 and functions in association with PIGX, which stabilizes PIGM.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162830
+
+                    </span>
+                </div>
+
+                <div class="reference-title">glucosaminyl-acyl-PI + dolichol phosphate D-mannose -&gt; mannose(al1-4)glucosaminyl-acyl-PI + dolichol phosphate</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reactome reaction for the PIG-M/PIG-X-catalyzed addition of the first mannose to glucosaminyl-acyl-PI at the lumenal surface of the ER membrane.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGM/PIGM-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB Q9H3S5 PIGM record</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt describes PIGM as the catalytic subunit of the GPI-mannosyltransferase I complex (with PIGX), a multi-pass ER membrane protein that transfers the first mannose via an alpha-1,4 bond from Dol-P-Man to GlcN-(acyl)PI.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the STARD7 interaction captured in BioPlex have any physiological relevance to GPI-MT-I function or ER lipid supply, or is it an incidental proteome-scale co-purification?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9H3S5" data-a="Q: Does the STARD7 interaction captured in BioPlex ha..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structural determination of the human PIGM-PIGX GPI-MT-I complex to define the Dol-P-Man and GlcN-(acyl)PI binding sites and the role of the lumenal DXD motif.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9H3S5" data-a="EXPERIMENT: Structural determination of the human PIGM-PIGX GP..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGM-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9H3S5" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigm-q9h3s5-review-notes">PIGM (Q9H3S5) review notes</h1>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>Human PIGM = GPI alpha-1,4-mannosyltransferase I, catalytic subunit; a.k.a. GPI mannosyltransferase I (GPI-MT-I), PIG-M. HGNC:18858. 423 aa, multipass ER membrane protein, GT50 (CAZy), Pfam PF05007 Mannosyl_trans, InterPro IPR007704.</li>
+</ul>
+<h2 id="core-biology-grounded">Core biology (grounded)</h2>
+<ul>
+<li>Catalytic subunit of the GPI-mannosyltransferase I (GPI-MT-I) complex (PIGM + PIGX). PIGX stabilizes PIGM.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/32156170" title="PIGM functions in association with PIGX, which stabilizes PIGM">PMID:32156170</a></li>
+<li>Transfers the FIRST mannose (Man1), via an alpha-1,4 bond, from dolichol-phosphate-mannose (Dol-P-Man) to GlcN-(acyl)PI, i.e. step 6 of GPI biosynthesis (Rhea:60500).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11226175" title="PIG-M transfers the first mannose to glycosylphosphatidylinositol on the lumenal side of the ER">PMID:11226175</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/32156170" title="PIGM and PIGV are GPI-mannosyltransferase (MT) I and II, respectively">PMID:32156170</a></li>
+<li>Reaction occurs on the LUMENAL side of the ER membrane; catalytic DXD motif (D49, D51) in a lumen-facing domain. D49A almost abolishes and D51A abolishes activity.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/11226175" title="PIG-M has a functionally important DXD motif, a characteristic of many glycosyltransferases, within a domain facing the lumen of the endoplasmic reticulum (ER)">PMID:11226175</a><br />
+  UniProt MUTAGEN D49 (almost abolishes), D51 (abolishes) — file:human/PIGM/PIGM-uniprot.txt</li>
+<li>Reactome R-HSA-162830: "It is catalyzed by a complex of at least two components, PIG-M and PIG-X (Maeda et al. 2001; Ashida et al. 2005)."</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>ER membrane, multi-pass (10 TM helices; UniProt topology). IDA in PMID:11226175; SubCell mapping; Reactome TAS; ComplexPortal NAS (CPX-2697).</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>GPIBD1 (glycosylphosphatidylinositol biosynthesis defect 1, MIM:610293): autosomal recessive; hypomorphic PIGM PROMOTER mutation. Portal/hepatic vein thrombosis, portal hypertension, absence/atypical-absence seizures, macrocephaly, splenomegaly, cytopenias, early cerebral infarctions.<br />
+  UniProt DISEASE cites PMID:16767100 (Almeida 2006, Nat Med, promoter mutation) and PMID:31445883 (Pode-Shakked 2019, cerebral+portal vein thrombosis, macrocephaly, atypical absence seizures). Neither is cached in publications/ and neither is a GOA reference; used only as background (via UniProt), not as supporting_text.</li>
+</ul>
+<h2 id="goa-mf-term-to-use-per-instruction-read-goa-for-exact-current-mf-idlabel">GOA MF term to use (per instruction: read GOA for exact current MF id/label)</h2>
+<ul>
+<li>GOA carries GO:0180041 "dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity" (IDA PMID:11226175; also IEA RHEA). This is the specific catalytic activity term = use for core_functions molecular_function. (Confirmed current label in go.db.)</li>
+<li>Broader MF terms present: GO:0004376 GPI mannosyltransferase activity (IEA InterPro), GO:0000030 mannosyltransferase activity (IBA), GO:0051751 alpha-1,4-mannosyltransferase activity (IEA InterPro) — all correct ancestors; the specific term (0180041) is the accurate one.</li>
+</ul>
+<h2 id="interaction-ipi-annotations">Interaction (IPI) annotations</h2>
+<ul>
+<li>Two IPI GO:0005515 "protein binding" from BioPlex (PMID:28514442 BioPlex 2.0; PMID:33961781 BioPlex 3.0), with:from UniProtKB:Q9NQZ5 = STARD7. UniProt records this same IntAct interaction (Q9H3S5–Q9NQZ5 STARD7, NbExp=2). High-throughput AP-MS; STARD7 is a lipid (PC) transfer protein, not the functional GPI-MT-I partner (PIGX). Uninformative "protein binding"; MARK_AS_OVER_ANNOTATED per policy (do not REMOVE bare protein-binding IPIs).</li>
+</ul>
+<h2 id="core_functions-term-branch-checks-godb">core_functions term branch checks (go.db)</h2>
+<ul>
+<li>GO:0180041 -&gt; molecular_function (subClassOf) OK</li>
+<li>GO:0006506 -&gt; biological_process (subClassOf) OK; GO:0005789 -&gt; cellular_component (subClassOf) OK<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9H3S5
+gene_symbol: PIGM
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGM is the catalytic subunit of GPI mannosyltransferase I (GPI-MT-I),
+  the enzyme that transfers the first mannose, in an alpha-1,4 linkage, from dolichyl-phosphate-mannose
+  (Dol-P-Man) onto the glucosaminyl-(acyl)phosphatidylinositol (GlcN-(acyl)PI) intermediate
+  during glycosylphosphatidylinositol (GPI) anchor biosynthesis. It is a multi-pass
+  endoplasmic reticulum membrane protein whose catalytic DXD motif faces the ER lumen,
+  so this mannosylation step occurs on the lumenal side of the ER membrane. PIGM acts
+  together with the stabilizing subunit PIGX to form the GPI-MT-I complex. Loss of
+  PIGM function causes an inherited GPI deficiency (GPI biosynthesis defect); a hypomorphic
+  PIGM promoter mutation is associated with portal and cerebral vein thrombosis and
+  atypical absence seizures.
+existing_annotations:
+- term:
+    id: GO:0000030
+    label: mannosyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: General mannosyltransferase activity, assigned by phylogenetic inference.
+      This is correct but far less specific than PIGM&#39;s characterized activity (transfer
+      of the first GPI mannose via an alpha-1,4 bond from Dol-P-Man), which is captured
+      by GO:0180041.
+    action: MODIFY
+    reason: The annotation is in the right molecular-function branch but is too general.
+      PIGM is a specific GPI alpha-1,4-mannosyltransferase (GPI-MT-I); the specific
+      term GO:0180041 (also present in GOA with IDA support) should be preferred.
+    proposed_replacement_terms:
+    - id: GO:0180041
+      label: dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: PIGM and PIGV are GPI-mannosyltransferase (MT) I and II, respectively
+- term:
+    id: GO:1990529
+    label: glycosylphosphatidylinositol-mannosyltransferase I complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: PIGM is part of the GPI-mannosyltransferase I complex, which in mammals
+      comprises the catalytic subunit PIGM and the stabilizing subunit PIGX. This
+      is the correct complex assignment for PIGM.
+    action: ACCEPT
+    reason: The GPI-MT-I complex membership is well established; PIGM is its catalytic
+      subunit and PIGX stabilizes it.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: PIGM functions in association with PIGX, which stabilizes PIGM
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: complex that is composed of PIGM and PIGX
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: PIGM catalyzes step 6 of GPI-anchor biosynthesis (addition of the first
+      mannose), so involvement in the GPI anchor biosynthetic process is the core
+      biological process for this gene.
+    action: ACCEPT
+    reason: Well-supported core biological process; consistent with the experimental
+      IDA annotation to the same term.
+    supported_by:
+    - reference_id: PMID:11226175
+      supporting_text: PIG-M transfers the first mannose to glycosylphosphatidylinositol
+        on the lumenal
+- term:
+    id: GO:0004376
+    label: GPI mannosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro-based (IPR007704, PIG-M) electronic annotation to GPI mannosyltransferase
+      activity. This is accurate for PIGM but less specific than the characterized
+      dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity (GO:0180041).
+    action: MODIFY
+    reason: Correct branch and biologically accurate, but the specific characterized
+      activity term (GO:0180041) is preferable as the representative molecular function.
+    proposed_replacement_terms:
+    - id: GO:0180041
+      label: dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity
+    supported_by:
+    - reference_id: PMID:11226175
+      supporting_text: PIG-M transfers the first mannose to glycosylphosphatidylinositol
+        on the lumenal
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic annotation from UniProt Subcellular Location mapping to ER
+      membrane, consistent with the experimental IDA localization (PMID:11226175)
+      and the multi-pass ER membrane topology.
+    action: ACCEPT
+    reason: Correct localization, corroborated by experimental evidence.
+    supported_by:
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic annotation (InterPro/UniPathway) to GPI anchor biosynthetic
+      process, redundant with and consistent with the IBA and IDA annotations to the
+      same term.
+    action: ACCEPT
+    reason: Correct core biological process; supported by experimental evidence.
+    supported_by:
+    - reference_id: PMID:11226175
+      supporting_text: PIG-M transfers the first mannose to glycosylphosphatidylinositol
+        on the lumenal
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: Generic membrane localization from InterPro. PIGM is a multi-pass ER
+      membrane protein, so this is correct but uninformatively broad relative to the
+      ER membrane annotation (GO:0005789).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Not wrong, but subsumed by the more specific and experimentally supported
+      GO:0005789 (endoplasmic reticulum membrane); the bare &#39;membrane&#39; term adds little.
+    supported_by:
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: Multi-pass membrane protein
+- term:
+    id: GO:0051751
+    label: alpha-1,4-mannosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro-based annotation to alpha-1,4-mannosyltransferase activity.
+      PIGM does form an alpha-1,4 mannosidic bond, so this is accurate, but it is
+      more general than the specific GPI substrate reaction (GO:0180041).
+    action: MODIFY
+    reason: Correct linkage-level activity but less specific than the characterized
+      dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity; GO:0180041 is
+      preferred.
+    proposed_replacement_terms:
+    - id: GO:0180041
+      label: dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity
+    supported_by:
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: transfer of the first mannose, via an alpha-1,4 bond from a
+        dolichol-phosphate-mannose
+- term:
+    id: GO:0180041
+    label: dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000116
+  qualifier: enables
+  review:
+    summary: Rhea-based electronic annotation (RHEA:60500) to the specific catalytic
+      activity of PIGM. This exactly matches the UniProt catalytic activity and the
+      experimental IDA annotation to the same term, and is the representative molecular
+      function of PIGM.
+    action: ACCEPT
+    reason: This is the precise, correct molecular function of PIGM and is independently
+      supported by experimental evidence (PMID:11226175) and the UniProt Rhea reaction.
+    supported_by:
+    - reference_id: PMID:11226175
+      supporting_text: PIG-M transfers the first mannose to glycosylphosphatidylinositol
+        on the lumenal
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: transfer of the first mannose, via an alpha-1,4 bond from a
+        dolichol-phosphate-mannose
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  qualifier: enables
+  review:
+    summary: High-throughput AP-MS interaction (BioPlex 2.0) recording binding to
+      STARD7 (UniProtKB:Q9NQZ5). &#39;Protein binding&#39; is uninformative and the partner
+      captured here is not the functional GPI-MT-I subunit (PIGX); STARD7 is a phosphatidylcholine
+      transfer protein, so this is most likely an incidental proteome-scale co-purification.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#39;protein binding&#39; from a genome-scale interactome screen does not
+      convey a specific molecular function and the STARD7 interaction is not the biologically
+      characterized GPI-MT-I partnership; retained but flagged rather than removed,
+      per policy on experimental IPIs.
+    supported_by:
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: &#39;Q9NQZ5: STARD7; NbExp=2&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: High-throughput AP-MS interaction (BioPlex 3.0) again recording binding
+      to STARD7 (UniProtKB:Q9NQZ5). As with the BioPlex 2.0 annotation, &#39;protein binding&#39;
+      is uninformative and STARD7 is not the functional GPI-MT-I partner.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Duplicate uninformative bare &#39;protein binding&#39; from a proteome-scale interactome;
+      does not represent a specific molecular function. Retained but flagged rather
+      than removed, per policy on experimental IPIs.
+    supported_by:
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: &#39;Q9NQZ5: STARD7; NbExp=2&#39;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32156170
+  qualifier: located_in
+  review:
+    summary: ComplexPortal (CPX-2697) assertion that PIGM localizes to the ER membrane,
+      where GPI biosynthesis takes place. Consistent with experimental and electronic
+      ER-membrane annotations.
+    action: ACCEPT
+    reason: Correct localization; GPI is assembled on the ER membrane and PIGM is
+      a multi-pass ER membrane protein.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: PIGM and PIGV are GPI-mannosyltransferase (MT) I and II, respectively
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:1990529
+    label: glycosylphosphatidylinositol-mannosyltransferase I complex
+  evidence_type: NAS
+  original_reference_id: PMID:32156170
+  qualifier: part_of
+  review:
+    summary: ComplexPortal (CPX-2697) assertion of PIGM membership in the GPI-mannosyltransferase
+      I complex (PIGM + PIGX). Correct and consistent with the IBA and ISS annotations
+      to the same complex.
+    action: ACCEPT
+    reason: Well-supported complex membership; PIGM is the catalytic subunit of GPI-MT-I.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: PIGM functions in association with PIGX, which stabilizes PIGM
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:11226175
+  qualifier: located_in
+  review:
+    summary: Direct experimental localization of PIG-M to the ER membrane; the catalytic
+      DXD motif faces the ER lumen, showing that PIGM is an ER membrane protein acting
+      on the lumenal side.
+    action: ACCEPT
+    reason: Experimental (IDA) ER membrane localization, corroborated by the multi-pass
+      ER membrane topology; this is the core localization.
+    supported_by:
+    - reference_id: PMID:11226175
+      supporting_text: PIG-M has a functionally important DXD motif, a characteristic
+        of many
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:11226175
+  qualifier: involved_in
+  review:
+    summary: Direct experimental demonstration that PIG-M is required for and catalyzes
+      the addition of the first mannose in GPI biosynthesis (identified via a GPI-MT-I-defective
+      human cell line rescued by PIG-M). This is the core biological process of PIGM.
+    action: ACCEPT
+    reason: Strong experimental (IDA) support for the core GPI-anchor biosynthetic
+      role.
+    supported_by:
+    - reference_id: PMID:11226175
+      supporting_text: PIG-M transfers the first mannose to glycosylphosphatidylinositol
+        on the lumenal
+- term:
+    id: GO:0180041
+    label: dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:11226175
+  qualifier: enables
+  review:
+    summary: Direct experimental evidence for the specific catalytic activity of PIG-M,
+      transfer of the first mannose via an alpha-1,4 bond from Dol-P-Man to GlcN-(acyl)PI,
+      on the lumenal side of the ER; mutation of the DXD motif (D49/D51) abolishes
+      activity. This is the representative molecular function of PIGM.
+    action: ACCEPT
+    reason: Precise, experimentally established (IDA) molecular function; the DXD-motif
+      mutagenesis confirms catalytic requirement.
+    supported_by:
+    - reference_id: PMID:11226175
+      supporting_text: PIG-M has a functionally important DXD motif, a characteristic
+        of many
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: transfer of the first mannose, via an alpha-1,4 bond from a
+        dolichol-phosphate-mannose
+- term:
+    id: GO:1990529
+    label: glycosylphosphatidylinositol-mannosyltransferase I complex
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: part_of
+  review:
+    summary: Sequence-similarity transfer (from mouse Pigm, UniProtKB:Q9EQY6) of membership
+      in the GPI-MT-I complex. Consistent with the IBA and NAS annotations to the
+      same complex.
+    action: ACCEPT
+    reason: Correct complex membership, corroborated by orthology and by ComplexPortal.
+    supported_by:
+    - reference_id: file:human/PIGM/PIGM-uniprot.txt
+      supporting_text: complex that is composed of PIGM and PIGX
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162830
+  qualifier: located_in
+  review:
+    summary: Reactome traceable assertion placing the PIG-M/PIG-X-catalyzed first-mannose
+      addition (step 6 of GPI synthesis) at the lumenal surface of the ER membrane.
+      Consistent with the experimental ER-membrane localization.
+    action: ACCEPT
+    reason: Correct localization from an authoritative pathway resource; matches experimental
+      evidence.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162830
+      supporting_text: In the fifth step of GPI synthesis, a mannose residue is added
+        to glucosaminyl-acyl-PI
+core_functions:
+- description: PIGM is the catalytic subunit of GPI mannosyltransferase I; it transfers
+    the first mannose in an alpha-1,4 linkage from dolichyl-phosphate-mannose (Dol-P-Man)
+    onto the GlcN-(acyl)PI intermediate during GPI-anchor biosynthesis, acting on
+    the lumenal side of the ER membrane.
+  molecular_function:
+    id: GO:0180041
+    label: dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:1990529
+    label: glycosylphosphatidylinositol-mannosyltransferase I complex
+  supported_by:
+  - reference_id: PMID:11226175
+    supporting_text: PIG-M transfers the first mannose to glycosylphosphatidylinositol
+      on the lumenal
+  - reference_id: file:human/PIGM/PIGM-uniprot.txt
+    supporting_text: transfer of the first mannose, via an alpha-1,4 bond from a dolichol-phosphate-mannose
+proposed_new_terms: []
+suggested_questions:
+- question: Does the STARD7 interaction captured in BioPlex have any physiological
+    relevance to GPI-MT-I function or ER lipid supply, or is it an incidental proteome-scale
+    co-purification?
+suggested_experiments:
+- description: Structural determination of the human PIGM-PIGX GPI-MT-I complex to
+    define the Dol-P-Man and GlcN-(acyl)PI binding sites and the role of the lumenal
+    DXD motif.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000116
+  title: Automatic Gene Ontology annotation based on Rhea mapping
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:11226175
+  title: PIG-M transfers the first mannose to glycosylphosphatidylinositol on the
+    lumenal side of the ER.
+  findings:
+  - statement: PIG-M is the catalytic mannosyltransferase that adds the first mannose
+      to GPI via an alpha-1,4 bond on the lumenal side of the ER, using a lumen-facing
+      DXD motif essential for activity.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; the defining functional and localization paper
+      for PIGM/GPI-MT-I. Cached entry is abstract-only, but the abstract plus UniProt
+      (which cites this PMID for FUNCTION, catalytic activity and mutagenesis) support
+      the annotations.
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: BioPlex 2.0 proteome-scale AP-MS; source of an uninformative &#39;protein
+      binding&#39; (STARD7) IPI. Correctly cited but low relevance to PIGM&#39;s characterized
+      function.
+- id: PMID:32156170
+  title: Biosynthesis and biology of mammalian GPI-anchored proteins.
+  findings:
+  - statement: PIGM and PIGV are GPI-mannosyltransferases I and II; PIGM adds Man1
+      and functions in association with PIGX, which stabilizes PIGM.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Authoritative Kinoshita review; full text available and directly
+      supports PIGM&#39;s role as GPI-MTI and its PIGX partnership.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: BioPlex 3.0 proteome-scale AP-MS; source of a duplicate uninformative
+      &#39;protein binding&#39; (STARD7) IPI. Correctly cited but low relevance.
+- id: Reactome:R-HSA-162830
+  title: glucosaminyl-acyl-PI + dolichol phosphate D-mannose -&gt; mannose(al1-4)glucosaminyl-acyl-PI
+    + dolichol phosphate
+  findings:
+  - statement: Reactome reaction for the PIG-M/PIG-X-catalyzed addition of the first
+      mannose to glucosaminyl-acyl-PI at the lumenal surface of the ER membrane.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Reactome reaction cited by GOA for ER-membrane localization; describes
+      the exact PIGM-catalyzed step.
+- id: file:human/PIGM/PIGM-uniprot.txt
+  title: UniProtKB Q9H3S5 PIGM record
+  findings:
+  - statement: UniProt describes PIGM as the catalytic subunit of the GPI-mannosyltransferase
+      I complex (with PIGX), a multi-pass ER membrane protein that transfers the first
+      mannose via an alpha-1,4 bond from Dol-P-Man to GlcN-(acyl)PI.
+    reference_section_type: OTHER
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: UniProt record for Q9H3S5; used for catalytic activity, subunit
+      composition, and subcellular location statements.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGP/PIGP-ai-review.html
+++ b/genes/human/PIGP/PIGP-ai-review.html
@@ -1,0 +1,3507 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGP - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGP</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P57054" target="_blank" class="term-link">
+                        P57054
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGP";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P57054" data-a="DESCRIPTION: PIGP (phosphatidylinositol N-acetylglucosaminyltra..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGP (phosphatidylinositol N-acetylglucosaminyltransferase subunit P; PIG-P) is a small (158 aa) multi-pass endoplasmic reticulum membrane protein that is a required, non-catalytic accessory subunit of the GPI-N-acetylglucosaminyltransferase (GPI-GnT) complex. GPI-GnT catalyzes the first, committed step of glycosylphosphatidylinositol (GPI) anchor biosynthesis: the transfer of N-acetylglucosamine from UDP-N-acetylglucosamine onto phosphatidylinositol to give GlcNAc-phosphatidylinositol. The catalytic subunit of the complex is PIGA; PIGP is one of several accessory components (with PIGC, PIGH, PIGQ/GPI1, PIGY and the regulatory protein DPM2) that are together required for enzyme activity, and it interacts directly with PIGA and PIGQ. PIGP is broadly (ubiquitously) expressed. Biallelic loss-of-function variants in PIGP cause an autosomal-recessive inherited GPI-deficiency disorder, developmental and epileptic encephalopathy 55 (DEE55), characterized by early-onset refractory seizures, hypotonia and profound developmental delay, reflecting reduced surface expression of GPI-anchored proteins.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0005783" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that PIGP is active in the endoplasmic reticulum. This is correct: the GPI-GnT complex is an ER-membrane enzyme and PIGP is one of its subunits. The more specific ER membrane term (GO:0005789) is also present with direct evidence and is the preferred location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the established ER localization of the GPI-GnT complex. PIGP is a subunit of this ER-membrane complex (UniProt SUBUNIT; ComplexPortal IDA).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGP/PIGP-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">acetylglucosaminyltransferase (GPI-GnT) complex composed at least by</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that PIGP is involved in GPI anchor biosynthetic process. This is the core biological process of PIGP: as a GPI-GnT subunit it participates in the first committed step of GPI-anchor biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well supported by experimental evidence in human and by the conserved role of PIGP orthologs (yeast GPI19, etc.); represents the core function of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28334793" target="_blank" class="term-link">
+                                        PMID:28334793
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGP encodes a subunit of the enzyme that catalyzes</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-P is essential for GPI-GnT since a cell lacking PIG-P is GPI-anchor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA, multi-method / InterPro + UniPathway) inference of involvement in GPI anchor biosynthetic process. Redundant with the IBA/IDA/IMP annotations to the same term but biologically correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process, consistent with all experimental evidence and the UniProt PATHWAY assignment (GPI-anchor biosynthesis).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGP/PIGP-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Interacts directly with PIGA and PIGQ (PubMed:10944123).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (IEA) annotation to the generic term &#34;membrane&#34;, derived from the UniProt Subcellular Location keyword (Membrane; Multi-pass membrane protein). Correct but uninformative: the specific location is the ER membrane (GO:0005789), which is annotated with direct evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong (PIGP is a multi-pass membrane protein) but far too general and subsumed by the more precise ER membrane annotation. Retain as a non-core, generic location rather than as a core statement.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGP/PIGP-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017176" target="_blank" class="term-link">
+                                    GO:0017176
+                                </a>
+                            </span>
+                            <span class="term-label">phosphatidylinositol N-acetylglucosaminyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0017176" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro2GO, ECO:0000256) inference that PIGP &#34;enables&#34; phosphatidylinositol N-acetylglucosaminyltransferase activity. This is the complex-level catalytic activity of GPI-GnT, whose catalytic subunit is PIGA. PIGP is a required but non-catalytic accessory subunit and does not independently have this transferase activity; assigning it via the &#34;enables&#34; qualifier over-attributes the whole-complex activity to a single non-catalytic subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The catalytic activity resides in the complex (catalytic subunit PIGA); PIGP contributes to but does not independently enable it. The InterPro family (IPR016542, PIG-P_GPI19) propagates the pathway-level MF to all members. The correct representation of PIGP&#39;s relationship to this activity is the parallel IDA annotation with the &#34;contributes_to&#34; qualifier, which is accepted. Per policy, an IEA that mis-attributes a complex activity to a non-catalytic subunit is marked as over-annotated rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">associates with PIG-A and GPI1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10944123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Initial enzyme for glycosylphosphatidylinositol biosynthesis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0005515" data-r="PMID:10944123" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI annotation (IntAct) recording physical interaction of PIGP with PIGA (UniProtKB:P37287). This is the functionally meaningful interaction that assembles PIGP into the GPI-GnT complex, but the bare &#34;protein binding&#34; term is uninformative on its own.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The interaction is real and experimentally supported (PIG-P associates directly with the catalytic subunit PIG-A), but &#34;protein binding&#34; (GO:0005515) conveys no specific molecular function. The biology is captured by the GPI-GnT complex membership (GO:0000506, part_of) and the contributes_to GO:0017176 annotation. Not removed (experimental IPI); flagged as a non-informative over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">associates with PIG-A and GPI1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0005515" data-r="PMID:16162815" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI annotation (IntAct) recording physical interaction of PIGP with PIGA (UniProtKB:P37287) in the study defining the seven-component GPI-GnT complex. As above, the interaction is meaningful but the bare &#34;protein binding&#34; term is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real complex-assembly interaction, but &#34;protein binding&#34; is not an informative molecular function. The relationship is properly represented by GPI-GnT complex membership (GO:0000506) and contributes_to GO:0017176. Not removed (experimental IPI).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; IPIs from a proteome-scale binary (yeast two-hybrid) interactome map (HuRI). The many recorded partners (e.g. ITGAM, KLF11, PLP1, PLP2, PTPN1, FIS1, and other membrane proteins) are high-throughput hits with no established functional relationship to PIGP&#39;s role in GPI-GnT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput binary-interactome hits captured as generic &#34;protein binding&#34;. They add no informative molecular function and largely reflect promiscuous or screen-specific membrane-protein interactions. Retained (experimental IPI) but flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A reference map of the human binary protein interactome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32814053
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactome Mapping Provides a Network of Neurodegenerative ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; IPIs from a neurodegenerative-disease interactome map (partners include DNALI1, KLF11, ARL6IP-like membrane proteins). Generic, uninformative interaction annotation from a large-scale screen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> High-throughput screen interactions recorded as &#34;protein binding&#34;; no specific molecular function is conveyed and no functional link to PIGP&#39;s GPI-GnT role is established. Retained (experimental IPI) but flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                                        PMID:32814053
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#34;protein binding&#34; IPI from a proteome-scale AP-MS interactome (BioPlex 3.0), recording interaction with PIGA (UniProtKB:P37287). Consistent with GPI-GnT complex membership but conveyed only as generic &#34;protein binding&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The PIGA interaction is consistent with the known complex, but &#34;protein binding&#34; is uninformative. The functional content is captured by GO:0000506 (part_of) and contributes_to GO:0017176. Retained (experimental IPI) but flagged as over-annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dual proteome-scale networks reveal cell-specific remodeling of the human</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162730
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0005789" data-r="Reactome:R-HSA-162730" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author (Reactome) statement placing PIGP at the endoplasmic reticulum membrane, in the reaction &#34;phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI + UDP&#34;. This is the correct, specific location of the GPI-GnT complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and specific subcellular location; the first step of GPI biosynthesis occurs on the cytoplasmic face of the ER membrane. Concordant with the IDA annotation to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGP/PIGP-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGP is part of the GPI-GnT complex (GO:0000506). Curated by ComplexPortal from the study establishing the seven-component complex (PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY, DPM2). This is a core structural/functional annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental complex-membership annotation and central to PIGP&#39;s function as a required accessory subunit of GPI-GnT.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGP/PIGP-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">acetylglucosaminyltransferase (GPI-GnT) complex composed at least by</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-anchored proteins, was a null mutant of PIG-Y. A complex of six components</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0005789" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (ComplexPortal IDA) localization of PIGP to the ER membrane. This is the correct, specific location of the GPI-GnT complex and PIGP within it.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Specific, experimentally supported location; preferred over the generic &#34;membrane&#34; IEA. Consistent with the Reactome TAS and IBA(ER) annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGP/PIGP-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay complex-membership annotation (UniProt) that PIGP is part of the GPI-GnT complex. Core annotation, duplicate of the ComplexPortal IPI to the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported and central to PIGP function; PIGP is one of the required components of the GPI-GnT complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GPI-anchored proteins, was a null mutant of PIG-Y. A complex of six components</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0006506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation that PIGP is involved in GPI anchor biosynthetic process, from the study characterizing the GPI-GnT complex. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported involvement in the first step of GPI-anchor biosynthesis; the core function of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28334793" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28334793
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Compound heterozygous mutations in the gene PIGP are associa...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0006506" data-r="PMID:28334793" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mutant-phenotype (IMP) evidence that PIGP is involved in GPI anchor biosynthetic process: biallelic PIGP variants in patients reduce PIGP mRNA and GPI-anchored cell-surface proteins, rescued by wild-type PIGP. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strong loss-of-function genetic evidence in human that PIGP is required for GPI anchor biosynthesis; directly links the gene to its core process and to DEE55.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28334793" target="_blank" class="term-link">
+                                        PMID:28334793
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cells showed reduced PIGP mRNA levels, and an associated reduction of</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28334793" target="_blank" class="term-link">
+                                        PMID:28334793
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGP encodes a subunit of the enzyme that catalyzes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10944123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Initial enzyme for glycosylphosphatidylinositol biosynthesis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0000506" data-r="PMID:10944123" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay (MGI) complex-membership annotation that PIGP is part of the GPI-GnT complex, from the study that identified PIG-P as an essential component and showed it associates with PIG-A and GPI1/PIGQ. Core annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported complex membership; PIG-P associates with the catalytic subunit PIG-A and GPI1 and is essential for the complex&#39;s activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">associates with PIG-A and GPI1.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017176" target="_blank" class="term-link">
+                                    GO:0017176
+                                </a>
+                            </span>
+                            <span class="term-label">phosphatidylinositol N-acetylglucosaminyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10944123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Initial enzyme for glycosylphosphatidylinositol biosynthesis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P57054" data-a="GO:0017176" data-r="PMID:10944123" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct-assay annotation (MGI) with the &#34;contributes_to&#34; qualifier: PIGP contributes to the phosphatidylinositol N-acetylglucosaminyltransferase activity of the GPI-GnT complex. This is the correct way to record a required, non-catalytic subunit&#39;s participation in the complex&#39;s catalytic activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The &#34;contributes_to&#34; qualifier appropriately captures that PIGP is essential for the complex-level transferase activity without itself being the catalytic subunit (PIGA is catalytic). PIG-P-null cells are GPI-anchor negative, demonstrating its necessity for the activity. Preferred over the IEA &#34;enables&#34; annotation to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-P is essential for GPI-GnT since a cell lacking PIG-P is GPI-anchor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PIGP is a required, non-catalytic accessory subunit of the GPI-GnT complex, an ER-membrane glycosyltransferase that catalyzes the first committed step of GPI-anchor biosynthesis (GlcNAc transfer from UDP-GlcNAc to phosphatidylinositol). PIGP does not independently possess transferase activity (the catalytic subunit is PIGA) but is essential for complex activity: PIG-P-null cells are GPI-anchor negative.</h3>
+                <span class="vote-buttons" data-g="P57054" data-a="FUNCTION: PIGP is a required, non-catalytic accessory subuni..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                            glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                PMID:10944123
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PIG-P is essential for GPI-GnT since a cell lacking PIG-P is GPI-anchor</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28334793" target="_blank" class="term-link">
+                                PMID:28334793
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PIGP encodes a subunit of the enzyme that catalyzes</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                            PMID:10944123
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-P and is regulated by DPM2.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                            PMID:16162815
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-Y, a seventh component.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28334793" target="_blank" class="term-link">
+                            PMID:28334793
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Compound heterozygous mutations in the gene PIGP are associated with early infantile epileptic encephalopathy.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                            PMID:32814053
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162730
+
+                    </span>
+                </div>
+
+                <div class="reference-title">phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI + UDP</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGP/PIGP-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry P57054 (PIGP_HUMAN)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGP-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P57054" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigp-human-review-notes">PIGP (human) — review notes</h1>
+<p>UniProtKB:P57054, HGNC:3046. Aliases: DSCR5, DCRC, DSCRC, DSCR6-neighbor; "Down syndrome<br />
+critical region protein 5 / C". Gene on chr 21q22.2. 158 aa, small multi-pass membrane<br />
+protein with two predicted TM helices (UniProt TRANSMEM 40-60, 80-100).</p>
+<h2 id="core-biology-grounded-in-uniprot-cached-abstracts">Core biology (grounded in UniProt + cached abstracts)</h2>
+<p>PIGP (PIG-P) is a small, <strong>non-catalytic accessory subunit</strong> of the<br />
+GPI-N-acetylglucosaminyltransferase (<strong>GPI-GnT</strong>) complex. GPI-GnT catalyses the first,<br />
+committed step of GPI-anchor biosynthesis: transfer of GlcNAc from UDP-GlcNAc onto<br />
+phosphatidylinositol (PI) to give GlcNAc-PI. The catalytic subunit is <strong>PIGA</strong>; PIGP is<br />
+required for activity but is not itself the catalytic enzyme.</p>
+<ul>
+<li>[PMID:10944123 abstract, "Biosynthesis of GPI is initiated by GPI-N-acetylglucosaminyltransferase (GPI-GnT), which transfers N-acetylglucosamine from UDP- N-acetylglucosamine to phosphatidylinositol."] — defines the reaction.</li>
+<li>[PMID:10944123 abstract, "PIG-P, a 134-amino acid protein having two hydrophobic domains, associates with PIG-A and GPI1."] — PIGP binds PIGA (P37287) and GPI1/PIGQ.</li>
+<li>[PMID:10944123 abstract, "PIG-P is essential for GPI-GnT since a cell lacking PIG-P is GPI-anchor negative."] — required subunit (IMP-like functional evidence: PIGP-null cells are GPI-anchor negative).</li>
+<li>[PMID:16162815 abstract, "consisting of at least six proteins" ... "A complex of six components was formed without PIG-Y."] — GPI-GnT is multi-subunit; PIGP is one of the components. UniProt SUBUNIT: "composed at least by PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2".</li>
+<li>[PMID:28334793 abstract, "PIGP encodes a subunit of the enzyme that catalyzes the first step of GPI anchor biosynthesis."] — subunit, first step.</li>
+</ul>
+<h2 id="localisation">Localisation</h2>
+<p>ER membrane. UniProt subcellular location is generic "Membrane; Multi-pass membrane<br />
+protein" but the GPI-GnT complex is an ER membrane complex; ComplexPortal IDA<br />
+(PMID:16162815) places PIGP at the ER membrane (GO:0005789). IBA is to ER (GO:0005783).<br />
+Reactome TAS also ER membrane.</p>
+<h2 id="disease">Disease</h2>
+<p>Biallelic (compound het) PIGP variants cause <strong>Developmental and epileptic encephalopathy 55<br />
+(DEE55 / MIM:617599)</strong>, an autosomal-recessive inherited GPI-deficiency (IGD). Patient cells<br />
+show reduced PIGP mRNA and reduced GPI-anchored surface proteins, rescued by WT PIGP.<br />
+- [PMID:28334793 abstract, "cells showed reduced PIGP mRNA levels, and an associated reduction of GPI-anchored cell surface proteins, which was rescued by exogenous expression of wild-type PIGP."]</p>
+<h2 id="annotation-decisions-summary">Annotation decisions summary</h2>
+<ul>
+<li>GPI anchor biosynthetic process (GO:0006506) — core BP. IBA/IEA/IDA/IMP all ACCEPT.</li>
+<li>GPI-GnT complex (GO:0000506, part_of) — core CC. IPI/IDA ACCEPT.</li>
+<li>ER (GO:0005783 IBA) / ER membrane (GO:0005789 IDA, TAS) — ACCEPT; ER membrane is the more precise, correct location.</li>
+<li>membrane (GO:0016020 IEA) — correct but generic; KEEP_AS_NON_CORE (subsumed by ER membrane).</li>
+<li>phosphatidylinositol N-acetylglucosaminyltransferase activity (GO:0017176):</li>
+<li>IEA (InterPro GO_REF:0000002, enables) — PIGP is a NON-catalytic subunit; assigning the<br />
+    catalytic MF via "enables" to the accessory subunit is an over-annotation of the whole-complex<br />
+    activity onto a single non-catalytic subunit. MARK_AS_OVER_ANNOTATED (do not REMOVE per policy on IEA vs. the correct complex-level activity residing in PIGA).</li>
+<li>IDA (PMID:10944123, contributes_to) — the <code>contributes_to</code> qualifier is exactly the correct<br />
+    way to record a non-catalytic subunit's participation in the complex's catalytic activity. ACCEPT.</li>
+<li>protein binding (GO:0005515 IPI) x several:</li>
+<li>PMID:10944123 (with PIGA P37287) and PMID:16162815 (with PIGA P37287) — these are the<br />
+    functionally meaningful GPI-GnT complex interactions. Bare <code>protein binding</code> is<br />
+    uninformative; MARK_AS_OVER_ANNOTATED (functional content captured by GPI-GnT complex part_of + GO:0017176 contributes_to). Not REMOVE (experimental IPI).</li>
+<li>PMID:32296183 (binary interactome / HuRI), PMID:32814053 (ND interactome), PMID:33961781<br />
+    (BioPlex) — high-throughput proteome-scale screens; bare <code>protein binding</code>, uninformative,<br />
+    many partners are unrelated membrane proteins (ITGAM, KLF11, PLP1, etc.). MARK_AS_OVER_ANNOTATED.</li>
+</ul>
+<p>No catalytic activity should be invented for PIGP itself; GOA carries GO:0017176 only via<br />
+IEA(enables, over-annotated) and IDA(contributes_to, correct). core_functions therefore<br />
+records BP + complex + location, and the MF only as contributes_to (GO:0017176) — not as an<br />
+<code>enables</code>/<code>molecular_function</code> claim for PIGP alone.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P57054
+gene_symbol: PIGP
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PIGP (phosphatidylinositol N-acetylglucosaminyltransferase subunit P; PIG-P)
+  is a small (158 aa) multi-pass endoplasmic reticulum membrane protein that is
+  a required, non-catalytic accessory subunit of the GPI-N-acetylglucosaminyltransferase
+  (GPI-GnT) complex. GPI-GnT catalyzes the first, committed step of
+  glycosylphosphatidylinositol (GPI) anchor biosynthesis: the transfer of
+  N-acetylglucosamine from UDP-N-acetylglucosamine onto phosphatidylinositol to
+  give GlcNAc-phosphatidylinositol. The catalytic subunit of the complex is PIGA;
+  PIGP is one of several accessory components (with PIGC, PIGH, PIGQ/GPI1, PIGY and
+  the regulatory protein DPM2) that are together required for enzyme activity, and
+  it interacts directly with PIGA and PIGQ. PIGP is broadly (ubiquitously) expressed.
+  Biallelic loss-of-function variants in PIGP cause an autosomal-recessive inherited
+  GPI-deficiency disorder, developmental and epileptic encephalopathy 55 (DEE55),
+  characterized by early-onset refractory seizures, hypotonia and profound
+  developmental delay, reflecting reduced surface expression of GPI-anchored proteins.
+alternative_products:
+- name: B
+  id: P57054-1
+- name: A
+  id: P57054-2
+  sequence_note: VSP_004202
+- name: C (DCRC-S)
+  id: P57054-3
+  sequence_note: VSP_004203, VSP_004204
+existing_annotations:
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that PIGP is active in the endoplasmic reticulum.
+      This is correct: the GPI-GnT complex is an ER-membrane enzyme and PIGP is one
+      of its subunits. The more specific ER membrane term (GO:0005789) is also present
+      with direct evidence and is the preferred location.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the established ER localization of the GPI-GnT complex. PIGP
+      is a subunit of this ER-membrane complex (UniProt SUBUNIT; ComplexPortal IDA).
+    supported_by:
+    - reference_id: file:human/PIGP/PIGP-uniprot.txt
+      supporting_text: &#34;acetylglucosaminyltransferase (GPI-GnT) complex composed at least by&#34;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that PIGP is involved in GPI anchor biosynthetic
+      process. This is the core biological process of PIGP: as a GPI-GnT subunit it
+      participates in the first committed step of GPI-anchor biosynthesis.
+    action: ACCEPT
+    reason: &gt;-
+      Well supported by experimental evidence in human and by the conserved role of
+      PIGP orthologs (yeast GPI19, etc.); represents the core function of the gene.
+    supported_by:
+    - reference_id: PMID:28334793
+      supporting_text: &#34;PIGP encodes a subunit of the enzyme that catalyzes&#34;
+    - reference_id: PMID:10944123
+      supporting_text: &#34;PIG-P is essential for GPI-GnT since a cell lacking PIG-P is GPI-anchor&#34;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (IEA, multi-method / InterPro + UniPathway) inference of involvement
+      in GPI anchor biosynthetic process. Redundant with the IBA/IDA/IMP annotations
+      to the same term but biologically correct.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core biological process, consistent with all experimental evidence and
+      the UniProt PATHWAY assignment (GPI-anchor biosynthesis).
+    supported_by:
+    - reference_id: file:human/PIGP/PIGP-uniprot.txt
+      supporting_text: &#34;Interacts directly with PIGA and PIGQ (PubMed:10944123).&#34;
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (IEA) annotation to the generic term &#34;membrane&#34;, derived from the
+      UniProt Subcellular Location keyword (Membrane; Multi-pass membrane protein).
+      Correct but uninformative: the specific location is the ER membrane (GO:0005789),
+      which is annotated with direct evidence.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Not wrong (PIGP is a multi-pass membrane protein) but far too general and
+      subsumed by the more precise ER membrane annotation. Retain as a non-core,
+      generic location rather than as a core statement.
+    supported_by:
+    - reference_id: file:human/PIGP/PIGP-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Membrane&#34;
+- term:
+    id: GO:0017176
+    label: phosphatidylinositol N-acetylglucosaminyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (InterPro2GO, ECO:0000256) inference that PIGP &#34;enables&#34;
+      phosphatidylinositol N-acetylglucosaminyltransferase activity. This is the
+      complex-level catalytic activity of GPI-GnT, whose catalytic subunit is PIGA.
+      PIGP is a required but non-catalytic accessory subunit and does not independently
+      have this transferase activity; assigning it via the &#34;enables&#34; qualifier
+      over-attributes the whole-complex activity to a single non-catalytic subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The catalytic activity resides in the complex (catalytic subunit PIGA); PIGP
+      contributes to but does not independently enable it. The InterPro family
+      (IPR016542, PIG-P_GPI19) propagates the pathway-level MF to all members. The
+      correct representation of PIGP&#39;s relationship to this activity is the parallel
+      IDA annotation with the &#34;contributes_to&#34; qualifier, which is accepted. Per policy,
+      an IEA that mis-attributes a complex activity to a non-catalytic subunit is
+      marked as over-annotated rather than removed.
+    supported_by:
+    - reference_id: PMID:10944123
+      supporting_text: &#34;associates with PIG-A and GPI1.&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:10944123
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI annotation (IntAct) recording physical interaction of PIGP with PIGA
+      (UniProtKB:P37287). This is the functionally meaningful interaction that
+      assembles PIGP into the GPI-GnT complex, but the bare &#34;protein binding&#34; term
+      is uninformative on its own.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The interaction is real and experimentally supported (PIG-P associates directly
+      with the catalytic subunit PIG-A), but &#34;protein binding&#34; (GO:0005515) conveys no
+      specific molecular function. The biology is captured by the GPI-GnT complex
+      membership (GO:0000506, part_of) and the contributes_to GO:0017176 annotation.
+      Not removed (experimental IPI); flagged as a non-informative over-annotation.
+    supported_by:
+    - reference_id: PMID:10944123
+      supporting_text: &#34;associates with PIG-A and GPI1.&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI annotation (IntAct) recording physical interaction of PIGP with PIGA
+      (UniProtKB:P37287) in the study defining the seven-component GPI-GnT complex.
+      As above, the interaction is meaningful but the bare &#34;protein binding&#34; term is
+      uninformative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Real complex-assembly interaction, but &#34;protein binding&#34; is not an informative
+      molecular function. The relationship is properly represented by GPI-GnT complex
+      membership (GO:0000506) and contributes_to GO:0017176. Not removed (experimental IPI).
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: &#34;complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; IPIs from a proteome-scale binary (yeast two-hybrid)
+      interactome map (HuRI). The many recorded partners (e.g. ITGAM, KLF11, PLP1,
+      PLP2, PTPN1, FIS1, and other membrane proteins) are high-throughput hits with
+      no established functional relationship to PIGP&#39;s role in GPI-GnT.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput binary-interactome hits captured as generic &#34;protein binding&#34;.
+      They add no informative molecular function and largely reflect promiscuous or
+      screen-specific membrane-protein interactions. Retained (experimental IPI) but
+      flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: &#34;A reference map of the human binary protein interactome&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; IPIs from a neurodegenerative-disease interactome map
+      (partners include DNALI1, KLF11, ARL6IP-like membrane proteins). Generic,
+      uninformative interaction annotation from a large-scale screen.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      High-throughput screen interactions recorded as &#34;protein binding&#34;; no specific
+      molecular function is conveyed and no functional link to PIGP&#39;s GPI-GnT role is
+      established. Retained (experimental IPI) but flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:32814053
+      supporting_text: &#34;Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Bare &#34;protein binding&#34; IPI from a proteome-scale AP-MS interactome (BioPlex 3.0),
+      recording interaction with PIGA (UniProtKB:P37287). Consistent with GPI-GnT
+      complex membership but conveyed only as generic &#34;protein binding&#34;.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The PIGA interaction is consistent with the known complex, but &#34;protein binding&#34;
+      is uninformative. The functional content is captured by GO:0000506 (part_of) and
+      contributes_to GO:0017176. Retained (experimental IPI) but flagged as over-annotation.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: &#34;Dual proteome-scale networks reveal cell-specific remodeling of the human&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162730
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Traceable-author (Reactome) statement placing PIGP at the endoplasmic reticulum
+      membrane, in the reaction &#34;phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt;
+      N-acetylglucosaminyl-PI + UDP&#34;. This is the correct, specific location of the
+      GPI-GnT complex.
+    action: ACCEPT
+    reason: &gt;-
+      Correct and specific subcellular location; the first step of GPI biosynthesis
+      occurs on the cytoplasmic face of the ER membrane. Concordant with the IDA
+      annotation to the same term.
+    supported_by:
+    - reference_id: file:human/PIGP/PIGP-uniprot.txt
+      supporting_text: &#34;Multi-pass membrane&#34;
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      PIGP is part of the GPI-GnT complex (GO:0000506). Curated by ComplexPortal from
+      the study establishing the seven-component complex (PIGA, PIGC, PIGH, PIGP, PIGQ,
+      PIGY, DPM2). This is a core structural/functional annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported experimental complex-membership annotation and central to
+      PIGP&#39;s function as a required accessory subunit of GPI-GnT.
+    supported_by:
+    - reference_id: file:human/PIGP/PIGP-uniprot.txt
+      supporting_text: &#34;acetylglucosaminyltransferase (GPI-GnT) complex composed at least by&#34;
+    - reference_id: PMID:16162815
+      supporting_text: &#34;GPI-anchored proteins, was a null mutant of PIG-Y. A complex of six components&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct-assay (ComplexPortal IDA) localization of PIGP to the ER membrane. This
+      is the correct, specific location of the GPI-GnT complex and PIGP within it.
+    action: ACCEPT
+    reason: &gt;-
+      Specific, experimentally supported location; preferred over the generic
+      &#34;membrane&#34; IEA. Consistent with the Reactome TAS and IBA(ER) annotations.
+    supported_by:
+    - reference_id: file:human/PIGP/PIGP-uniprot.txt
+      supporting_text: &#34;Multi-pass membrane&#34;
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct-assay complex-membership annotation (UniProt) that PIGP is part of the
+      GPI-GnT complex. Core annotation, duplicate of the ComplexPortal IPI to the same
+      term.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported and central to PIGP function; PIGP is one of the
+      required components of the GPI-GnT complex.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: &#34;GPI-anchored proteins, was a null mutant of PIG-Y. A complex of six components&#34;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct-assay annotation that PIGP is involved in GPI anchor biosynthetic process,
+      from the study characterizing the GPI-GnT complex. Core biological process.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported involvement in the first step of GPI-anchor biosynthesis;
+      the core function of the gene.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: &#34;complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six&#34;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:28334793
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Mutant-phenotype (IMP) evidence that PIGP is involved in GPI anchor biosynthetic
+      process: biallelic PIGP variants in patients reduce PIGP mRNA and GPI-anchored
+      cell-surface proteins, rescued by wild-type PIGP. Core biological process.
+    action: ACCEPT
+    reason: &gt;-
+      Strong loss-of-function genetic evidence in human that PIGP is required for GPI
+      anchor biosynthesis; directly links the gene to its core process and to DEE55.
+    supported_by:
+    - reference_id: PMID:28334793
+      supporting_text: &#34;cells showed reduced PIGP mRNA levels, and an associated reduction of&#34;
+    - reference_id: PMID:28334793
+      supporting_text: &#34;PIGP encodes a subunit of the enzyme that catalyzes&#34;
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IDA
+  original_reference_id: PMID:10944123
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct-assay (MGI) complex-membership annotation that PIGP is part of the GPI-GnT
+      complex, from the study that identified PIG-P as an essential component and showed
+      it associates with PIG-A and GPI1/PIGQ. Core annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally supported complex membership; PIG-P associates with the catalytic
+      subunit PIG-A and GPI1 and is essential for the complex&#39;s activity.
+    supported_by:
+    - reference_id: PMID:10944123
+      supporting_text: &#34;associates with PIG-A and GPI1.&#34;
+- term:
+    id: GO:0017176
+    label: phosphatidylinositol N-acetylglucosaminyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:10944123
+  qualifier: contributes_to
+  review:
+    summary: &gt;-
+      Direct-assay annotation (MGI) with the &#34;contributes_to&#34; qualifier: PIGP
+      contributes to the phosphatidylinositol N-acetylglucosaminyltransferase activity
+      of the GPI-GnT complex. This is the correct way to record a required, non-catalytic
+      subunit&#39;s participation in the complex&#39;s catalytic activity.
+    action: ACCEPT
+    reason: &gt;-
+      The &#34;contributes_to&#34; qualifier appropriately captures that PIGP is essential for
+      the complex-level transferase activity without itself being the catalytic subunit
+      (PIGA is catalytic). PIG-P-null cells are GPI-anchor negative, demonstrating its
+      necessity for the activity. Preferred over the IEA &#34;enables&#34; annotation to the same term.
+    supported_by:
+    - reference_id: PMID:10944123
+      supporting_text: &#34;PIG-P is essential for GPI-GnT since a cell lacking PIG-P is GPI-anchor&#34;
+core_functions:
+- description: &gt;-
+    PIGP is a required, non-catalytic accessory subunit of the GPI-GnT complex, an
+    ER-membrane glycosyltransferase that catalyzes the first committed step of GPI-anchor
+    biosynthesis (GlcNAc transfer from UDP-GlcNAc to phosphatidylinositol). PIGP does not
+    independently possess transferase activity (the catalytic subunit is PIGA) but is
+    essential for complex activity: PIG-P-null cells are GPI-anchor negative.
+  supported_by:
+  - reference_id: PMID:10944123
+    supporting_text: &#34;PIG-P is essential for GPI-GnT since a cell lacking PIG-P is GPI-anchor&#34;
+  - reference_id: PMID:28334793
+    supporting_text: &#34;PIGP encodes a subunit of the enzyme that catalyzes&#34;
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  contributes_to_molecular_function:
+    id: GO:0017176
+    label: phosphatidylinositol N-acetylglucosaminyltransferase activity
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10944123
+  title: Initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-P
+    and is regulated by DPM2.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache. Establishes PIG-P as an essential component of GPI-GnT
+      that associates with PIG-A and GPI1; PIG-P-null cells are GPI-anchor negative.
+      Directly supports the complex-membership, GPI-biosynthesis, and contributes_to
+      transferase-activity annotations.
+- id: PMID:16162815
+  title: The initial enzyme for glycosylphosphatidylinositol biosynthesis requires
+    PIG-Y, a seventh component.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache. Defines the multi-component GPI-GnT complex (PIGP among
+      the components); supports complex membership, ER-membrane localization, and
+      GPI-anchor biosynthesis.
+- id: PMID:28334793
+  title: Compound heterozygous mutations in the gene PIGP are associated with early
+    infantile epileptic encephalopathy.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only in cache. Loss-of-function human genetic evidence (DEE55) that
+      PIGP is required for GPI-anchor biosynthesis; states PIGP encodes a subunit of
+      the enzyme catalyzing the first step of GPI-anchor biosynthesis.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Proteome-scale binary (Y2H) interactome. Source of several generic &#34;protein
+      binding&#34; IPIs for PIGP; partners are high-throughput hits with no established
+      functional link to GPI-GnT.
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
+    and Uncovers Widespread Protein Aggregation in Affected Brains.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Large-scale neurodegenerative-disease interactome. Source of generic &#34;protein
+      binding&#34; IPIs for PIGP; no specific functional relationship established.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      BioPlex 3.0 AP-MS interactome. Records a PIGA interaction consistent with GPI-GnT
+      but as generic &#34;protein binding&#34;.
+- id: Reactome:R-HSA-162730
+  title: phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI
+    + UDP
+  findings: []
+- id: file:human/PIGP/PIGP-uniprot.txt
+  title: UniProtKB entry P57054 (PIGP_HUMAN)
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGQ/PIGQ-ai-review.html
+++ b/genes/human/PIGQ/PIGQ-ai-review.html
@@ -1,0 +1,3358 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGQ - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGQ</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9BRB3" target="_blank" class="term-link">
+                        Q9BRB3
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGQ";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9BRB3" data-a="DESCRIPTION: PIGQ (also known as GPI1 or PIG-Q) is a non-cataly..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGQ (also known as GPI1 or PIG-Q) is a non-catalytic subunit of the glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex, the multi-protein enzyme that catalyses the first, committed step of glycosylphosphatidylinositol (GPI) anchor biosynthesis: transfer of N-acetylglucosamine from UDP-GlcNAc onto phosphatidylinositol to form GlcNAc-phosphatidylinositol. Within this complex, PIGA is the catalytic subunit, while PIGQ is a required accessory subunit (together with PIGC, PIGH, PIGP, PIGY and DPM2) that stabilises the complex and supports its activity; PIGQ itself has no independent enzymatic activity. It is a multi-pass integral membrane protein of the endoplasmic reticulum membrane, where the GPI-GnT complex assembles and acts. Biallelic loss-of-function variants in PIGQ cause multiple congenital anomalies-hypotonia-seizures syndrome 4 (MCAHS4), an autosomal-recessive inherited GPI-deficiency disorder presenting as a developmental and epileptic encephalopathy with refractory neonatal seizures, severe global developmental delay, dysmorphism and skeletal, renal and ophthalmic anomalies.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0005783" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation placing PIGQ in the endoplasmic reticulum. This is correct: the GPI-GnT complex containing PIGQ was biochemically shown to be an ER-membrane complex (PMID:9463366). ER is a core location, though the more specific ER membrane term (GO:0005789, below) better captures the localization of this multi-pass membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with experimental localization of the GPI-GnT complex to the ER membrane and conserved across orthologs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation to GPI anchor biosynthetic process. This is the core biological process for PIGQ: as a subunit of the GPI-GnT complex it participates in the first step of GPI biosynthesis, and the mammalian GPI1 protein functionally rescues yeast gpi1 mutants defective in this process (PMID:9729469).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core, well-supported and phylogenetically conserved biological role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9729469" target="_blank" class="term-link">
+                                        PMID:9729469
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the mammalian GPI1 homologues can rescue haploids</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGQ/PIGQ-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the first step of GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (InterPro IPR007720 PigQ/GPI1 signature plus UniPathway) to GPI anchor biosynthetic process. The InterPro-to-GO mapping is accurate for this family-defining domain and agrees with the experimental and phylogenetic annotations to the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct family-level electronic inference, concordant with experimental evidence for the same process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGQ/PIGQ-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the first step of GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0016020" data-r="GO_REF:0000120" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation to the generic term membrane (from UniProt SubCell SL-0162 / InterPro). PIGQ is indeed a multi-pass membrane protein, but the specific compartment is known experimentally to be the endoplasmic reticulum membrane (PMID:9463366; PMID:16162815). The generic membrane term is uninformative and should be replaced by the more specific ER membrane term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Too general; experimental evidence localizes PIGQ/the GPI-GnT complex specifically to the ER membrane, so GO:0005789 is the appropriate term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    endoplasmic reticulum membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGQ/PIGQ-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10944123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Initial enzyme for glycosylphosphatidylinositol biosynthesis...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0005515" data-r="PMID:10944123" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI (IntAct) annotation recording binary interactions of PIGQ/GPI1 with DPM2 and PIGA. These are physiological partners within the GPI-GnT complex: DPM2 associates with GPI-GnT through interactions that include GPI1, and PIG-P associates with both PIG-A and GPI1 (PMID:10944123). The bare &#34;protein binding&#34; term is uninformative; the underlying biology is captured by part_of the GPI-GnT complex (GO:0000506).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> &#34;Protein binding&#34; (GO:0005515) is too generic to convey function; the documented interactions are with fellow GPI-GnT subunits and are better represented by complex membership. Retained (not removed) as an experimental interaction annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DPM2, but not two other components of dolichol-phosphate-mannose synthase, associates with GPI-GnT through interactions with PIG-A, PIG-C and GPI1</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                                        PMID:10944123
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-P, a 134-amino acid protein having two hydrophobic domains, associates with PIG-A and GPI1</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0005515" data-r="PMID:16162815" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI (IntAct) annotation recording interaction of PIGQ with PIGA, a co-subunit of the GPI-GnT complex characterized in this study (PMID:16162815). As above, &#34;protein binding&#34; is uninformative and the interaction reflects assembly of the GPI-GnT complex (GO:0000506).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic MF term; the interaction is with a fellow complex subunit and is better captured by GPI-GnT complex membership. Retained as an experimental interaction annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI (IntAct) annotation from the BioPlex 3.0 proteome-scale AP-MS interactome (PMID:33961781), recording interaction of PIGQ with PIGH, a GPI-GnT subunit. High-throughput; &#34;protein binding&#34; is uninformative and the interaction is consistent with GPI-GnT complex membership (GO:0000506).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic MF term from a high-throughput interactome screen; the partner is a fellow complex subunit, better represented by complex membership. Retained as an experimental interaction annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                                        PMID:33961781
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">BioPlex 3.0, results from affinity purification of 10,128 human proteins-half the proteome-in 293T cells and includes 118,162 interactions among 14,586 proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40205054
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multimodal cell maps as a foundation for structural and func...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI (IntAct) annotation from a multimodal cell-map AP-MS study (PMID:40205054), recording interaction of PIGQ with PIGH. As with the other IPI annotations, &#34;protein binding&#34; is uninformative; the partner is a GPI-GnT subunit, consistent with complex membership (GO:0000506).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic MF term from a high-throughput interactome/imaging study; the partner is a fellow complex subunit. Retained as an experimental interaction annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                                        PMID:40205054
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a total of 36,842 interactions among 7,543 proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9463366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The first step of glycosylphosphatidylinositol biosynthesis ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0005515" data-r="PMID:9463366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI (IntAct) annotation recording interactions of PIGQ/GPI1 with PIGA, PIGC and PIGH. This is the foundational study defining the PIG-A/PIG-H/PIG-C/GPI1 complex in the ER membrane (PMID:9463366). The bare &#34;protein binding&#34; term is uninformative; the biology is captured by GPI-GnT complex membership (GO:0000506).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic MF term; all partners are fellow GPI-GnT subunits and the interactions define the complex, which is better represented by GO:0000506. Retained as an experimental interaction annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGQ is a component of the GPI-GnT complex. This ComplexPortal annotation (CPX-6502) records PIGQ as a subunit of the seven-component GPI-GnT complex (PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY, DPM2) characterized in PMID:16162815. This is a core cellular-component annotation for PIGQ.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by biochemical characterization of the GPI-GnT complex; PIGQ is an established subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six proteins</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGQ/PIGQ-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0005789" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation localizing PIGQ to the endoplasmic reticulum membrane, where the GPI-GnT complex assembles and acts. The GPI-GnT complex was biochemically shown to reside in the ER membrane (PMID:9463366), and PIGQ is a multi-pass ER-membrane protein. Core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Specific, experimentally supported subcellular localization consistent with the complex&#39;s site of action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation (UniProt) recording PIGQ as part of the GPI-GnT complex, based on the biochemical characterization in PMID:16162815. Duplicate of the ComplexPortal complex annotation with direct experimental evidence; core cellular-component annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by experimental characterization of the GPI-GnT complex; PIGQ is an established subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A complex of six components was formed without PIG-Y</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGQ/PIGQ-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0006506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA annotation to GPI anchor biosynthetic process, from the study establishing the seven-component GPI-GnT complex that catalyses the first step of GPI biosynthesis (PMID:16162815). This is the core biological process for PIGQ.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process, directly supported by characterization of the GPI-GnT complex to which PIGQ belongs.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162730
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0005789" data-r="Reactome:R-HSA-162730" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS annotation from Reactome localizing the GlcNAc-PI-forming reaction and its catalysing multimeric enzyme to the ER membrane. Concordant with the IDA ER-membrane annotation; core location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with experimental localization of the GPI-GnT complex to the ER membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                        PMID:9463366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005975" target="_blank" class="term-link">
+                                    GO:0005975
+                                </a>
+                            </span>
+                            <span class="term-label">carbohydrate metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9729469" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9729469
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human and mouse Gpi1p homologues restore glycosylphosphatidy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9BRB3" data-a="GO:0005975" data-r="PMID:9729469" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS annotation to the very broad term carbohydrate metabolic process, based on the cloning/functional-complementation study of GPI1 (PMID:9729469). While technically true (the GPI-GnT reaction transfers a sugar), this term is far too general. The specific process is GPI anchor biosynthesis (formation of GlcNAc-PI), already captured by GO:0006506.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Overly general; the informative and accurate term is GPI anchor biosynthetic process (GO:0006506), which describes the actual pathway PIGQ participates in.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GPI anchor biosynthetic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9729469" target="_blank" class="term-link">
+                                        PMID:9729469
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">allow conclusions about a specific function for Gpi1p in stabilizing the enzymic complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Non-catalytic subunit of the GPI-N-acetylglucosaminyltransferase (GPI-GnT) complex, contributing to the first committed step of GPI-anchor biosynthesis (transfer of GlcNAc from UDP-GlcNAc to phosphatidylinositol) at the ER membrane; PIGQ stabilises the complex rather than performing catalysis itself (the catalytic subunit is PIGA).</h3>
+                <span class="vote-buttons" data-g="Q9BRB3" data-a="FUNCTION: Non-catalytic subunit of the GPI-N-acetylglucosami..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                            glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                                PMID:9463366
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">four mammalian gene products form a protein complex in the endoplasmic reticulum membrane</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9729469" target="_blank" class="term-link">
+                                PMID:9729469
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">allow conclusions about a specific function for Gpi1p in stabilizing the enzymic complex</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGQ/PIGQ-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">participates in the first step of GPI</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10944123" target="_blank" class="term-link">
+                            PMID:10944123
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-P and is regulated by DPM2.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                            PMID:16162815
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-Y, a seventh component.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
+                            PMID:40205054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9463366" target="_blank" class="term-link">
+                            PMID:9463366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The first step of glycosylphosphatidylinositol biosynthesis is mediated by a complex of PIG-A, PIG-H, PIG-C and GPI1.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9729469" target="_blank" class="term-link">
+                            PMID:9729469
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human and mouse Gpi1p homologues restore glycosylphosphatidylinositol membrane anchor biosynthesis in yeast mutants.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162730
+
+                    </span>
+                </div>
+
+                <div class="reference-title">phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI + UDP</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGQ/PIGQ-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q9BRB3 (PIGQ_HUMAN)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the precise structural and mechanistic contribution of PIGQ within the GPI-GnT complex - does it act purely as a scaffolding/stabilising subunit, or does it also modulate substrate (phosphatidylinositol) selection or catalytic rate?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BRB3" data-a="Q: What is the precise structural and mechanistic con..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute the human GPI-GnT complex with and without PIGQ and measure GlcNAc-PI transferase activity and complex stability to quantify PIGQ&#39;s contribution to assembly versus catalysis.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BRB3" data-a="EXPERIMENT: Reconstitute the human GPI-GnT complex with and wi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine a cryo-EM structure of the intact human GPI-GnT complex to define PIGQ&#39;s interfaces with PIGA (catalytic subunit), PIGC, PIGH, PIGP, PIGY and DPM2.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9BRB3" data-a="EXPERIMENT: Determine a cryo-EM structure of the intact human ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGQ-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9BRB3" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigq-gpi1-review-notes">PIGQ (GPI1) review notes</h1>
+<p>UniProtKB: Q9BRB3. HGNC:14135. Synonym GPI1. Gene on chr16p13.3.</p>
+<h2 id="function-verified-from-primary-literature-uniprot">Function (verified from primary literature + UniProt)</h2>
+<p>PIGQ (also GPI1 / PIG-Q) is a <strong>non-catalytic subunit of the GPI-N-acetylglucosaminyltransferase (GPI-GnT) complex</strong>, the multi-protein ER-membrane enzyme that catalyses the <strong>first, committed step of GPI-anchor biosynthesis</strong>: transfer of GlcNAc from UDP-GlcNAc to phosphatidylinositol (PI) → GlcNAc-PI. The catalytic subunit is PIGA; PIGQ is a required accessory/scaffolding subunit.</p>
+<ul>
+<li>UniProt FUNCTION: "Part of the glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex that catalyzes the transfer of N-acetylglucosamine from UDP-N-acetylglucosamine to phosphatidylinositol and participates in the first step of GPI biosynthesis." [file:human/PIGQ/PIGQ-uniprot.txt]</li>
+<li>UniProt SUBUNIT: complex composed at least by PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2 (PMID:16162815, PMID:9463366). Interacts with PIGA, PIGH and PIGC (PMID:9463366).</li>
+<li>The GOA TSV carries <strong>no catalytic MF term</strong>. UniProt DR has GO:0017176 (phosphatidylinositol N-acetylglucosaminyltransferase activity) as IEA:Ensembl, but this is NOT in the GOA snapshot, and PIGQ is not the catalytic subunit — so no catalytic activity is asserted here.</li>
+</ul>
+<h3 id="complex-membership-role">Complex membership / role</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/9463366" title="four mammalian gene products form a protein complex in the endoplasmic reticulum membrane. ... The protein complex had GPI-GlcNAc transferase (GPI-GnT) activity in vitro">PMID:9463366</a> — first defines the PIG-A/PIG-H/PIG-C/GPI1 complex; localises it to the ER membrane; GPI-GnT activity in vitro.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/9729469" title="allow conclusions about a specific function for Gpi1p in stabilizing the enzymic complex">PMID:9729469</a> — Gpi1p/GPI1 role = stabilising the GPI-GnT enzymic complex; mammalian GPI1 rescues yeast gpi1 mutants (first step of GPI biosynthesis, conserved).</li>
+<li>[PMID:10944123 "GPI-GnT is a uniquely complex glycosyltransferase, consisting of at least four proteins, PIG-A, PIG-H, PIG-C and GPI1"; "PIG-P ... associates with PIG-A and GPI1"; "DPM2 ... associates with GPI-GnT through interactions with PIG-A, PIG-C and GPI1"] — GPI1 interacts with PIG-P and DPM2 within the complex (IPI partners DPM2 O94777, PIGA P37287).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16162815" title="Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT) consisting of at least six proteins. Here, we report that human GPI-GnT requires another component, termed PIG-Y ... A complex of six components was formed without PIG-Y.">PMID:16162815</a> — establishes 7-component complex incl. PIGQ; the "complex of six" (PIGA/PIGC/PIGH/PIGP/PIGQ/DPM2) forms without PIG-Y. Source of the IDA GPI-GnT-complex, ER-membrane, and GPI-anchor-biosynthesis annotations.</li>
+</ul>
+<h3 id="location">Location</h3>
+<ul>
+<li>ER membrane. PMID:9463366 (complex in ER membrane). UniProt SUBCELLULAR LOCATION: Membrane; multi-pass membrane protein (5 predicted TM helices, residues 278-497).</li>
+<li>Reactome R-HSA-162730: the GlcNAc-PI-forming reaction and its catalysing multimeric enzyme are "localized to the endoplasmic reticulum membrane".</li>
+</ul>
+<h2 id="mf-protein-binding-ipi-annotations">MF: protein binding (IPI) annotations</h2>
+<p>Five IPI GO:0005515 annotations from IntAct, all to physiological GPI-GnT partners:<br />
+- PMID:10944123 → DPM2 (O94777), PIGA (P37287)<br />
+- PMID:16162815 → PIGA (P37287)<br />
+- PMID:33961781 (BioPlex) → PIGH (Q14442)<br />
+- PMID:40205054 (multimodal cell maps) → PIGH (Q14442)<br />
+- PMID:9463366 → PIGA (P37287), PIGC (Q92535), PIGH (Q14442)<br />
+Bare "protein binding" is uninformative per curation policy; the biology is better captured by part_of GPI-GnT complex (GO:0000506). Per policy, do NOT REMOVE experimental IPIs whose full text is unverified — MARK_AS_OVER_ANNOTATED. Interactions with PIGA/PIGC/PIGH/PIGP/DPM2 are all with fellow complex subunits, corroborating complex membership.</p>
+<h2 id="disease">Disease</h2>
+<p>Biallelic PIGQ loss-of-function → <strong>Multiple congenital anomalies-hypotonia-seizures syndrome 4 (MCAHS4; MIM:618548)</strong>, an autosomal-recessive inherited GPI-deficiency disorder (GPIBD) = a developmental and epileptic encephalopathy: refractory neonatal seizures, severe global developmental delay, dysmorphism, skeletal/renal/ophthalmic anomalies; caused cellularly by defective GPI synthesis. Refs PMID:24463883, 25558065, 27513193, 31148362. (These are disease/phenotype refs, not in GOA; noted for description only.)</p>
+<h2 id="annotation-review-decisions-goa-has-15-rows">Annotation review decisions (GOA has 15 rows)</h2>
+<ul>
+<li>GO:0005783 endoplasmic reticulum (IBA, GO_REF:0000033, is_active_in) → ACCEPT (core location, phylo). ER is correct; ER membrane (below) is more specific.</li>
+<li>GO:0006506 GPI anchor biosynthetic process (IBA, GO_REF:0000033) → ACCEPT (core BP).</li>
+<li>GO:0006506 GPI anchor biosynthetic process (IEA, GO_REF:0000120; InterPro IPR007720 + UniPathway) → ACCEPT.</li>
+<li>GO:0016020 membrane (IEA, GO_REF:0000120; SubCell SL-0162) → MODIFY → GO:0005789 ER membrane (too general; specific ER-membrane localization is known).</li>
+<li>GO:0005515 protein binding ×5 (IPI) → MARK_AS_OVER_ANNOTATED (uninformative; partners are complex subunits; captured by GO:0000506).</li>
+<li>GO:0000506 GPI-GnT complex (IPI, PMID:16162815, ComplexPortal) → ACCEPT (core CC).</li>
+<li>GO:0005789 ER membrane (IDA, PMID:16162815, ComplexPortal) → ACCEPT (core location).</li>
+<li>GO:0000506 GPI-GnT complex (IDA, PMID:16162815, UniProt) → ACCEPT (core CC).</li>
+<li>GO:0006506 GPI anchor biosynthetic process (IDA, PMID:16162815) → ACCEPT (core BP).</li>
+<li>GO:0005789 ER membrane (TAS, Reactome R-HSA-162730) → ACCEPT.</li>
+<li>GO:0005975 carbohydrate metabolic process (TAS, PMID:9729469) → MODIFY → GO:0006506 (too general; the specific process is GPI anchor biosynthesis / GlcNAc-PI formation).</li>
+</ul>
+<h2 id="core_functions">core_functions</h2>
+<p>No catalytic MF in GOA → omit <code>function</code>; record BP via directly_involved_in GO:0006506, location GO:0005789 (ER membrane), complex GO:0000506 (GPI-GnT complex).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9BRB3
+gene_symbol: PIGQ
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PIGQ (also known as GPI1 or PIG-Q) is a non-catalytic subunit of the
+  glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+  complex, the multi-protein enzyme that catalyses the first, committed step of
+  glycosylphosphatidylinositol (GPI) anchor biosynthesis: transfer of
+  N-acetylglucosamine from UDP-GlcNAc onto phosphatidylinositol to form
+  GlcNAc-phosphatidylinositol. Within this complex, PIGA is the catalytic
+  subunit, while PIGQ is a required accessory subunit (together with PIGC, PIGH,
+  PIGP, PIGY and DPM2) that stabilises the complex and supports its activity;
+  PIGQ itself has no independent enzymatic activity. It is a multi-pass integral
+  membrane protein of the endoplasmic reticulum membrane, where the GPI-GnT
+  complex assembles and acts. Biallelic loss-of-function variants in PIGQ cause
+  multiple congenital anomalies-hypotonia-seizures syndrome 4 (MCAHS4), an
+  autosomal-recessive inherited GPI-deficiency disorder presenting as a
+  developmental and epileptic encephalopathy with refractory neonatal seizures,
+  severe global developmental delay, dysmorphism and skeletal, renal and
+  ophthalmic anomalies.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q9BRB3-1
+- name: &#39;2&#39;
+  id: Q9BRB3-2
+  sequence_note: VSP_007281, VSP_007282
+- name: &#39;3&#39;
+  id: Q9BRB3-3
+  sequence_note: VSP_007279, VSP_007280
+existing_annotations:
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation placing PIGQ in the endoplasmic reticulum.
+      This is correct: the GPI-GnT complex containing PIGQ was biochemically
+      shown to be an ER-membrane complex (PMID:9463366). ER is a core location,
+      though the more specific ER membrane term (GO:0005789, below) better
+      captures the localization of this multi-pass membrane protein.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with experimental localization of the GPI-GnT complex to the ER
+      membrane and conserved across orthologs.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: &gt;-
+        four mammalian gene products form a protein complex in the endoplasmic
+        reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) annotation to GPI anchor biosynthetic process. This is
+      the core biological process for PIGQ: as a subunit of the GPI-GnT complex
+      it participates in the first step of GPI biosynthesis, and the mammalian
+      GPI1 protein functionally rescues yeast gpi1 mutants defective in this
+      process (PMID:9729469).
+    action: ACCEPT
+    reason: &gt;-
+      Core, well-supported and phylogenetically conserved biological role.
+    supported_by:
+    - reference_id: PMID:9729469
+      supporting_text: &gt;-
+        the mammalian GPI1 homologues can rescue haploids
+    - reference_id: file:human/PIGQ/PIGQ-uniprot.txt
+      supporting_text: participates in the first step of GPI
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic annotation (InterPro IPR007720 PigQ/GPI1 signature plus
+      UniPathway) to GPI anchor biosynthetic process. The InterPro-to-GO mapping
+      is accurate for this family-defining domain and agrees with the
+      experimental and phylogenetic annotations to the same term.
+    action: ACCEPT
+    reason: &gt;-
+      Correct family-level electronic inference, concordant with experimental
+      evidence for the same process.
+    supported_by:
+    - reference_id: file:human/PIGQ/PIGQ-uniprot.txt
+      supporting_text: participates in the first step of GPI
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic annotation to the generic term membrane (from UniProt SubCell
+      SL-0162 / InterPro). PIGQ is indeed a multi-pass membrane protein, but the
+      specific compartment is known experimentally to be the endoplasmic
+      reticulum membrane (PMID:9463366; PMID:16162815). The generic membrane
+      term is uninformative and should be replaced by the more specific ER
+      membrane term.
+    action: MODIFY
+    reason: &gt;-
+      Too general; experimental evidence localizes PIGQ/the GPI-GnT complex
+      specifically to the ER membrane, so GO:0005789 is the appropriate term.
+    proposed_replacement_terms:
+    - id: GO:0005789
+      label: endoplasmic reticulum membrane
+    supported_by:
+    - reference_id: file:human/PIGQ/PIGQ-uniprot.txt
+      supporting_text: Membrane
+    - reference_id: PMID:9463366
+      supporting_text: &gt;-
+        four mammalian gene products form a protein complex in the endoplasmic
+        reticulum membrane
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:10944123
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI (IntAct) annotation recording binary interactions of PIGQ/GPI1 with
+      DPM2 and PIGA. These are physiological partners within the GPI-GnT
+      complex: DPM2 associates with GPI-GnT through interactions that include
+      GPI1, and PIG-P associates with both PIG-A and GPI1 (PMID:10944123). The
+      bare &#34;protein binding&#34; term is uninformative; the underlying biology is
+      captured by part_of the GPI-GnT complex (GO:0000506).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;Protein binding&#34; (GO:0005515) is too generic to convey function; the
+      documented interactions are with fellow GPI-GnT subunits and are better
+      represented by complex membership. Retained (not removed) as an
+      experimental interaction annotation.
+    supported_by:
+    - reference_id: PMID:10944123
+      supporting_text: &gt;-
+        DPM2, but not two other components of dolichol-phosphate-mannose
+        synthase, associates with GPI-GnT through interactions with PIG-A, PIG-C
+        and GPI1
+    - reference_id: PMID:10944123
+      supporting_text: &gt;-
+        PIG-P, a 134-amino acid protein having two hydrophobic domains,
+        associates with PIG-A and GPI1
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI (IntAct) annotation recording interaction of PIGQ with PIGA, a
+      co-subunit of the GPI-GnT complex characterized in this study
+      (PMID:16162815). As above, &#34;protein binding&#34; is uninformative and the
+      interaction reflects assembly of the GPI-GnT complex (GO:0000506).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic MF term; the interaction is with a fellow complex subunit and is
+      better captured by GPI-GnT complex membership. Retained as an experimental
+      interaction annotation.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: &gt;-
+        Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an
+        unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT)
+        consisting of at least six proteins
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI (IntAct) annotation from the BioPlex 3.0 proteome-scale AP-MS
+      interactome (PMID:33961781), recording interaction of PIGQ with PIGH, a
+      GPI-GnT subunit. High-throughput; &#34;protein binding&#34; is uninformative and
+      the interaction is consistent with GPI-GnT complex membership
+      (GO:0000506).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic MF term from a high-throughput interactome screen; the partner is
+      a fellow complex subunit, better represented by complex membership.
+      Retained as an experimental interaction annotation.
+    supported_by:
+    - reference_id: PMID:33961781
+      supporting_text: &gt;-
+        BioPlex 3.0, results from affinity purification of 10,128 human
+        proteins-half the proteome-in 293T cells and includes 118,162
+        interactions among 14,586 proteins
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI (IntAct) annotation from a multimodal cell-map AP-MS study
+      (PMID:40205054), recording interaction of PIGQ with PIGH. As with the
+      other IPI annotations, &#34;protein binding&#34; is uninformative; the partner is
+      a GPI-GnT subunit, consistent with complex membership (GO:0000506).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic MF term from a high-throughput interactome/imaging study; the
+      partner is a fellow complex subunit. Retained as an experimental
+      interaction annotation.
+    supported_by:
+    - reference_id: PMID:40205054
+      supporting_text: &gt;-
+        a total of 36,842 interactions among 7,543 proteins
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:9463366
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI (IntAct) annotation recording interactions of PIGQ/GPI1 with PIGA,
+      PIGC and PIGH. This is the foundational study defining the
+      PIG-A/PIG-H/PIG-C/GPI1 complex in the ER membrane (PMID:9463366). The bare
+      &#34;protein binding&#34; term is uninformative; the biology is captured by
+      GPI-GnT complex membership (GO:0000506).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Generic MF term; all partners are fellow GPI-GnT subunits and the
+      interactions define the complex, which is better represented by GO:0000506.
+      Retained as an experimental interaction annotation.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: &gt;-
+        four mammalian gene products form a protein complex in the endoplasmic
+        reticulum membrane
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      PIGQ is a component of the GPI-GnT complex. This ComplexPortal annotation
+      (CPX-6502) records PIGQ as a subunit of the seven-component GPI-GnT complex
+      (PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY, DPM2) characterized in PMID:16162815.
+      This is a core cellular-component annotation for PIGQ.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by biochemical characterization of the GPI-GnT complex;
+      PIGQ is an established subunit.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: &gt;-
+        Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an
+        unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT)
+        consisting of at least six proteins
+    - reference_id: file:human/PIGQ/PIGQ-uniprot.txt
+      supporting_text: PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      IDA annotation localizing PIGQ to the endoplasmic reticulum membrane,
+      where the GPI-GnT complex assembles and acts. The GPI-GnT complex was
+      biochemically shown to reside in the ER membrane (PMID:9463366), and PIGQ
+      is a multi-pass ER-membrane protein. Core location.
+    action: ACCEPT
+    reason: &gt;-
+      Specific, experimentally supported subcellular localization consistent
+      with the complex&#39;s site of action.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: &gt;-
+        four mammalian gene products form a protein complex in the endoplasmic
+        reticulum membrane
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      IDA annotation (UniProt) recording PIGQ as part of the GPI-GnT complex,
+      based on the biochemical characterization in PMID:16162815. Duplicate of
+      the ComplexPortal complex annotation with direct experimental evidence;
+      core cellular-component annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by experimental characterization of the GPI-GnT
+      complex; PIGQ is an established subunit.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: &gt;-
+        A complex of six components was formed without PIG-Y
+    - reference_id: file:human/PIGQ/PIGQ-uniprot.txt
+      supporting_text: PIGA, PIGC, PIGH, PIGP, PIGQ, PIGY and DPM2
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      IDA annotation to GPI anchor biosynthetic process, from the study
+      establishing the seven-component GPI-GnT complex that catalyses the first
+      step of GPI biosynthesis (PMID:16162815). This is the core biological
+      process for PIGQ.
+    action: ACCEPT
+    reason: &gt;-
+      Core process, directly supported by characterization of the GPI-GnT
+      complex to which PIGQ belongs.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: &gt;-
+        Biosynthesis of glycosylphosphatidylinositol (GPI) is initiated by an
+        unusually complex GPI-N-acetylglucosaminyltransferase (GPI-GnT)
+        consisting of at least six proteins
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162730
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      TAS annotation from Reactome localizing the GlcNAc-PI-forming reaction and
+      its catalysing multimeric enzyme to the ER membrane. Concordant with the
+      IDA ER-membrane annotation; core location.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with experimental localization of the GPI-GnT complex to the ER
+      membrane.
+    supported_by:
+    - reference_id: PMID:9463366
+      supporting_text: &gt;-
+        four mammalian gene products form a protein complex in the endoplasmic
+        reticulum membrane
+- term:
+    id: GO:0005975
+    label: carbohydrate metabolic process
+  evidence_type: TAS
+  original_reference_id: PMID:9729469
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAS annotation to the very broad term carbohydrate metabolic process,
+      based on the cloning/functional-complementation study of GPI1
+      (PMID:9729469). While technically true (the GPI-GnT reaction transfers a
+      sugar), this term is far too general. The specific process is GPI anchor
+      biosynthesis (formation of GlcNAc-PI), already captured by GO:0006506.
+    action: MODIFY
+    reason: &gt;-
+      Overly general; the informative and accurate term is GPI anchor
+      biosynthetic process (GO:0006506), which describes the actual pathway PIGQ
+      participates in.
+    proposed_replacement_terms:
+    - id: GO:0006506
+      label: GPI anchor biosynthetic process
+    supported_by:
+    - reference_id: PMID:9729469
+      supporting_text: &gt;-
+        allow conclusions about a specific function for Gpi1p in stabilizing the
+        enzymic complex
+core_functions:
+- description: &gt;-
+    Non-catalytic subunit of the GPI-N-acetylglucosaminyltransferase (GPI-GnT)
+    complex, contributing to the first committed step of GPI-anchor biosynthesis
+    (transfer of GlcNAc from UDP-GlcNAc to phosphatidylinositol) at the ER
+    membrane; PIGQ stabilises the complex rather than performing catalysis
+    itself (the catalytic subunit is PIGA).
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  supported_by:
+  - reference_id: PMID:9463366
+    supporting_text: &gt;-
+      four mammalian gene products form a protein complex in the endoplasmic
+      reticulum membrane
+  - reference_id: PMID:9729469
+    supporting_text: &gt;-
+      allow conclusions about a specific function for Gpi1p in stabilizing the
+      enzymic complex
+  - reference_id: file:human/PIGQ/PIGQ-uniprot.txt
+    supporting_text: participates in the first step of GPI
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    What is the precise structural and mechanistic contribution of PIGQ within
+    the GPI-GnT complex - does it act purely as a scaffolding/stabilising
+    subunit, or does it also modulate substrate (phosphatidylinositol) selection
+    or catalytic rate?
+suggested_experiments:
+- description: &gt;-
+    Reconstitute the human GPI-GnT complex with and without PIGQ and measure
+    GlcNAc-PI transferase activity and complex stability to quantify PIGQ&#39;s
+    contribution to assembly versus catalysis.
+- description: &gt;-
+    Determine a cryo-EM structure of the intact human GPI-GnT complex to define
+    PIGQ&#39;s interfaces with PIGA (catalytic subunit), PIGC, PIGH, PIGP, PIGY and
+    DPM2.
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10944123
+  title: Initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-P
+    and is regulated by DPM2.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Establishes GPI1/PIGQ as a component of the GPI-GnT complex and its
+      interactions with PIG-P and DPM2 within the complex. Supports IPI and
+      complex-membership annotations.
+- id: PMID:16162815
+  title: The initial enzyme for glycosylphosphatidylinositol biosynthesis requires
+    PIG-Y, a seventh component.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Defines the seven-component GPI-GnT complex including PIGQ; source of the
+      IDA GPI-GnT-complex, ER-membrane and GPI-anchor-biosynthesis annotations.
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput BioPlex 3.0 AP-MS interactome; contributes a PIGQ-PIGH
+      interaction underpinning a generic protein-binding annotation.
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput multimodal (AP-MS + imaging) cell-map study; contributes a
+      PIGQ-PIGH interaction underpinning a generic protein-binding annotation.
+- id: PMID:9463366
+  title: The first step of glycosylphosphatidylinositol biosynthesis is mediated by
+    a complex of PIG-A, PIG-H, PIG-C and GPI1.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Foundational study cloning human GPI1 and defining the PIG-A/PIG-H/PIG-C/GPI1
+      complex in the ER membrane with GPI-GnT activity in vitro.
+- id: PMID:9729469
+  title: Human and mouse Gpi1p homologues restore glycosylphosphatidylinositol membrane
+    anchor biosynthesis in yeast mutants.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Shows mammalian GPI1 functionally complements yeast gpi1 mutants and
+      concludes GPI1&#39;s role is stabilising the GPI-GnT enzymic complex.
+- id: Reactome:R-HSA-162730
+  title: phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI
+    + UDP
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reactome reaction for the first step of GPI biosynthesis, localized to the
+      ER membrane; supports the TAS ER-membrane annotation.
+- id: file:human/PIGQ/PIGQ-uniprot.txt
+  title: UniProtKB entry Q9BRB3 (PIGQ_HUMAN)
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGV/PIGV-ai-review.html
+++ b/genes/human/PIGV/PIGV-ai-review.html
@@ -1,0 +1,3565 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGV - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGV</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9NUD9" target="_blank" class="term-link">
+                        Q9NUD9
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGV";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9NUD9" data-a="DESCRIPTION: PIGV (GPI alpha-1,6-mannosyltransferase 2; GPI man..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGV (GPI alpha-1,6-mannosyltransferase 2; GPI mannosyltransferase II, GPI-MT-II) is a multi-pass endoplasmic reticulum membrane protein that catalyzes transfer of the second mannose, via an alpha-1,6 linkage, from dolichyl-phosphate-mannose (Dol-P-Man) onto the growing glycosylphosphatidylinositol (GPI) intermediate (Man1-GlcN-(acyl)PI to Man2-GlcN-(acyl)PI). This is one of four Dol-P-Man-dependent mannosyltransferase steps in GPI-anchor biosynthesis, occurring on the lumenal face of the ER membrane; the resulting GPI anchor is used to attach many proteins to the cell surface. PIGV belongs to CAZy glycosyltransferase family GT76 (Pfam Mannosyl_trans2 / InterPro PIG-V/Gpi18) and is conserved across eukaryotes, with the Saccharomyces cerevisiae ortholog GPI18/YBR004C. Loss-of-function variants cause hyperphosphatasia with impaired intellectual development syndrome 1 (HPMRS1, Mabry syndrome), characterized by elevated serum alkaline phosphatase, intellectual disability, seizures, hypotonia, and facial dysmorphism.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) localization of PIGV activity to the ER membrane. PIGV is a multi-pass ER membrane enzyme whose GPI-MT-II activity acts on the lumenal face of the ER, so ER membrane is the correct site of action. Consistent with direct experimental localization (PMID:15623507) and UniProt subcellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and specific cellular component for this ER-resident GPI biosynthetic enzyme; supported by direct experimental evidence in addition to the IBA inference.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human PIG-V encodes a 493-amino acid, endoplasmic reticulum (ER) resident protein with eight putative transmembrane regions.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120563" target="_blank" class="term-link">
+                                    GO:0120563
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(1)GlcN-acyl-PI alpha-1,6-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0120563" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of the specific GPI-MT-II catalytic activity, the transfer of the second mannose via an alpha-1,6 bond from Dol-P-Man onto the Man1-GlcN-(acyl)PI GPI intermediate. This is the exact enzymatic activity of PIGV and the most informative molecular function term available; it is corroborated by direct human experimental work (PMID:15623507) and yeast/human complementation (PMID:15720390).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core molecular function of PIGV, at the correct level of specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we report the cloning of PIG-V involved in transferring the second mannose in the GPI anchor.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four Dol-P-Man-dependent mannosyltransferases, GPI-MT-I, -MT-II, -MT-III, and -MT-IV for the first, second, third, and fourth mannoses</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031501" target="_blank" class="term-link">
+                                    GO:0031501
+                                </a>
+                            </span>
+                            <span class="term-label">mannosyltransferase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0031501" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment of PIGV to a mannosyltransferase complex. Mammalian GPI-MT-II activity is attributed to PIG-V acting as the catalyst or as a component of the catalytic complex, so complex membership is plausible. However, the composition of a distinct PIGV mannosyltransferase complex in human is not experimentally well established here, so this is retained as a supporting (non-core) annotation rather than a defining function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reasonable at the phylogenetic level and consistent with GPI-MT-II being a component of a catalytic assembly, but it is a supporting structural annotation, not the core catalytic/process function of the gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162873
+
+                                </span>
+
+                                <div class="support-text">PIG-V was identified as the catylyst, or a component of the catalyst, of this reaction</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment to GPI anchor biosynthesis. PIGV catalyzes the seventh step of the GPI-anchor biosynthetic pathway (second-mannose addition), so this is the correct core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process of PIGV; strongly supported by experimental (PMID:15623507, PMID:15720390) and pathway evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The biosynthetic pathway of GPI is mediated by sequential additions of sugars and other components to phosphatidylinositol.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15720390" target="_blank" class="term-link">
+                                        PMID:15720390
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A bioinformatics-based strategy identified the essential Saccharomyces cerevisiae Ybr004c protein as a candidate for the second GPI alpha-mannosyltransferase (GPI-MT-II).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000009" target="_blank" class="term-link">
+                                    GO:0000009
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,6-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0000009" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO (IEA) mapping from the PIG-V/Gpi18 domain (IPR007315) to alpha-1,6-mannosyltransferase activity. This is a correct but less specific parent of the exact PIGV activity (GO:0120563); PIGV forms the alpha-1,6 mannosyl linkage.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate parent molecular-function term; consistent with the specific GPI-MT-II activity but broader. Kept as a correct (non-core) generalization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-V involved in transferring the second mannose in glycosylphosphatidylinositol.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004376" target="_blank" class="term-link">
+                                    GO:0004376
+                                </a>
+                            </span>
+                            <span class="term-label">GPI mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0004376" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO (IEA) mapping from the PIG-V/Gpi18 domain (IPR007315) to GPI mannosyltransferase activity. This is a correct parent term of the specific PIGV activity (GO:0120563 is a subclass of GO:0004376) and accurately describes PIGV as a GPI mannosyltransferase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate parent molecular-function term for this GPI mannosyltransferase; broader than the specific GPI-MT-II term but correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">four Dol-P-Man-dependent mannosyltransferases, GPI-MT-I, -MT-II, -MT-III, and -MT-IV for the first, second, third, and fourth mannoses</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt subcellular-location keyword mapping (IEA) to ER membrane, matching the experimentally determined localization of PIGV as a multi-pass ER membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization, consistent with experimental IDA evidence and UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGV/PIGV-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (IEA) assignment to GPI anchor biosynthesis via InterPro and UniPathway (UPA00196). This is the correct core biological process for PIGV.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process; independently supported by experimental annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15720390" target="_blank" class="term-link">
+                                        PMID:15720390
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A bioinformatics-based strategy identified the essential Saccharomyces cerevisiae Ybr004c protein as a candidate for the second GPI alpha-mannosyltransferase (GPI-MT-II).</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32814053
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactome Mapping Provides a Network of Neurodegenerative ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Bare &#39;protein binding&#39; from a large-scale yeast two-hybrid neurodegenerative-disease interactome screen (interactions reported with TGFBR2, CBX5, and SERPINH1). The term is uninformative about molecular function and the proposed partners are not expected physiological interactors of an ER-lumenal GPI biosynthetic enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare protein binding provides no functional insight and derives from a high-throughput Y2H screen; per curation policy this is marked as over-annotated rather than removed.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                                        PMID:32814053
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">systematic yeast two-hybrid interaction screening of ∼500 ND-related proteins and integration of literature interactions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162710
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0006506" data-r="Reactome:R-HSA-162710" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) placement of PIGV in the human GPI synthesis pathway (Synthesis of glycosylphosphatidylinositol). Correct core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process, curated from Reactome pathway knowledge.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162710
+
+                                </span>
+
+                                <div class="support-text">GPI is synthesized in the endoplasmic reticulum.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0005783" data-r="GO_REF:0000052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct immunofluorescence (HPA, IDA) localizing PIGV to the endoplasmic reticulum. Correct but less specific than the ER membrane annotation; PIGV is an integral ER membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported ER localization; correct parent of the more specific ER membrane term. Retained as accurate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human PIG-V encodes a 493-amino acid, endoplasmic reticulum (ER) resident protein with eight putative transmembrane regions.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004376" target="_blank" class="term-link">
+                                    GO:0004376
+                                </a>
+                            </span>
+                            <span class="term-label">GPI mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162873
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0004376" data-r="Reactome:R-HSA-162873" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) assignment of GPI mannosyltransferase activity to PIGV for the second-mannose-addition reaction. Correct parent of the specific GPI-MT-II activity (GO:0120563).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Accurate GPI mannosyltransferase molecular function, curated from Reactome; a correct generalization of the specific PIGV activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162873
+
+                                </span>
+
+                                <div class="support-text">a second mannose residue is added to the glycolipid on the lumenal face of the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120563" target="_blank" class="term-link">
+                                    GO:0120563
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(1)GlcN-acyl-PI alpha-1,6-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15623507
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-V involved in transferring the second mannose in glycosy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0120563" data-r="PMID:15623507" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (IMP) that human PIG-V is the second GPI mannosyltransferase (GPI-MT-II), transferring the second mannose via an alpha-1,6 linkage. Kang et al. cloned PIG-V, defined its catalytic activity and ER topology, and identified functionally important lumenal residues by mutagenesis. This is the exact catalytic activity of PIGV.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function with direct experimental support at the correct specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we report the cloning of PIG-V involved in transferring the second mannose in the GPI anchor.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-V has two functionally important conserved regions facing the ER lumen.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120563" target="_blank" class="term-link">
+                                    GO:0120563
+                                </a>
+                            </span>
+                            <span class="term-label">dol-P-Man:Man(1)GlcN-acyl-PI alpha-1,6-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15623507
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-V involved in transferring the second mannose in glycosy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0120563" data-r="PMID:15623507" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic interaction evidence (IGI) supporting the GPI-MT-II activity of PIGV, based on functional complementation with the yeast ortholog GPI18/YBR004C (UniProtKB:P38211). Human PIG-V cDNA rescued the yeast gpi18 deletion mutant, demonstrating conserved second-mannose-transfer function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cross-species genetic complementation directly supports the specific catalytic activity; core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Viability of the yeast gpi18 deletion mutant was restored by human PIG-V cDNA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000009" target="_blank" class="term-link">
+                                    GO:0000009
+                                </a>
+                            </span>
+                            <span class="term-label">alpha-1,6-mannosyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15720390" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15720390
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Saccharomyces cerevisiae Ybr004c and its human homologue are...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0000009" data-r="PMID:15720390" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic interaction evidence (IGI) with the yeast ortholog Ybr004c/GPI18 (UniProtKB:P38211). Fabre et al. showed the human Ybr004cp homologue (PIGV) substitutes for the yeast protein in vivo, supporting alpha-1,6-mannosyltransferase activity in second-mannose addition. This is a correct parent of the specific GPI-MT-II activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cross-species complementation supports the alpha-1,6-mannosyltransferase function; accurate parent term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15720390" target="_blank" class="term-link">
+                                        PMID:15720390
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The human Ybr004cp homologue can substitute for its S. cerevisiae counterpart in vivo.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162873
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0005789" data-r="Reactome:R-HSA-162873" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) localization of the second-mannose-addition reaction (and PIGV) to the ER membrane, consistent with PIGV being a multi-pass ER membrane enzyme acting on the lumenal face.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization, curated from Reactome; consistent with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162873
+
+                                </span>
+
+                                <div class="support-text">a second mannose residue is added to the glycolipid on the lumenal face of the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15623507
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-V involved in transferring the second mannose in glycosy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0005789" data-r="PMID:15623507" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (IDA) that PIGV is an ER-membrane protein. Kang et al. characterized PIG-V as an ER-resident protein with multiple transmembrane regions and mapped its membrane topology, establishing ER membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally determined localization; core cellular component. The multi-pass ER membrane topology is documented in UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Human PIG-V encodes a 493-amino acid, endoplasmic reticulum (ER) resident protein with eight putative transmembrane regions.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGV/PIGV-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15623507
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-V involved in transferring the second mannose in glycosy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0006506" data-r="PMID:15623507" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (IMP) placing PIGV in GPI anchor biosynthesis, via characterization of PIG-V as the enzyme transferring the second mannose in GPI assembly. Core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process with direct experimental support.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we suggest that PIG-V is the second mannosyltransferase in GPI anchor biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15623507
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIG-V involved in transferring the second mannose in glycosy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0006506" data-r="PMID:15623507" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic interaction evidence (IGI) with yeast GPI18/YBR004C (UniProtKB:P38211) supporting the role of PIGV in GPI anchor biosynthesis, via cross-species complementation of the second-mannose-addition step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Genetic complementation supports involvement in GPI anchor biosynthesis; core biological process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                        PMID:15623507
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Viability of the yeast gpi18 deletion mutant was restored by human PIG-V cDNA.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15720390" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15720390
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Saccharomyces cerevisiae Ybr004c and its human homologue are...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NUD9" data-a="GO:0006506" data-r="PMID:15720390" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic interaction evidence (IGI) with yeast Ybr004c/GPI18 (UniProtKB:P38211). Fabre et al. showed Ybr004cp-depleted yeast accumulate a single-mannose GPI intermediate and cannot incorporate inositol into proteins, and that the human homologue (PIGV) complements the defect, supporting PIGV&#39;s role in GPI anchor biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cross-species genetic evidence supports involvement in GPI anchor biosynthesis; core biological process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15720390" target="_blank" class="term-link">
+                                        PMID:15720390
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accumulate a GPI intermediate having a single mannose that is likely modified with ethanolamine phosphate</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Alpha-1,6-mannosyltransferase (GPI-MT-II) that transfers the second mannose from dolichyl-phosphate-mannose (Dol-P-Man) onto the Man1-GlcN-(acyl)PI GPI intermediate, forming the alpha-1,6 mannosyl linkage, during GPI-anchor biosynthesis on the lumenal face of the ER membrane.</h3>
+                <span class="vote-buttons" data-g="Q9NUD9" data-a="FUNCTION: Alpha-1,6-mannosyltransferase (GPI-MT-II) that tra..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120563" target="_blank" class="term-link">
+                            dol-P-Man:Man(1)GlcN-acyl-PI alpha-1,6-mannosyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                                PMID:15623507
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Here we report the cloning of PIG-V involved in transferring the second mannose in the GPI anchor.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15720390" target="_blank" class="term-link">
+                                PMID:15720390
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">A bioinformatics-based strategy identified the essential Saccharomyces cerevisiae Ybr004c protein as a candidate for the second GPI alpha-mannosyltransferase (GPI-MT-II).</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15623507" target="_blank" class="term-link">
+                            PMID:15623507
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIG-V involved in transferring the second mannose in glycosylphosphatidylinositol.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15720390" target="_blank" class="term-link">
+                            PMID:15720390
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Saccharomyces cerevisiae Ybr004c and its human homologue are required for addition of the second mannose during glycosylphosphatidylinositol precursor assembly.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                            PMID:32814053
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162710
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Synthesis of glycosylphosphatidylinositol (GPI)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162873
+
+                    </span>
+                </div>
+
+                <div class="reference-title">(ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI + dolichol phosphate D-mannose -&gt; mannose (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI + dolichol phosphate</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGV/PIGV-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB Q9NUD9 (PIGV_HUMAN) entry</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGV-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9NUD9" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigv-gpi-alpha-16-mannosyltransferase-2-gpi-mt-ii-review-notes">PIGV (GPI alpha-1,6-mannosyltransferase 2 / GPI-MT-II) — review notes</h1>
+<p>UniProtKB: Q9NUD9. HGNC:26031. 493 aa, multi-pass ER membrane protein (8 predicted TM helices).<br />
+CAZy GT76 (glycosyltransferase family 76); Pfam PF04188 (Mannosyl_trans2); InterPro IPR007315 (PIG-V/Gpi18).</p>
+<h2 id="core-function-verified">Core function (verified)</h2>
+<p>PIGV is GPI mannosyltransferase II (GPI-MT-II). It transfers the <strong>second mannose</strong>, via an<br />
+<strong>alpha-1,6 linkage</strong>, from <strong>dolichyl-phosphate-mannose (Dol-P-Man)</strong> onto the growing GPI<br />
+intermediate (Man1-GlcN-(acyl)PI -&gt; Man2-GlcN-(acyl)PI), the seventh step of GPI-anchor<br />
+biosynthesis, on the lumenal face of the ER membrane.</p>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/15623507" title="Here we report the cloning of PIG-V involved in transferring the second mannose in the GPI anchor. Human PIG-V encodes a 493-amino acid, endoplasmic reticulum (ER) resident protein with eight putative transmembrane regions.">PMID:15623507</a> — human PIG-V cloning, ER localization, topology; abstract-only cache but full text carries CATALYTIC ACTIVITY, PATHWAY, SUBCELLULAR LOCATION, TOPOLOGY, and mutagenesis (Trp66, Asp67, PP293-294, Gln308, Trp312) per UniProt RN[6].</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/15720390" title="A bioinformatics-based strategy identified the essential Saccharomyces cerevisiae Ybr004c protein as a candidate for the second GPI alpha-mannosyltransferase (GPI-MT-II).">PMID:15720390</a> — yeast Ybr004c/GPI18 = ortholog; human homologue complements yeast (IGI with S. cerevisiae P38211/GPI18).</li>
+<li>UniProt CATALYTIC ACTIVITY: RHEA:60488 (Dol-P-Man + Man1-GlcN-acyl-PI -&gt; Man2-GlcN-acyl-PI). EC 2.4.1.-. PATHWAY: Glycolipid biosynthesis; GPI-anchor biosynthesis (UPA00196).</li>
+</ul>
+<h2 id="goa-mf-term">GOA MF term</h2>
+<p>GOA carries the specific term <strong>GO:0120563 dol-P-Man:Man(1)GlcN-acyl-PI alpha-1,6-mannosyltransferase activity</strong><br />
+(IBA GO_REF:0000033; IMP+IGI PMID:15623507; also broader GO:0004376 GPI mannosyltransferase activity and<br />
+GO:0000009 alpha-1,6-mannosyltransferase activity as IEA/IGI/TAS). GO:0120563 is a subclass of both broader<br />
+terms and is the exact catalytic activity of PIGV — used as the core MF.</p>
+<h2 id="localization">Localization</h2>
+<p>ER membrane, multi-pass (GO:0005789) — UniProt SUBCELLULAR LOCATION ECO:0000269|PubMed:15623507; also<br />
+HPA IDA to ER (GO:0005783).</p>
+<h2 id="complex">Complex</h2>
+<p>GOA IBA GO:0031501 mannosyltransferase complex (part_of). GPI-MT-II activity is attributed to PIG-V "or a<br />
+component of the catalyst" (Reactome R-HSA-162873). Mammalian GPI-MT-II is a complex (PIGV with PIGX/PIGN etc.),<br />
+so complex membership is reasonable at IBA level; keep as non-core supporting term.</p>
+<h2 id="disease">Disease</h2>
+<p>Hyperphosphatasia with impaired intellectual development syndrome 1 (HPMRS1 / Mabry syndrome), MIM 239300:<br />
+elevated serum alkaline phosphatase, intellectual disability, seizures, hypotonia, facial dysmorphism.<br />
+Variants Q256K, A341E/V, H385P (PMID:20802478). Original Mabry syndrome description PMID:5465362.<br />
+(Disease context; not a GOA annotation to review.)</p>
+<h2 id="protein-binding-ipi-pmid32814053">Protein binding IPI (PMID:32814053)</h2>
+<p>Large-scale Y2H neurodegenerative-disease interactome. Three bare GO:0005515 protein binding IPIs<br />
+(TGFBR2 P37173, CBX5 P45973, SERPINH1 P50454). Uninformative for molecular function; per curation policy<br />
+bare protein binding from high-throughput screens -&gt; MARK_AS_OVER_ANNOTATED (not REMOVE). These are unlikely<br />
+physiological partners of an ER-lumenal GPI biosynthetic enzyme.</p>
+<h2 id="schema-note">Schema note</h2>
+<p>core_functions: directly_involved_in and locations are multivalued (list of Term);<br />
+molecular_function and in_complex are single inlined Term.</p>
+<h2 id="action-plan-for-goa-lines">Action plan for GOA lines</h2>
+<ul>
+<li>GO:0120563 MF (IBA/IMP/IGI) -&gt; ACCEPT (core MF)</li>
+<li>GO:0004376 GPI mannosyltransferase activity (IEA/TAS) -&gt; ACCEPT (correct parent)</li>
+<li>GO:0000009 alpha-1,6-mannosyltransferase activity (IEA/IGI) -&gt; ACCEPT (correct parent)</li>
+<li>GO:0006506 GPI anchor biosynthetic process (IBA/IEA/TAS/IMP/IGI) -&gt; ACCEPT (core BP)</li>
+<li>GO:0005789 ER membrane (IBA/IEA/TAS/IDA) -&gt; ACCEPT (core CC)</li>
+<li>GO:0005783 endoplasmic reticulum (IDA HPA) -&gt; ACCEPT (parent CC; correct but less specific than ER membrane)</li>
+<li>GO:0031501 mannosyltransferase complex (IBA part_of) -&gt; KEEP_AS_NON_CORE</li>
+<li>GO:0005515 protein binding x3 (IPI) -&gt; MARK_AS_OVER_ANNOTATED</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9NUD9
+gene_symbol: PIGV
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGV (GPI alpha-1,6-mannosyltransferase 2; GPI mannosyltransferase II,
+  GPI-MT-II) is a multi-pass endoplasmic reticulum membrane protein that catalyzes
+  transfer of the second mannose, via an alpha-1,6 linkage, from dolichyl-phosphate-mannose
+  (Dol-P-Man) onto the growing glycosylphosphatidylinositol (GPI) intermediate (Man1-GlcN-(acyl)PI
+  to Man2-GlcN-(acyl)PI). This is one of four Dol-P-Man-dependent mannosyltransferase
+  steps in GPI-anchor biosynthesis, occurring on the lumenal face of the ER membrane;
+  the resulting GPI anchor is used to attach many proteins to the cell surface. PIGV
+  belongs to CAZy glycosyltransferase family GT76 (Pfam Mannosyl_trans2 / InterPro
+  PIG-V/Gpi18) and is conserved across eukaryotes, with the Saccharomyces cerevisiae
+  ortholog GPI18/YBR004C. Loss-of-function variants cause hyperphosphatasia with impaired
+  intellectual development syndrome 1 (HPMRS1, Mabry syndrome), characterized by elevated
+  serum alkaline phosphatase, intellectual disability, seizures, hypotonia, and facial
+  dysmorphism.
+existing_annotations:
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) localization of PIGV activity to the ER membrane.
+      PIGV is a multi-pass ER membrane enzyme whose GPI-MT-II activity acts on the
+      lumenal face of the ER, so ER membrane is the correct site of action. Consistent
+      with direct experimental localization (PMID:15623507) and UniProt subcellular
+      location.
+    action: ACCEPT
+    reason: Correct and specific cellular component for this ER-resident GPI biosynthetic
+      enzyme; supported by direct experimental evidence in addition to the IBA inference.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: Human PIG-V encodes a 493-amino acid, endoplasmic reticulum
+        (ER) resident protein with eight putative transmembrane regions.
+- term:
+    id: GO:0120563
+    label: dol-P-Man:Man(1)GlcN-acyl-PI alpha-1,6-mannosyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) assignment of the specific GPI-MT-II catalytic activity,
+      the transfer of the second mannose via an alpha-1,6 bond from Dol-P-Man onto
+      the Man1-GlcN-(acyl)PI GPI intermediate. This is the exact enzymatic activity
+      of PIGV and the most informative molecular function term available; it is corroborated
+      by direct human experimental work (PMID:15623507) and yeast/human complementation
+      (PMID:15720390).
+    action: ACCEPT
+    reason: This is the core molecular function of PIGV, at the correct level of specificity.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: Here we report the cloning of PIG-V involved in transferring
+        the second mannose in the GPI anchor.
+    - reference_id: PMID:15623507
+      supporting_text: four Dol-P-Man-dependent mannosyltransferases, GPI-MT-I, -MT-II,
+        -MT-III, and -MT-IV for the first, second, third, and fourth mannoses
+- term:
+    id: GO:0031501
+    label: mannosyltransferase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: Phylogenetic (IBA) assignment of PIGV to a mannosyltransferase complex.
+      Mammalian GPI-MT-II activity is attributed to PIG-V acting as the catalyst or
+      as a component of the catalytic complex, so complex membership is plausible.
+      However, the composition of a distinct PIGV mannosyltransferase complex in human
+      is not experimentally well established here, so this is retained as a supporting
+      (non-core) annotation rather than a defining function.
+    action: KEEP_AS_NON_CORE
+    reason: Reasonable at the phylogenetic level and consistent with GPI-MT-II being
+      a component of a catalytic assembly, but it is a supporting structural annotation,
+      not the core catalytic/process function of the gene.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162873
+      supporting_text: PIG-V was identified as the catylyst, or a component of the
+        catalyst, of this reaction
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic (IBA) assignment to GPI anchor biosynthesis. PIGV catalyzes
+      the seventh step of the GPI-anchor biosynthetic pathway (second-mannose addition),
+      so this is the correct core biological process.
+    action: ACCEPT
+    reason: Core biological process of PIGV; strongly supported by experimental (PMID:15623507,
+      PMID:15720390) and pathway evidence.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: The biosynthetic pathway of GPI is mediated by sequential additions
+        of sugars and other components to phosphatidylinositol.
+    - reference_id: PMID:15720390
+      supporting_text: A bioinformatics-based strategy identified the essential Saccharomyces
+        cerevisiae Ybr004c protein as a candidate for the second GPI alpha-mannosyltransferase
+        (GPI-MT-II).
+- term:
+    id: GO:0000009
+    label: alpha-1,6-mannosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO (IEA) mapping from the PIG-V/Gpi18 domain (IPR007315) to
+      alpha-1,6-mannosyltransferase activity. This is a correct but less specific
+      parent of the exact PIGV activity (GO:0120563); PIGV forms the alpha-1,6 mannosyl
+      linkage.
+    action: ACCEPT
+    reason: Accurate parent molecular-function term; consistent with the specific
+      GPI-MT-II activity but broader. Kept as a correct (non-core) generalization.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: &#39;PIG-V involved in transferring the second mannose in glycosylphosphatidylinositol.&#39;
+- term:
+    id: GO:0004376
+    label: GPI mannosyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO (IEA) mapping from the PIG-V/Gpi18 domain (IPR007315) to
+      GPI mannosyltransferase activity. This is a correct parent term of the specific
+      PIGV activity (GO:0120563 is a subclass of GO:0004376) and accurately describes
+      PIGV as a GPI mannosyltransferase.
+    action: ACCEPT
+    reason: Accurate parent molecular-function term for this GPI mannosyltransferase;
+      broader than the specific GPI-MT-II term but correct.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: four Dol-P-Man-dependent mannosyltransferases, GPI-MT-I, -MT-II,
+        -MT-III, and -MT-IV for the first, second, third, and fourth mannoses
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt subcellular-location keyword mapping (IEA) to ER membrane, matching
+      the experimentally determined localization of PIGV as a multi-pass ER membrane
+      protein.
+    action: ACCEPT
+    reason: Correct localization, consistent with experimental IDA evidence and UniProt.
+    supported_by:
+    - reference_id: file:human/PIGV/PIGV-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Automated (IEA) assignment to GPI anchor biosynthesis via InterPro and
+      UniPathway (UPA00196). This is the correct core biological process for PIGV.
+    action: ACCEPT
+    reason: Correct core biological process; independently supported by experimental
+      annotations.
+    supported_by:
+    - reference_id: PMID:15720390
+      supporting_text: A bioinformatics-based strategy identified the essential Saccharomyces
+        cerevisiae Ybr004c protein as a candidate for the second GPI alpha-mannosyltransferase
+        (GPI-MT-II).
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  qualifier: enables
+  review:
+    summary: Bare &#39;protein binding&#39; from a large-scale yeast two-hybrid neurodegenerative-disease
+      interactome screen (interactions reported with TGFBR2, CBX5, and SERPINH1).
+      The term is uninformative about molecular function and the proposed partners
+      are not expected physiological interactors of an ER-lumenal GPI biosynthetic
+      enzyme.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare protein binding provides no functional insight and derives from a
+      high-throughput Y2H screen; per curation policy this is marked as over-annotated
+      rather than removed.
+    supported_by:
+    - reference_id: PMID:32814053
+      supporting_text: systematic yeast two-hybrid interaction screening of ∼500 ND-related
+        proteins and integration of literature interactions
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162710
+  qualifier: involved_in
+  review:
+    summary: Reactome (TAS) placement of PIGV in the human GPI synthesis pathway (Synthesis
+      of glycosylphosphatidylinositol). Correct core biological process.
+    action: ACCEPT
+    reason: Correct core biological process, curated from Reactome pathway knowledge.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162710
+      supporting_text: GPI is synthesized in the endoplasmic reticulum.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: Direct immunofluorescence (HPA, IDA) localizing PIGV to the endoplasmic
+      reticulum. Correct but less specific than the ER membrane annotation; PIGV is
+      an integral ER membrane protein.
+    action: ACCEPT
+    reason: Experimentally supported ER localization; correct parent of the more specific
+      ER membrane term. Retained as accurate.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: Human PIG-V encodes a 493-amino acid, endoplasmic reticulum
+        (ER) resident protein with eight putative transmembrane regions.
+- term:
+    id: GO:0004376
+    label: GPI mannosyltransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162873
+  qualifier: enables
+  review:
+    summary: Reactome (TAS) assignment of GPI mannosyltransferase activity to PIGV
+      for the second-mannose-addition reaction. Correct parent of the specific GPI-MT-II
+      activity (GO:0120563).
+    action: ACCEPT
+    reason: Accurate GPI mannosyltransferase molecular function, curated from Reactome;
+      a correct generalization of the specific PIGV activity.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162873
+      supporting_text: a second mannose residue is added to the glycolipid on the
+        lumenal face of the endoplasmic reticulum membrane
+- term:
+    id: GO:0120563
+    label: dol-P-Man:Man(1)GlcN-acyl-PI alpha-1,6-mannosyltransferase activity
+  evidence_type: IMP
+  original_reference_id: PMID:15623507
+  qualifier: enables
+  review:
+    summary: Direct experimental evidence (IMP) that human PIG-V is the second GPI
+      mannosyltransferase (GPI-MT-II), transferring the second mannose via an alpha-1,6
+      linkage. Kang et al. cloned PIG-V, defined its catalytic activity and ER topology,
+      and identified functionally important lumenal residues by mutagenesis. This
+      is the exact catalytic activity of PIGV.
+    action: ACCEPT
+    reason: Core molecular function with direct experimental support at the correct
+      specificity.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: Here we report the cloning of PIG-V involved in transferring
+        the second mannose in the GPI anchor.
+    - reference_id: PMID:15623507
+      supporting_text: PIG-V has two functionally important conserved regions facing
+        the ER lumen.
+- term:
+    id: GO:0120563
+    label: dol-P-Man:Man(1)GlcN-acyl-PI alpha-1,6-mannosyltransferase activity
+  evidence_type: IGI
+  original_reference_id: PMID:15623507
+  qualifier: enables
+  review:
+    summary: Genetic interaction evidence (IGI) supporting the GPI-MT-II activity
+      of PIGV, based on functional complementation with the yeast ortholog GPI18/YBR004C
+      (UniProtKB:P38211). Human PIG-V cDNA rescued the yeast gpi18 deletion mutant,
+      demonstrating conserved second-mannose-transfer function.
+    action: ACCEPT
+    reason: Cross-species genetic complementation directly supports the specific catalytic
+      activity; core molecular function.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: Viability of the yeast gpi18 deletion mutant was restored by
+        human PIG-V cDNA.
+- term:
+    id: GO:0000009
+    label: alpha-1,6-mannosyltransferase activity
+  evidence_type: IGI
+  original_reference_id: PMID:15720390
+  qualifier: enables
+  review:
+    summary: Genetic interaction evidence (IGI) with the yeast ortholog Ybr004c/GPI18
+      (UniProtKB:P38211). Fabre et al. showed the human Ybr004cp homologue (PIGV)
+      substitutes for the yeast protein in vivo, supporting alpha-1,6-mannosyltransferase
+      activity in second-mannose addition. This is a correct parent of the specific
+      GPI-MT-II activity.
+    action: ACCEPT
+    reason: Cross-species complementation supports the alpha-1,6-mannosyltransferase
+      function; accurate parent term.
+    supported_by:
+    - reference_id: PMID:15720390
+      supporting_text: The human Ybr004cp homologue can substitute for its S. cerevisiae
+        counterpart in vivo.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162873
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) localization of the second-mannose-addition reaction (and
+      PIGV) to the ER membrane, consistent with PIGV being a multi-pass ER membrane
+      enzyme acting on the lumenal face.
+    action: ACCEPT
+    reason: Correct localization, curated from Reactome; consistent with experimental
+      evidence.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162873
+      supporting_text: a second mannose residue is added to the glycolipid on the
+        lumenal face of the endoplasmic reticulum membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:15623507
+  qualifier: located_in
+  review:
+    summary: Direct experimental evidence (IDA) that PIGV is an ER-membrane protein.
+      Kang et al. characterized PIG-V as an ER-resident protein with multiple transmembrane
+      regions and mapped its membrane topology, establishing ER membrane localization.
+    action: ACCEPT
+    reason: Experimentally determined localization; core cellular component. The multi-pass
+      ER membrane topology is documented in UniProt.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: Human PIG-V encodes a 493-amino acid, endoplasmic reticulum
+        (ER) resident protein with eight putative transmembrane regions.
+    - reference_id: file:human/PIGV/PIGV-uniprot.txt
+      supporting_text: Multi-pass membrane protein
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:15623507
+  qualifier: involved_in
+  review:
+    summary: Direct experimental evidence (IMP) placing PIGV in GPI anchor biosynthesis,
+      via characterization of PIG-V as the enzyme transferring the second mannose
+      in GPI assembly. Core biological process.
+    action: ACCEPT
+    reason: Core biological process with direct experimental support.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: we suggest that PIG-V is the second mannosyltransferase in GPI
+        anchor biosynthesis
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IGI
+  original_reference_id: PMID:15623507
+  qualifier: involved_in
+  review:
+    summary: Genetic interaction evidence (IGI) with yeast GPI18/YBR004C (UniProtKB:P38211)
+      supporting the role of PIGV in GPI anchor biosynthesis, via cross-species complementation
+      of the second-mannose-addition step.
+    action: ACCEPT
+    reason: Genetic complementation supports involvement in GPI anchor biosynthesis;
+      core biological process.
+    supported_by:
+    - reference_id: PMID:15623507
+      supporting_text: Viability of the yeast gpi18 deletion mutant was restored by
+        human PIG-V cDNA.
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IGI
+  original_reference_id: PMID:15720390
+  qualifier: involved_in
+  review:
+    summary: Genetic interaction evidence (IGI) with yeast Ybr004c/GPI18 (UniProtKB:P38211).
+      Fabre et al. showed Ybr004cp-depleted yeast accumulate a single-mannose GPI
+      intermediate and cannot incorporate inositol into proteins, and that the human
+      homologue (PIGV) complements the defect, supporting PIGV&#39;s role in GPI anchor
+      biosynthesis.
+    action: ACCEPT
+    reason: Cross-species genetic evidence supports involvement in GPI anchor biosynthesis;
+      core biological process.
+    supported_by:
+    - reference_id: PMID:15720390
+      supporting_text: accumulate a GPI intermediate having a single mannose that
+        is likely modified with ethanolamine phosphate
+core_functions:
+- description: Alpha-1,6-mannosyltransferase (GPI-MT-II) that transfers the second
+    mannose from dolichyl-phosphate-mannose (Dol-P-Man) onto the Man1-GlcN-(acyl)PI
+    GPI intermediate, forming the alpha-1,6 mannosyl linkage, during GPI-anchor biosynthesis
+    on the lumenal face of the ER membrane.
+  molecular_function:
+    id: GO:0120563
+    label: dol-P-Man:Man(1)GlcN-acyl-PI alpha-1,6-mannosyltransferase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:15623507
+    supporting_text: Here we report the cloning of PIG-V involved in transferring the
+      second mannose in the GPI anchor.
+  - reference_id: PMID:15720390
+    supporting_text: A bioinformatics-based strategy identified the essential Saccharomyces
+      cerevisiae Ybr004c protein as a candidate for the second GPI alpha-mannosyltransferase
+      (GPI-MT-II).
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:15623507
+  title: PIG-V involved in transferring the second mannose in glycosylphosphatidylinositol.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Primary paper that cloned human PIG-V and identified it as GPI-MT-II,
+      transferring the second mannose in GPI biosynthesis; defines catalytic activity,
+      ER topology, and functional residues. Abstract-only in cache; full text underlies
+      the experimental annotations.
+- id: PMID:15720390
+  title: Saccharomyces cerevisiae Ybr004c and its human homologue are required for
+    addition of the second mannose during glycosylphosphatidylinositol precursor assembly.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Identifies yeast Ybr004c/GPI18 as GPI-MT-II and shows the human
+      homologue (PIGV) complements it in vivo; supports the alpha-1,6-mannosyltransferase
+      and GPI biosynthesis annotations.
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
+    and Uncovers Widespread Protein Aggregation in Affected Brains.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Large-scale yeast two-hybrid neurodegenerative-disease interactome;
+      source of bare protein binding IPIs for PIGV that are uninformative about its
+      molecular function.
+- id: Reactome:R-HSA-162710
+  title: Synthesis of glycosylphosphatidylinositol (GPI)
+  findings: []
+- id: Reactome:R-HSA-162873
+  title: (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI + dolichol phosphate
+    D-mannose -&gt; mannose (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI
+    + dolichol phosphate
+  findings: []
+- id: file:human/PIGV/PIGV-uniprot.txt
+  title: UniProtKB Q9NUD9 (PIGV_HUMAN) entry
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGW/PIGW-ai-review.html
+++ b/genes/human/PIGW/PIGW-ai-review.html
@@ -1,0 +1,3249 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGW - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGW</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q7Z7B1" target="_blank" class="term-link">
+                        Q7Z7B1
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGW";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q7Z7B1" data-a="DESCRIPTION: PIGW (phosphatidylinositol-glycan biosynthesis cla..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGW (phosphatidylinositol-glycan biosynthesis class W protein; PIG-W) is the GPI inositol acyltransferase of glycosylphosphatidylinositol (GPI) anchor biosynthesis. It is a multi-pass endoplasmic reticulum membrane protein that catalyses the fourth step of GPI-anchor assembly: transfer of an acyl group (usually palmitate) from acyl-CoA to the 2-OH of the inositol ring of glucosaminyl-phosphatidylinositol (GlcN-PI), producing 2-acyl-GlcN-PI (GlcN-(acyl)PI). This inositol acyl group is required for downstream recognition of the GPI intermediate by the GPI transamidase complex and is normally removed by PGAP1 after the anchor is attached to protein. Through this activity PIGW is essential for the ER synthesis of GPI anchors and hence for the transport of GPI-anchored proteins to the cell surface. Biallelic loss-of-function variants cause an autosomal-recessive inherited GPI-deficiency disorder (glycosylphosphatidylinositol biosynthesis defect 11, GPIBD11) on the hyperphosphatasia-with-mental-retardation / epileptic-encephalopathy spectrum, characterised by developmental delay, intellectual disability, seizures (including West syndrome with hypsarrhythmia), dysmorphic features, and elevated serum alkaline phosphatase.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0005783" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGW acts in the endoplasmic reticulum, where GPI-anchor biosynthesis occurs. This phylogenetic (IBA) location is correct but general; the ER membrane (GO:0005789) is the precise compartment for this multi-pass membrane enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with UniProt subcellular location and with GPI biosynthesis being an ER process. Kept as a correct-but-broad cellular component; the membrane-specific term is the core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process: PIGW catalyses the fourth step of GPI-anchor biosynthesis (inositol acylation of GlcN-PI). The IBA is well supported across orthologues (PomBase, SGD, CGD, RGD) and matches the human function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the central biological role of PIGW and is corroborated experimentally and by UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the fourth step of GPI-anchor biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032216" target="_blank" class="term-link">
+                                    GO:0032216
+                                </a>
+                            </span>
+                            <span class="term-label">glucosaminyl-phosphatidylinositol O-acyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0032216" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function: PIGW is the GPI inositol acyltransferase, transferring an acyl group from acyl-CoA to the 2-OH of the inositol of GlcN-PI. This specific term is the correct MF and is supported by the UniProt catalytic activity (RHEA:60496/RHEA:83759) and by the IBA across orthologues.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Specific, correct molecular function directly matching the characterised reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acyltransferase that catalyzes the acyl transfer from an</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGW is a multi-pass ER membrane protein; the ER membrane is its precise location. This SubCell-mapping IEA is correct and represents the core cellular component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matches UniProt subcellular location (ER membrane, multi-pass) and the topology features.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006505" target="_blank" class="term-link">
+                                    GO:0006505
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0006505" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GPI anchor metabolic process is the broad parent of GPI anchor biosynthetic process. PIGW is a biosynthetic enzyme, so the more specific biosynthetic term (GO:0006506) is the informative core annotation. This ARBA-generated IEA to the parent is redundant with that specific term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong, but a less-informative parent that is fully subsumed by the accepted biosynthetic process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the fourth step of GPI-anchor biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Duplicate of the core GPI anchor biosynthetic process annotation, here via combined-IEA (InterPro IPR009447 / UniPathway UPA00196). Correct and consistent with the IBA/ISS/TAS annotations to the same term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly captures the core biosynthetic role; duplicates of a correct term are acceptable.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic &#34;membrane&#34; from an InterPro2GO mapping. PIGW is specifically an ER membrane protein, so this uninformative parent is superseded by GO:0005789 (ER membrane).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Too general; the specific ER membrane location is annotated and preferred.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016746" target="_blank" class="term-link">
+                                    GO:0016746
+                                </a>
+                            </span>
+                            <span class="term-label">acyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0016746" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic acyltransferase activity from InterPro2GO. This is a broad parent of the specific, correct MF GO:0032216 (glucosaminyl-phosphatidylinositol O-acyltransferase activity).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong but uninformative relative to the specific inositol-acyltransferase term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acyltransferase that catalyzes the acyl transfer from an</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032216" target="_blank" class="term-link">
+                                    GO:0032216
+                                </a>
+                            </span>
+                            <span class="term-label">glucosaminyl-phosphatidylinositol O-acyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000116
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0032216" data-r="GO_REF:0000116" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Rhea-mapped IEA (RHEA:60496/RHEA:83759) to the specific GPI inositol acyltransferase activity, matching the UniProt catalytic activity. Duplicate of the accepted core MF term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct specific molecular function derived from the curated Rhea reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acyltransferase that catalyzes the acyl transfer from an</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162710
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0006506" data-r="Reactome:R-HSA-162710" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable annotation to the core biosynthetic process, from the human GPI synthesis pathway (R-HSA-162710), in which PIGW catalyses the inositol-acylation step.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly captures the core biosynthetic role, consistent with the IBA/IEA/ISS annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the fourth step of GPI-anchor biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0005789" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer of ER membrane localisation from the mouse orthologue (UniProtKB:Q7TSN4), consistent with the multi-pass ER membrane topology. Core cellular component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matches UniProt subcellular location for the human protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032216" target="_blank" class="term-link">
+                                    GO:0032216
+                                </a>
+                            </span>
+                            <span class="term-label">glucosaminyl-phosphatidylinositol O-acyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0032216" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer of the GPI inositol acyltransferase activity from the mouse orthologue (UniProtKB:Q7TSN4). Duplicate of the accepted specific core MF term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct specific molecular function, supported by orthology and the curated reaction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acyltransferase that catalyzes the acyl transfer from an</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0006506" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS transfer of the core GPI-anchor biosynthetic process from the mouse orthologue (UniProtKB:Q7TSN4). Duplicate of the accepted core BP term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process, supported by orthology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the fourth step of GPI-anchor biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016747" target="_blank" class="term-link">
+                                    GO:0016747
+                                </a>
+                            </span>
+                            <span class="term-label">acyltransferase activity, transferring groups other than amino-acyl groups</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162683
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0016747" data-r="Reactome:R-HSA-162683" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable annotation to a broad acyltransferase-class term for the inositol-acylation reaction (R-HSA-162683). This is a general parent of the specific MF GO:0032216.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not wrong but uninformative relative to the specific glucosaminyl-PI O-acyltransferase term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acyltransferase that catalyzes the acyl transfer from an</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006505" target="_blank" class="term-link">
+                                    GO:0006505
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor metabolic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24367057" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24367057
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Glycosylphosphatidylinositol (GPI) anchor deficiency caused ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0006505" data-r="PMID:24367057" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Curator-inferred (IC, from the GO:0072659 IMP in the same paper) annotation to the broad GPI anchor metabolic process. PIGW is specifically biosynthetic, so the biosynthetic child (GO:0006506) is the informative core term; this broad parent is a redundant over-annotation relative to the accepted biosynthetic-process term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct in essence (PIGW is in GPI-anchor metabolism) but a broad parent superseded by the specific biosynthetic-process term; kept rather than removed, consistent with the other GO:0006505 annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24367057" target="_blank" class="term-link">
+                                        PMID:24367057
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">involved in the addition of the acyl-chain to inositol in an early step of GPI</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072659" target="_blank" class="term-link">
+                                    GO:0072659
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24367057" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24367057
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Glycosylphosphatidylinositol (GPI) anchor deficiency caused ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0072659" data-r="PMID:24367057" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IMP) annotation from patient/variant studies: PIGW loss reduces surface expression of GPI-anchored proteins, i.e. PIGW is required for transport of GPI-APs to the plasma membrane. This is a downstream consequence of the enzyme&#39;s role in GPI-anchor synthesis rather than the direct molecular function, so it is retained as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Valid experimental phenotype (defer to curator; not removed). Represents a downstream cellular outcome of GPI-anchor biosynthesis, not PIGW&#39;s direct acyltransferase function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24367057" target="_blank" class="term-link">
+                                        PMID:24367057
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">decreased surface expression of GPI-APs on</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Required for the transport of GPI-anchored proteins to the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162683
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q7Z7B1" data-a="GO:0005789" data-r="Reactome:R-HSA-162683" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-traceable ER membrane localisation for the inositol-acylation reaction, consistent with the multi-pass ER membrane topology. Duplicate of the accepted core CC term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core location, consistent with UniProt and the ISS/IEA annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGW/PIGW-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>GPI inositol acyltransferase that transfers an acyl group (usually palmitate) from acyl-CoA to the 2-OH of the inositol ring of glucosaminyl-phosphatidylinositol (GlcN-PI), forming 2-acyl-GlcN-PI (GlcN-(acyl)PI) during GPI-anchor biosynthesis in the ER membrane.</h3>
+                <span class="vote-buttons" data-g="Q7Z7B1" data-a="FUNCTION: GPI inositol acyltransferase that transfers an acy..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032216" target="_blank" class="term-link">
+                            glucosaminyl-phosphatidylinositol O-acyltransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGW/PIGW-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Acyltransferase that catalyzes the acyl transfer from an</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGW/PIGW-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">participates in the fourth step of GPI-anchor biosynthesis</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGW/PIGW-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000116.md" target="_blank" class="term-link">
+                            GO_REF:0000116
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic Gene Ontology annotation based on Rhea mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24367057" target="_blank" class="term-link">
+                            PMID:24367057
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Glycosylphosphatidylinositol (GPI) anchor deficiency caused by mutations in PIGW is associated with West syndrome and hyperphosphatasia with mental retardation syndrome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">First reported patient with PIGW deficiency (GPIBD11): West syndrome with hypsarrhythmia, developmental delay, dysmorphic features and hyperphosphatasia, with decreased surface expression of GPI-anchored proteins on blood granulocytes; compound heterozygous PIGW variants.</div>
+
+                        <div class="finding-text">"involved in the addition of the acyl-chain to inositol in an early step of GPI"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162683
+
+                    </span>
+                </div>
+
+                <div class="reference-title">glucosaminyl-PI + fatty acyl-CoA -&gt; glucosaminyl-acyl-PI + CoA-SH</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Fourth step of GPI synthesis: an acyl group (typically palmitate) is transferred from acyl-CoA to glucosaminyl-PI; PIG-W catalyses this reaction.</div>
+
+                        <div class="finding-text">"In the fourth step of GPI synthesis, an acyl group (typically palmitate) is transferred from acyl CoA to glucosaminyl-PI."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162710
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Synthesis of glycosylphosphatidylinositol (GPI)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human GPI synthesis pathway (nine reactions in the ER); PIGW performs the inositol-acylation step within this pathway.</div>
+
+                        <div class="finding-text">"GPI is synthesized in the endoplasmic reticulum."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGW/PIGW-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB Q7Z7B1 PIGW record</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PIGW is an ER multi-pass membrane acyltransferase that acylates the inositol of GlcN-PI at the fourth step of GPI-anchor biosynthesis; deficiency causes GPIBD11.</div>
+
+                        <div class="finding-text">"participates in the fourth step of GPI-anchor biosynthesis"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGW-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q7Z7B1" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigw-review-notes">PIGW review notes</h1>
+<p>UniProtKB:Q7Z7B1, HGNC:23213, human PIGW (Glucosaminyl-phosphatidylinositol-acyltransferase PIGW; PIG-W;<br />
+GlcN-PI-acyltransferase). 504 aa, multi-pass ER membrane protein (11 TM helices per UniProt features).<br />
+PANTHER PTHR20661; Pfam PF06423 (GWT1); InterPro IPR009447 (PIGW/GWT1); PIRSF017321 (GWT1).</p>
+<p>Deep research: falcon provider is OUT OF CREDITS (HTTP 402) — no <code>-deep-research-falcon.md</code> was generated.<br />
+This review is grounded in the UniProt record, the seeded GOA, and cached publications (PMID:24367057;<br />
+Reactome R-HSA-162710, R-HSA-162683).</p>
+<h2 id="core-biology">Core biology</h2>
+<p>PIGW is the <strong>GPI inositol acyltransferase</strong> that catalyses the fourth step of GPI-anchor biosynthesis in<br />
+the ER: transfer of an acyl group (usually palmitate) from acyl-CoA to the <strong>2-OH of the inositol ring</strong> of<br />
+glucosaminyl-phosphatidylinositol (GlcN-PI), producing GlcN-(acyl)PI.</p>
+<p>UniProt FUNCTION [file:human/PIGW/PIGW-uniprot.txt "Acyltransferase that catalyzes the acyl transfer from an<br />
+acyl-CoA at the 2-OH position of the inositol ring of a 6-(alpha-D-glucosaminyl)-1-(1,2-diacyl-sn-glycero-3-<br />
+phospho)-1D-myo-inositol (glucosaminyl phosphatidylinositol, GlcN-PI) ... and participates in the fourth step<br />
+of GPI-anchor biosynthesis"].</p>
+<p>Catalytic activity (RHEA:60496 / RHEA:83759): GlcN-PI + fatty acyl-CoA -&gt; GlcN-(acyl)PI + CoA. The inositol<br />
+acyl group is important for GPI transamidase recognition and is later removed by PGAP1.</p>
+<p>Reactome R-HSA-162683: "In the fourth step of GPI synthesis, an acyl group (typically palmitate) is<br />
+transferred from acyl CoA to glucosaminyl-PI. Mutagenesis and cloning studies suggest that a single protein,<br />
+PIG-W, catalyzes this reaction (Murakami et al. 2003)."</p>
+<h2 id="goa-mf-term">GOA MF term</h2>
+<p>The GOA molecular-function term carried across IBA (GO_REF:0000033), IEA/RHEA (GO_REF:0000116), and ISS<br />
+(GO_REF:0000024) is <strong>GO:0032216 glucosaminyl-phosphatidylinositol O-acyltransferase activity</strong> (label<br />
+confirmed current in local go.db 2026-07). This is the exact current term to use for core_functions MF.</p>
+<h2 id="localisation">Localisation</h2>
+<p>ER membrane, multi-pass. UniProt [file:human/PIGW/PIGW-uniprot.txt "SUBCELLULAR LOCATION: Endoplasmic<br />
+reticulum membrane"; "Multi-pass membrane protein"]. GO:0005789 (ER membrane) is the current CC.</p>
+<h2 id="disease">Disease</h2>
+<p>Deficiency causes GPIBD11 (MIM:616025) — inherited GPI deficiency (hyperphosphatasia with mental retardation /<br />
+epileptic encephalopathy spectrum). PMID:24367057 (Chiyonobu et al. 2014): first PIGW-deficient patient, West<br />
+syndrome (hypsarrhythmia) + hyperphosphatasia + developmental delay; compound heterozygous NM_178517<br />
+c.211A&gt;C (T71P) and c.499A&gt;G (M167V). Variants reduce GPI-anchored protein surface expression on granulocytes.<br />
+UniProt DISEASE [file:human/PIGW/PIGW-uniprot.txt "developmental delay, intellectual disability, tonic<br />
+seizures associated with hypsarrhythmia, dysmorphic facial features, and elevated serum alkaline phosphatase"].</p>
+<p>PMID:24367057 abstract is the basis of the two experimental-ish GOA annotations:<br />
+- GO:0072659 (protein localization to plasma membrane) IMP — the reduced surface GPI-AP expression phenotype<br />
+  (transport of GPI-APs to the cell surface requires PIGW).<br />
+- GO:0006505 (GPI anchor metabolic process) IC — curator inference (with GO:0072659) from the same paper.</p>
+<h2 id="annotation-review-decisions">Annotation review decisions</h2>
+<ul>
+<li>GO:0032216 O-acyltransferase activity (IBA, IEA-RHEA, ISS): ACCEPT — this is the specific, correct MF.</li>
+<li>GO:0006506 GPI anchor biosynthetic process (IBA, IEA, ISS, TAS-Reactome): ACCEPT — core BP.</li>
+<li>GO:0005783 endoplasmic reticulum (IBA): ACCEPT (CC; located within ER; ER membrane is more specific).</li>
+<li>GO:0005789 ER membrane (IEA-SubCell, ISS x2, TAS-Reactome): ACCEPT — precise location, multi-pass.</li>
+<li>GO:0006505 GPI anchor metabolic process (IEA-ARBA, IC): parent of biosynthetic process; keep the IC<br />
+  (curator, PMID:24367057) as ACCEPT but non-core (biosynthetic child is the informative core term);<br />
+  the IEA-ARBA duplicate MARK_AS_OVER_ANNOTATED (less informative parent, redundant with biosynthetic).</li>
+<li>GO:0016020 membrane (IEA-InterPro): MARK_AS_OVER_ANNOTATED — too general; ER membrane is the specific CC.</li>
+<li>GO:0016746 acyltransferase activity (IEA-InterPro): MARK_AS_OVER_ANNOTATED — general parent of GO:0032216.</li>
+<li>GO:0016747 acyltransferase activity, transferring groups other than amino-acyl groups (TAS-Reactome):<br />
+  MARK_AS_OVER_ANNOTATED — general parent of GO:0032216.</li>
+<li>GO:0072659 protein localization to plasma membrane (IMP, PMID:24367057): KEEP_AS_NON_CORE — downstream<br />
+  consequence of GPI-anchor synthesis, not the direct MF; experimental (defer to curator, do not REMOVE).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q7Z7B1
+gene_symbol: PIGW
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PIGW (phosphatidylinositol-glycan biosynthesis class W protein; PIG-W) is the GPI inositol
+  acyltransferase of glycosylphosphatidylinositol (GPI) anchor biosynthesis. It is a multi-pass
+  endoplasmic reticulum membrane protein that catalyses the fourth step of GPI-anchor assembly:
+  transfer of an acyl group (usually palmitate) from acyl-CoA to the 2-OH of the inositol ring of
+  glucosaminyl-phosphatidylinositol (GlcN-PI), producing 2-acyl-GlcN-PI (GlcN-(acyl)PI). This
+  inositol acyl group is required for downstream recognition of the GPI intermediate by the GPI
+  transamidase complex and is normally removed by PGAP1 after the anchor is attached to protein.
+  Through this activity PIGW is essential for the ER synthesis of GPI anchors and hence for the
+  transport of GPI-anchored proteins to the cell surface. Biallelic loss-of-function variants cause
+  an autosomal-recessive inherited GPI-deficiency disorder (glycosylphosphatidylinositol biosynthesis
+  defect 11, GPIBD11) on the hyperphosphatasia-with-mental-retardation / epileptic-encephalopathy
+  spectrum, characterised by developmental delay, intellectual disability, seizures (including West
+  syndrome with hypsarrhythmia), dysmorphic features, and elevated serum alkaline phosphatase.
+existing_annotations:
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      PIGW acts in the endoplasmic reticulum, where GPI-anchor biosynthesis occurs. This
+      phylogenetic (IBA) location is correct but general; the ER membrane (GO:0005789) is the
+      precise compartment for this multi-pass membrane enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with UniProt subcellular location and with GPI biosynthesis being an ER process.
+      Kept as a correct-but-broad cellular component; the membrane-specific term is the core location.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process: PIGW catalyses the fourth step of GPI-anchor biosynthesis (inositol
+      acylation of GlcN-PI). The IBA is well supported across orthologues (PomBase, SGD, CGD, RGD)
+      and matches the human function.
+    action: ACCEPT
+    reason: &gt;-
+      This is the central biological role of PIGW and is corroborated experimentally and by UniProt.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;participates in the fourth step of GPI-anchor biosynthesis&#34;
+- term:
+    id: GO:0032216
+    label: glucosaminyl-phosphatidylinositol O-acyltransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core molecular function: PIGW is the GPI inositol acyltransferase, transferring an acyl group
+      from acyl-CoA to the 2-OH of the inositol of GlcN-PI. This specific term is the correct MF and
+      is supported by the UniProt catalytic activity (RHEA:60496/RHEA:83759) and by the IBA across
+      orthologues.
+    action: ACCEPT
+    reason: &gt;-
+      Specific, correct molecular function directly matching the characterised reaction.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;Acyltransferase that catalyzes the acyl transfer from an&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      PIGW is a multi-pass ER membrane protein; the ER membrane is its precise location. This
+      SubCell-mapping IEA is correct and represents the core cellular component.
+    action: ACCEPT
+    reason: &gt;-
+      Matches UniProt subcellular location (ER membrane, multi-pass) and the topology features.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;Multi-pass membrane protein&#34;
+- term:
+    id: GO:0006505
+    label: GPI anchor metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      GPI anchor metabolic process is the broad parent of GPI anchor biosynthetic process. PIGW is a
+      biosynthetic enzyme, so the more specific biosynthetic term (GO:0006506) is the informative
+      core annotation. This ARBA-generated IEA to the parent is redundant with that specific term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Not wrong, but a less-informative parent that is fully subsumed by the accepted biosynthetic
+      process annotation.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;participates in the fourth step of GPI-anchor biosynthesis&#34;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Duplicate of the core GPI anchor biosynthetic process annotation, here via combined-IEA
+      (InterPro IPR009447 / UniPathway UPA00196). Correct and consistent with the IBA/ISS/TAS
+      annotations to the same term.
+    action: ACCEPT
+    reason: &gt;-
+      Correctly captures the core biosynthetic role; duplicates of a correct term are acceptable.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor&#34;
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Generic &#34;membrane&#34; from an InterPro2GO mapping. PIGW is specifically an ER membrane protein, so
+      this uninformative parent is superseded by GO:0005789 (ER membrane).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Too general; the specific ER membrane location is annotated and preferred.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0016746
+    label: acyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic acyltransferase activity from InterPro2GO. This is a broad parent of the specific,
+      correct MF GO:0032216 (glucosaminyl-phosphatidylinositol O-acyltransferase activity).
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Not wrong but uninformative relative to the specific inositol-acyltransferase term.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;Acyltransferase that catalyzes the acyl transfer from an&#34;
+- term:
+    id: GO:0032216
+    label: glucosaminyl-phosphatidylinositol O-acyltransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000116
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Rhea-mapped IEA (RHEA:60496/RHEA:83759) to the specific GPI inositol acyltransferase activity,
+      matching the UniProt catalytic activity. Duplicate of the accepted core MF term.
+    action: ACCEPT
+    reason: &gt;-
+      Correct specific molecular function derived from the curated Rhea reaction.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;Acyltransferase that catalyzes the acyl transfer from an&#34;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162710
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome-traceable annotation to the core biosynthetic process, from the human GPI synthesis
+      pathway (R-HSA-162710), in which PIGW catalyses the inositol-acylation step.
+    action: ACCEPT
+    reason: &gt;-
+      Correctly captures the core biosynthetic role, consistent with the IBA/IEA/ISS annotations.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;participates in the fourth step of GPI-anchor biosynthesis&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      ISS transfer of ER membrane localisation from the mouse orthologue (UniProtKB:Q7TSN4),
+      consistent with the multi-pass ER membrane topology. Core cellular component.
+    action: ACCEPT
+    reason: &gt;-
+      Matches UniProt subcellular location for the human protein.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+- term:
+    id: GO:0032216
+    label: glucosaminyl-phosphatidylinositol O-acyltransferase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      ISS transfer of the GPI inositol acyltransferase activity from the mouse orthologue
+      (UniProtKB:Q7TSN4). Duplicate of the accepted specific core MF term.
+    action: ACCEPT
+    reason: &gt;-
+      Correct specific molecular function, supported by orthology and the curated reaction.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;Acyltransferase that catalyzes the acyl transfer from an&#34;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      ISS transfer of the core GPI-anchor biosynthetic process from the mouse orthologue
+      (UniProtKB:Q7TSN4). Duplicate of the accepted core BP term.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core biological process, supported by orthology.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;participates in the fourth step of GPI-anchor biosynthesis&#34;
+- term:
+    id: GO:0016747
+    label: acyltransferase activity, transferring groups other than amino-acyl groups
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162683
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome-traceable annotation to a broad acyltransferase-class term for the inositol-acylation
+      reaction (R-HSA-162683). This is a general parent of the specific MF GO:0032216.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Not wrong but uninformative relative to the specific glucosaminyl-PI O-acyltransferase term.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;Acyltransferase that catalyzes the acyl transfer from an&#34;
+- term:
+    id: GO:0006505
+    label: GPI anchor metabolic process
+  evidence_type: IC
+  original_reference_id: PMID:24367057
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Curator-inferred (IC, from the GO:0072659 IMP in the same paper) annotation to the broad GPI
+      anchor metabolic process. PIGW is specifically biosynthetic, so the biosynthetic child
+      (GO:0006506) is the informative core term; this broad parent is a redundant over-annotation
+      relative to the accepted biosynthetic-process term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Correct in essence (PIGW is in GPI-anchor metabolism) but a broad parent superseded by the
+      specific biosynthetic-process term; kept rather than removed, consistent with the other
+      GO:0006505 annotation.
+    supported_by:
+    - reference_id: PMID:24367057
+      supporting_text: &#34;involved in the addition of the acyl-chain to inositol in an early step of GPI&#34;
+- term:
+    id: GO:0072659
+    label: protein localization to plasma membrane
+  evidence_type: IMP
+  original_reference_id: PMID:24367057
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (IMP) annotation from patient/variant studies: PIGW loss reduces surface
+      expression of GPI-anchored proteins, i.e. PIGW is required for transport of GPI-APs to the
+      plasma membrane. This is a downstream consequence of the enzyme&#39;s role in GPI-anchor synthesis
+      rather than the direct molecular function, so it is retained as non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Valid experimental phenotype (defer to curator; not removed). Represents a downstream cellular
+      outcome of GPI-anchor biosynthesis, not PIGW&#39;s direct acyltransferase function.
+    supported_by:
+    - reference_id: PMID:24367057
+      supporting_text: &#34;decreased surface expression of GPI-APs on&#34;
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;Required for the transport of GPI-anchored proteins to the&#34;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162683
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome-traceable ER membrane localisation for the inositol-acylation reaction, consistent
+      with the multi-pass ER membrane topology. Duplicate of the accepted core CC term.
+    action: ACCEPT
+    reason: &gt;-
+      Correct core location, consistent with UniProt and the ISS/IEA annotations.
+    supported_by:
+    - reference_id: file:human/PIGW/PIGW-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000116
+  title: Automatic Gene Ontology annotation based on Rhea mapping
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:24367057
+  title: Glycosylphosphatidylinositol (GPI) anchor deficiency caused by mutations
+    in PIGW is associated with West syndrome and hyperphosphatasia with mental retardation
+    syndrome.
+  findings:
+  - statement: &gt;-
+      First reported patient with PIGW deficiency (GPIBD11): West syndrome with hypsarrhythmia,
+      developmental delay, dysmorphic features and hyperphosphatasia, with decreased surface
+      expression of GPI-anchored proteins on blood granulocytes; compound heterozygous PIGW variants.
+    reference_section_type: ABSTRACT
+    supporting_text: &gt;-
+      involved in the addition of the acyl-chain to inositol in an early step of GPI
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified case report; establishes the human disease association (GPIBD11) and the
+      GPI-AP surface-transport phenotype that underlie the IMP and IC annotations. Abstract-only in
+      cache (full_text_available: false).
+- id: Reactome:R-HSA-162683
+  title: glucosaminyl-PI + fatty acyl-CoA -&gt; glucosaminyl-acyl-PI + CoA-SH
+  findings:
+  - statement: &gt;-
+      Fourth step of GPI synthesis: an acyl group (typically palmitate) is transferred from acyl-CoA
+      to glucosaminyl-PI; PIG-W catalyses this reaction.
+    supporting_text: &gt;-
+      In the fourth step of GPI synthesis, an acyl group (typically palmitate) is transferred from
+      acyl CoA to glucosaminyl-PI.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Reactome reaction for the PIGW-catalysed inositol-acylation step; title left exactly as fetched.
+- id: Reactome:R-HSA-162710
+  title: Synthesis of glycosylphosphatidylinositol (GPI)
+  findings:
+  - statement: &gt;-
+      Human GPI synthesis pathway (nine reactions in the ER); PIGW performs the inositol-acylation
+      step within this pathway.
+    supporting_text: &gt;-
+      GPI is synthesized in the endoplasmic reticulum.
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Pathway-level Reactome entry; title left exactly as fetched.
+- id: file:human/PIGW/PIGW-uniprot.txt
+  title: UniProtKB Q7Z7B1 PIGW record
+  findings:
+  - statement: &gt;-
+      PIGW is an ER multi-pass membrane acyltransferase that acylates the inositol of GlcN-PI at the
+      fourth step of GPI-anchor biosynthesis; deficiency causes GPIBD11.
+    supporting_text: &gt;-
+      participates in the fourth step of GPI-anchor biosynthesis
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Curated UniProt record for the reviewed protein; source of the catalytic activity, subcellular
+      location, topology, and disease statements.
+core_functions:
+- description: &gt;-
+    GPI inositol acyltransferase that transfers an acyl group (usually palmitate) from acyl-CoA to
+    the 2-OH of the inositol ring of glucosaminyl-phosphatidylinositol (GlcN-PI), forming
+    2-acyl-GlcN-PI (GlcN-(acyl)PI) during GPI-anchor biosynthesis in the ER membrane.
+  molecular_function:
+    id: GO:0032216
+    label: glucosaminyl-phosphatidylinositol O-acyltransferase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: file:human/PIGW/PIGW-uniprot.txt
+    supporting_text: &#34;Acyltransferase that catalyzes the acyl transfer from an&#34;
+  - reference_id: file:human/PIGW/PIGW-uniprot.txt
+    supporting_text: &#34;participates in the fourth step of GPI-anchor biosynthesis&#34;
+  - reference_id: file:human/PIGW/PIGW-uniprot.txt
+    supporting_text: &#34;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#34;
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGX/PIGX-ai-review.html
+++ b/genes/human/PIGX/PIGX-ai-review.html
@@ -1,0 +1,2159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGX - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGX</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q8TBF5" target="_blank" class="term-link">
+                        Q8TBF5
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGX";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q8TBF5" data-a="DESCRIPTION: PIGX (phosphatidylinositol-glycan biosynthesis cla..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGX (phosphatidylinositol-glycan biosynthesis class X protein) is the non-catalytic stabilizing subunit of GPI mannosyltransferase I (GPI-MT-I), the endoplasmic reticulum complex that adds the first mannose during glycosylphosphatidylinositol (GPI) anchor biosynthesis. GPI-MT-I transfers this mannose in an alpha-1,4 linkage from dolichyl-phosphate-mannose (Dol-P-Man) onto the glucosaminyl-(acyl)phosphatidylinositol (GlcN-(acyl)PI) intermediate; PIGX itself has no catalytic activity and instead binds and stabilizes the catalytic mannosyltransferase PIGM, protecting it from degradation, so that PIGX is required for GPI-MT-I activity. PIGX is a single-pass type I endoplasmic reticulum membrane protein and functions as part of the GPI-MT-I complex on the lumenal side of the ER membrane. Loss of PIGX/GPI-MT-I function causes inherited GPI deficiency (GPI biosynthesis defect), a developmental and epileptic encephalopathy.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TBF5" data-a="GO:0005789" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (InterPro PIG-X/PBN1 signature plus UniProt Subcellular Location mapping) placing PIGX in the ER membrane. This is correct; PIGX is a single-pass type I ER membrane protein and GPI biosynthesis occurs on the ER membrane, so this is the core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization, consistent with the UniProt-annotated single-pass ER membrane topology and with the ComplexPortal, ISS, and Reactome ER-membrane annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGX/PIGX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGX/PIGX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Single-pass type I membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TBF5" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (InterPro PIG-X signatures and UniPathway GPI-anchor biosynthesis) to the GPI anchor biosynthetic process. PIGX is a required subunit of GPI-MT-I, which performs the first-mannose-addition step of GPI biosynthesis, so this is the core biological process for the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and central biological process; PIGX is essential for GPI-MT-I activity, which catalyzes step 6 (first mannose) of GPI-anchor biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGM functions in association with PIGX, which stabilizes PIGM</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGX/PIGX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32156170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Biosynthesis and biology of mammalian GPI-anchored proteins.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TBF5" data-a="GO:0005789" data-r="PMID:32156170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-2697) traceable assertion that PIGX localizes to the ER membrane, where GPI is assembled. Consistent with the electronic, ISS, and Reactome ER-membrane annotations and with the UniProt single-pass ER topology.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization; the GPI-MT-I complex acts on the lumenal side of the ER membrane and PIGX is an ER membrane protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The core GPI is assembled on the endoplasmic reticulum (ER) membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGX/PIGX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990529" target="_blank" class="term-link">
+                                    GO:1990529
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-mannosyltransferase I complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32156170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Biosynthesis and biology of mammalian GPI-anchored proteins.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TBF5" data-a="GO:1990529" data-r="PMID:32156170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal (CPX-2697) assertion that PIGX is part of the GPI-mannosyltransferase I complex, which in mammals comprises the catalytic subunit PIGM and the stabilizing subunit PIGX. This is the defining, characteristic complex membership for PIGX and captures how the gene product acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Well-established complex membership; PIGX is the stabilizing subunit of GPI-MT-I and binds/stabilizes catalytic PIGM.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGM functions in association with PIGX, which stabilizes PIGM</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGX/PIGX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">complex that is composed of PIGM and PIGX. Interacts with PIGM; PIGX</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TBF5" data-a="GO:0005789" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer (from mouse Pigx, UniProtKB:Q60GF7) of ER membrane localization. Consistent with the human UniProt topology and with the electronic, ComplexPortal, and Reactome ER-membrane annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization, corroborated by orthology and by the human single-pass type I ER membrane topology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGX/PIGX-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162830
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TBF5" data-a="GO:0005789" data-r="Reactome:R-HSA-162830" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable assertion placing the PIG-M/PIG-X-catalyzed addition of the first mannose to glucosaminyl-acyl-PI at the lumenal surface of the ER membrane. Consistent with all other ER-membrane annotations for PIGX.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization from an authoritative pathway resource; matches the UniProt ER topology and the complex&#39;s lumenal ER activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162830
+
+                                </span>
+
+                                <div class="support-text">The reaction takes place at the lumenal surface of the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162830
+
+                                </span>
+
+                                <div class="support-text">It is catalyzed by a complex of at least two components, PIG-M and PIG-X</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PIGX is the non-catalytic stabilizing subunit of GPI mannosyltransferase I (GPI-MT-I); it binds and stabilizes the catalytic mannosyltransferase PIGM and is required for the first-mannose-addition step of GPI-anchor biosynthesis, acting as part of the GPI-MT-I complex on the lumenal side of the ER membrane. PIGX itself has no characterized catalytic activity, so no molecular_function term is asserted.</h3>
+                <span class="vote-buttons" data-g="Q8TBF5" data-a="FUNCTION: PIGX is the non-catalytic stabilizing subunit of G..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990529" target="_blank" class="term-link">
+                            glycosylphosphatidylinositol-mannosyltransferase I complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                PMID:32156170
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PIGM functions in association with PIGX, which stabilizes PIGM</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGX/PIGX-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Probably acts by stabilizing the mannosyltransferase PIGM.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                            PMID:32156170
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis and biology of mammalian GPI-anchored proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PIGM (GPI-MTI) adds the first GPI mannose and functions in association with PIGX, which stabilizes PIGM; the core GPI is assembled on the ER membrane.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162830
+
+                    </span>
+                </div>
+
+                <div class="reference-title">glucosaminyl-acyl-PI + dolichol phosphate D-mannose -&gt; mannose(al1-4)glucosaminyl-acyl-PI + dolichol phosphate</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reactome reaction for the first-mannose addition to glucosaminyl-acyl-PI, catalyzed by a complex of PIG-M and PIG-X at the lumenal surface of the ER membrane.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGX/PIGX-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB Q8TBF5 PIGX record</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt describes PIGX as the stabilizing subunit of the GPI-mannosyltransferase I complex (with PIGM) that probably acts by stabilizing PIGM, a single-pass type I ER membrane protein participating in GPI-anchor biosynthesis.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does PIGX have any function beyond stabilizing PIGM (e.g. substrate presentation or lipid recognition within GPI-MT-I), or is protecting PIGM from degradation its sole role?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q8TBF5" data-a="Q: Does PIGX have any function beyond stabilizing PIG..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structural determination of the human PIGM-PIGX GPI-MT-I complex to define how PIGX binds and stabilizes PIGM and whether it contributes to Dol-P-Man or GlcN-(acyl)PI recognition.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q8TBF5" data-a="EXPERIMENT: Structural determination of the human PIGM-PIGX GP..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q8TBF5
+gene_symbol: PIGX
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGX (phosphatidylinositol-glycan biosynthesis class X protein) is the
+  non-catalytic stabilizing subunit of GPI mannosyltransferase I (GPI-MT-I), the endoplasmic
+  reticulum complex that adds the first mannose during glycosylphosphatidylinositol
+  (GPI) anchor biosynthesis. GPI-MT-I transfers this mannose in an alpha-1,4 linkage
+  from dolichyl-phosphate-mannose (Dol-P-Man) onto the glucosaminyl-(acyl)phosphatidylinositol
+  (GlcN-(acyl)PI) intermediate; PIGX itself has no catalytic activity and instead binds
+  and stabilizes the catalytic mannosyltransferase PIGM, protecting it from degradation,
+  so that PIGX is required for GPI-MT-I activity. PIGX is a single-pass type I endoplasmic
+  reticulum membrane protein and functions as part of the GPI-MT-I complex on the lumenal
+  side of the ER membrane. Loss of PIGX/GPI-MT-I function causes inherited GPI deficiency
+  (GPI biosynthesis defect), a developmental and epileptic encephalopathy.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q8TBF5-1
+- name: &#39;2&#39;
+  id: Q8TBF5-2
+  sequence_note: VSP_019842
+existing_annotations:
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Electronic annotation (InterPro PIG-X/PBN1 signature plus UniProt Subcellular
+      Location mapping) placing PIGX in the ER membrane. This is correct; PIGX is a
+      single-pass type I ER membrane protein and GPI biosynthesis occurs on the ER
+      membrane, so this is the core localization.
+    action: ACCEPT
+    reason: Correct localization, consistent with the UniProt-annotated single-pass
+      ER membrane topology and with the ComplexPortal, ISS, and Reactome ER-membrane
+      annotations.
+    supported_by:
+    - reference_id: file:human/PIGX/PIGX-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum&#39;
+    - reference_id: file:human/PIGX/PIGX-uniprot.txt
+      supporting_text: Single-pass type I membrane protein
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic annotation (InterPro PIG-X signatures and UniPathway GPI-anchor
+      biosynthesis) to the GPI anchor biosynthetic process. PIGX is a required subunit
+      of GPI-MT-I, which performs the first-mannose-addition step of GPI biosynthesis,
+      so this is the core biological process for the gene.
+    action: ACCEPT
+    reason: Correct and central biological process; PIGX is essential for GPI-MT-I
+      activity, which catalyzes step 6 (first mannose) of GPI-anchor biosynthesis.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: PIGM functions in association with PIGX, which stabilizes PIGM
+    - reference_id: file:human/PIGX/PIGX-uniprot.txt
+      supporting_text: participates in
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32156170
+  qualifier: located_in
+  review:
+    summary: ComplexPortal (CPX-2697) traceable assertion that PIGX localizes to the
+      ER membrane, where GPI is assembled. Consistent with the electronic, ISS, and
+      Reactome ER-membrane annotations and with the UniProt single-pass ER topology.
+    action: ACCEPT
+    reason: Correct localization; the GPI-MT-I complex acts on the lumenal side of
+      the ER membrane and PIGX is an ER membrane protein.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: The core GPI is assembled on the endoplasmic reticulum (ER) membrane
+    - reference_id: file:human/PIGX/PIGX-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum&#39;
+- term:
+    id: GO:1990529
+    label: glycosylphosphatidylinositol-mannosyltransferase I complex
+  evidence_type: NAS
+  original_reference_id: PMID:32156170
+  qualifier: part_of
+  review:
+    summary: ComplexPortal (CPX-2697) assertion that PIGX is part of the GPI-mannosyltransferase
+      I complex, which in mammals comprises the catalytic subunit PIGM and the stabilizing
+      subunit PIGX. This is the defining, characteristic complex membership for PIGX
+      and captures how the gene product acts.
+    action: ACCEPT
+    reason: Well-established complex membership; PIGX is the stabilizing subunit of
+      GPI-MT-I and binds/stabilizes catalytic PIGM.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: PIGM functions in association with PIGX, which stabilizes PIGM
+    - reference_id: file:human/PIGX/PIGX-uniprot.txt
+      supporting_text: complex that is composed of PIGM and PIGX. Interacts with PIGM;
+        PIGX
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: Sequence-similarity transfer (from mouse Pigx, UniProtKB:Q60GF7) of ER
+      membrane localization. Consistent with the human UniProt topology and with the
+      electronic, ComplexPortal, and Reactome ER-membrane annotations.
+    action: ACCEPT
+    reason: Correct localization, corroborated by orthology and by the human single-pass
+      type I ER membrane topology.
+    supported_by:
+    - reference_id: file:human/PIGX/PIGX-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum&#39;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162830
+  qualifier: located_in
+  review:
+    summary: Reactome traceable assertion placing the PIG-M/PIG-X-catalyzed addition
+      of the first mannose to glucosaminyl-acyl-PI at the lumenal surface of the ER
+      membrane. Consistent with all other ER-membrane annotations for PIGX.
+    action: ACCEPT
+    reason: Correct localization from an authoritative pathway resource; matches the
+      UniProt ER topology and the complex&#39;s lumenal ER activity.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162830
+      supporting_text: The reaction takes place at the lumenal surface of the endoplasmic
+        reticulum membrane
+    - reference_id: Reactome:R-HSA-162830
+      supporting_text: It is catalyzed by a complex of at least two components, PIG-M
+        and PIG-X
+core_functions:
+- description: PIGX is the non-catalytic stabilizing subunit of GPI mannosyltransferase
+    I (GPI-MT-I); it binds and stabilizes the catalytic mannosyltransferase PIGM and
+    is required for the first-mannose-addition step of GPI-anchor biosynthesis, acting
+    as part of the GPI-MT-I complex on the lumenal side of the ER membrane. PIGX itself
+    has no characterized catalytic activity, so no molecular_function term is asserted.
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:1990529
+    label: glycosylphosphatidylinositol-mannosyltransferase I complex
+  supported_by:
+  - reference_id: PMID:32156170
+    supporting_text: PIGM functions in association with PIGX, which stabilizes PIGM
+  - reference_id: file:human/PIGX/PIGX-uniprot.txt
+    supporting_text: Probably acts by stabilizing the mannosyltransferase PIGM.
+proposed_new_terms: []
+suggested_questions:
+- question: Does PIGX have any function beyond stabilizing PIGM (e.g. substrate presentation
+    or lipid recognition within GPI-MT-I), or is protecting PIGM from degradation its
+    sole role?
+suggested_experiments:
+- description: Structural determination of the human PIGM-PIGX GPI-MT-I complex to
+    define how PIGX binds and stabilizes PIGM and whether it contributes to Dol-P-Man
+    or GlcN-(acyl)PI recognition.
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:32156170
+  title: Biosynthesis and biology of mammalian GPI-anchored proteins.
+  findings:
+  - statement: PIGM (GPI-MTI) adds the first GPI mannose and functions in association
+      with PIGX, which stabilizes PIGM; the core GPI is assembled on the ER membrane.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Authoritative Kinoshita review; full text available and directly
+      states PIGX&#39;s role as the stabilizing (regulatory) subunit of GPI-MTI that stabilizes
+      catalytic PIGM. Also the ComplexPortal-cited reference for the ER-membrane and
+      GPI-MT-I complex annotations.
+- id: Reactome:R-HSA-162830
+  title: glucosaminyl-acyl-PI + dolichol phosphate D-mannose -&gt; mannose(al1-4)glucosaminyl-acyl-PI
+    + dolichol phosphate
+  findings:
+  - statement: Reactome reaction for the first-mannose addition to glucosaminyl-acyl-PI,
+      catalyzed by a complex of PIG-M and PIG-X at the lumenal surface of the ER membrane.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Reactome reaction cited by GOA for PIGX ER-membrane localization;
+      describes the PIGM/PIGX-catalyzed GPI-MT-I step and names both subunits.
+- id: file:human/PIGX/PIGX-uniprot.txt
+  title: UniProtKB Q8TBF5 PIGX record
+  findings:
+  - statement: UniProt describes PIGX as the stabilizing subunit of the GPI-mannosyltransferase
+      I complex (with PIGM) that probably acts by stabilizing PIGM, a single-pass type
+      I ER membrane protein participating in GPI-anchor biosynthesis.
+    reference_section_type: OTHER
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: UniProt record for Q8TBF5; used for the subunit-stabilization function,
+      subcellular location, and single-pass type I membrane topology statements.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGY/PIGY-ai-review.html
+++ b/genes/human/PIGY/PIGY-ai-review.html
@@ -1,0 +1,2828 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGY - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGY</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q3MUY2" target="_blank" class="term-link">
+                        Q3MUY2
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGY";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q3MUY2" data-a="DESCRIPTION: PIGY (PIG-Y) is a small (71-residue) two-transmemb..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGY (PIG-Y) is a small (71-residue) two-transmembrane endoplasmic reticulum membrane protein that is a required non-catalytic subunit of the glycosylphosphatidylinositol N-acetylglucosaminyltransferase (GPI-GnT) complex. This complex catalyses the first, committed step of GPI-anchor biosynthesis, transferring N-acetylglucosamine from UDP-GlcNAc onto phosphatidylinositol to form GlcNAc-PI. Within the complex, which additionally comprises the catalytic subunit PIGA together with PIGC, PIGH, PIGP, PIGQ and DPM2, PIGY interacts directly with PIGA and acts as a regulatory accessory subunit rather than as an independent enzyme. Loss of PIGY function causes an inherited GPI-deficiency disorder in the hyperphosphatasia with impaired intellectual development / epileptic encephalopathy spectrum (HPMRS6), with reduced cell-surface display of GPI-anchored proteins.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0000506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment that PIGY is part of the GPI-GnT complex. This is directly supported by the defining experimental work and by UniProt, which lists PIGY as a component of the complex alongside PIGA, PIGC, PIGH, PIGP, PIGQ and DPM2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; PIGY is an established structural component of the GPI-GnT complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here, we report that human GPI-GnT requires another component, termed PIG-Y, a 71 amino acid protein with two transmembrane domains.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGY/PIGY-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Component of the glycosylphosphatidylinositol-N-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) assignment that PIGY is involved in GPI anchor biosynthesis. As part of the GPI-GnT complex, PIGY participates in the first step of GPI biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; this is PIGY&#39;s central biological role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGY/PIGY-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the first step of GPI biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniProt SubCell keyword mapping) assignment to the ER membrane, consistent with the experimentally determined subcellular location of PIGY as a multi-pass ER membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; matches experimental IDA and TAS annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGY/PIGY-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0005515" data-r="PMID:16162815" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI protein-protein interaction annotation (IntAct/UniProt) recording binding to PIGA (UniProtKB:P37287). The direct PIGY-PIGA interaction is biologically the most important, being the interaction through which PIGY regulates GPI-GnT catalytic activity; however the bare &#34;protein binding&#34; term is uninformative about function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, bare &#34;protein binding&#34; (GO:0005515) conveys no functional information and should not be retained as a core molecular function. The biologically meaningful content (direct interaction with the catalytic subunit PIGA, regulating complex activity) is captured by the contributes_to GO:0017176 annotation and by the complex membership term. The underlying experimental interaction is genuine, so this is over-annotation rather than an incorrect annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-Y appeared to be directly associated with PIG-A, implying that PIG-Y is the key molecule that regulates GPI-GnT activity by binding directly to the catalytic subunit PIG-A.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI protein-protein interaction annotations (IntAct) from the HuRI human binary interactome map, recording high-throughput yeast two-hybrid interactions of PIGY with TMEM72 (UniProtKB:A0PK05) and ERG28 (UniProtKB:Q9UKR5). These are systematic-screen hits without an established functional relationship to PIGY&#39;s role in GPI-GnT.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; (GO:0005515) is uninformative per curation guidelines, and these particular interactors derive from a large-scale binary interactome screen rather than GPI-pathway-focused work, with no demonstrated biological significance for PIGY function. Not core. The experimental interaction data are retained in IntAct; this is over-annotation for the purposes of representing gene function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A reference map of the human binary protein interactome</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000041
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0006506" data-r="GO_REF:0000041" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (UniPathway vocabulary mapping, UPA00196) assignment to GPI anchor biosynthetic process, consistent with PIGY&#39;s role in the first step of GPI biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; redundant with the IBA and IDA annotations to the same BP term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGY/PIGY-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ComplexPortal IPI annotation (CPX-6502) placing PIGY as part of the GPI-GnT complex, based on the co-precipitation / reconstitution work that identified PIGY as the seventh component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; experimentally supported complex membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">human GPI-GnT requires another component, termed PIG-Y</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0005789" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA, ComplexPortal) localisation of PIGY to the ER membrane, where the GPI-GnT complex initiates GPI biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; this is the established site of action of PIGY and the GPI-GnT complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGY/PIGY-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017176" target="_blank" class="term-link">
+                                    GO:0017176
+                                </a>
+                            </span>
+                            <span class="term-label">phosphatidylinositol N-acetylglucosaminyltransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0017176" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) annotation with the contributes_to qualifier, capturing that PIGY is required for the phosphatidylinositol N-acetylglucosaminyltransferase activity of the GPI-GnT complex. PIGY is not itself the catalytic subunit (that is PIGA); it binds directly to PIGA and regulates the complex&#39;s activity, so contributes_to is the appropriate qualifier.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and represents PIGY&#39;s core molecular contribution. The contributes_to qualifier correctly reflects that PIGY is a required non-catalytic subunit of the enzyme complex rather than an independent catalyst.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-Y is the key molecule that regulates GPI-GnT activity by binding directly to the catalytic subunit PIG-A</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162730
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0005789" data-r="Reactome:R-HSA-162730" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement (Reactome) localising the GlcNAc-PI-forming reaction and its catalysing complex, including PIGY, to the ER membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; consistent with the experimental IDA and IEA ER membrane annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162730
+
+                                </span>
+
+                                <div class="support-text">The first step of GPI synthesis is the transfer of N-acetylglucosamine from cytosolic UDP-N-acetylglucosamine to phosphatidyl inositol (PI) in the endoplasmic reticulum membrane.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                                    GO:0000506
+                                </a>
+                            </span>
+                            <span class="term-label">glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0000506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA, MGI) annotation placing PIGY as part of the GPI-GnT complex, from the study that identified PIGY as the seventh required component of the complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; experimentally established complex membership.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A complex of six components was formed without PIG-Y.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0005886" data-r="PMID:16162815" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA, MGI) localisation to the plasma membrane. PIGY is an ER-resident GPI-GnT subunit; its established site of function is the ER membrane, and UniProt records only the ER membrane as its subcellular location. A plasma membrane assignment is inconsistent with an ER GPI-biosynthesis subunit and most likely reflects an overexpression/tag-driven readout in the original study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The functionally relevant, well-established location of PIGY is the ER membrane (multiple IDA/IEA/TAS annotations and UniProt). Plasma membrane localisation does not fit PIGY&#39;s role in the ER-localised GPI-GnT complex. Because this is an experimental annotation whose full text is not available in the cache, it is not removed but flagged as an over-annotation / non-core location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGY/PIGY-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16162815
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The initial enzyme for glycosylphosphatidylinositol biosynth...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3MUY2" data-a="GO:0006506" data-r="PMID:16162815" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA, MGI) annotation that PIGY acts upstream of or within GPI anchor biosynthesis, based on the demonstration that the PIGY-null Daudi cell line is severely defective in surface expression of GPI-anchored proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and core; loss of PIGY abolishes GPI-GnT function and hence GPI-anchor biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                        PMID:16162815
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The Burkitt lymphoma cell line Daudi, severely defective in the surface expression of GPI-anchored proteins, was a null mutant of PIG-Y.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Required non-catalytic subunit of the GPI-GnT complex that contributes to the phosphatidylinositol N-acetylglucosaminyltransferase activity catalysing the first step of GPI biosynthesis (GlcNAc transfer from UDP-GlcNAc to phosphatidylinositol), acting by direct binding to and regulation of the catalytic subunit PIGA in the ER membrane.</h3>
+                <span class="vote-buttons" data-g="Q3MUY2" data-a="FUNCTION: Required non-catalytic subunit of the GPI-GnT comp..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000506" target="_blank" class="term-link">
+                            glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT) complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                                PMID:16162815
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PIG-Y is the key molecule that regulates GPI-GnT activity by binding directly to the catalytic subunit PIG-A</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000041.md" target="_blank" class="term-link">
+                            GO_REF:0000041
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniPathway vocabulary mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16162815" target="_blank" class="term-link">
+                            PMID:16162815
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The initial enzyme for glycosylphosphatidylinositol biosynthesis requires PIG-Y, a seventh component.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162730
+
+                    </span>
+                </div>
+
+                <div class="reference-title">phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI + UDP</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGY/PIGY-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q3MUY2 (PIGY_HUMAN)</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGY-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q3MUY2" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigy-q3muy2-review-notes">PIGY (Q3MUY2) review notes</h1>
+<h2 id="summary-of-gene-function">Summary of gene function</h2>
+<p>PIGY / PIG-Y (phosphatidylinositol N-acetylglucosaminyltransferase subunit Y, HGNC:28213,<br />
+UniProtKB:Q3MUY2) is a small (71 aa), two-transmembrane-domain ER membrane protein that is<br />
+the seventh identified component of the glycosylphosphatidylinositol N-acetylglucosaminyl-<br />
+transferase (GPI-GnT) complex. This complex catalyses the first, committed step of GPI-anchor<br />
+biosynthesis: transfer of GlcNAc from UDP-GlcNAc onto phosphatidylinositol to give GlcNAc-PI.</p>
+<ul>
+<li>Defining paper: Murakami et al. 2005 (PMID:16162815), abstract-only in cache<br />
+  (<code>full_text_available: false</code>).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16162815" title="Here, we report that human GPI-GnT requires another component, termed     PIG-Y, a 71 amino acid protein with two transmembrane domains.">PMID:16162815</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16162815" title="PIG-Y appeared to be directly associated with PIG-A, implying that PIG-Y     is the key molecule that regulates GPI-GnT activity by binding directly to the catalytic     subunit PIG-A.">PMID:16162815</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16162815" title="We did not obtain evidence for a functional linkage between GPI-GnT and ras     GTPases in mammalian cells as has been reported for yeast cells.">PMID:16162815</a> -&gt; explicitly argues<br />
+    against a Ras/GTPase functional role.</li>
+<li>
+<p><a href="https://pubmed.ncbi.nlm.nih.gov/16162815" title="A complex of six components was formed without PIG-Y.">PMID:16162815</a> -&gt; PIG-Y is a<br />
+    required accessory/regulatory subunit, not part of the catalytic minimal core assembly.</p>
+</li>
+<li>
+<p>UniProt (Q3MUY2):</p>
+</li>
+<li>FUNCTION: "Part of the glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)<br />
+    complex that catalyzes the transfer of N-acetylglucosamine from UDP-N-acetylglucosamine to<br />
+    phosphatidylinositol and participates in the first step of GPI biosynthesis... May act by<br />
+    regulating the catalytic subunit PIGA."</li>
+<li>SUBUNIT: "Component of the ... (GPI-GnT) complex composed at least by PIGA, PIGC, PIGH, PIGP,<br />
+    PIGQ, PIGY and DPM2. Interacts directly with PIGA; this interaction regulates ... activity.<br />
+    Does not interact with Ras proteins."</li>
+<li>SUBCELLULAR LOCATION: "Endoplasmic reticulum membrane; Multi-pass membrane protein."</li>
+<li>Topology: cytoplasmic 1-3, TM 4-26, lumenal 27-44, TM 45-65, cytoplasmic 66-71.</li>
+<li>DISEASE: HPMRS6 (Hyperphosphatasia with impaired intellectual development syndrome 6),<br />
+    MIM:616809; variant L46P (PMID:26293662).</li>
+<li>
+<p>PATHWAY: Glycolipid biosynthesis; GPI-anchor biosynthesis (UniPathway UPA00196).</p>
+</li>
+<li>
+<p>Disease: Ilkovski et al. 2015 (PMID:26293662; not cached) established PIGY variants cause an<br />
+  inherited GPI-deficiency disorder (GPIBD) in the hyperphosphatasia / epileptic encephalopathy<br />
+  spectrum. L46P diminishes protein expression/stability and reduces cell-surface expression of<br />
+  GPI-anchored proteins CD55 and CD59.</p>
+</li>
+</ul>
+<h2 id="annotation-by-annotation-notes">Annotation-by-annotation notes</h2>
+<p>GOA (<code>PIGY-goa.tsv</code>) carries 15 data rows across these terms:</p>
+<ul>
+<li>GO:0000506 GPI-GnT complex (CC, part_of): IBA (GO_REF:0000033), IPI (PMID:16162815, ComplexPortal),<br />
+  IDA (PMID:16162815, MGI). All ACCEPT — core, directly established.</li>
+<li>GO:0006506 GPI anchor biosynthetic process (BP): IBA (GO_REF:0000033, involved_in), IEA<br />
+  (GO_REF:0000041 UniPathway, involved_in), IDA (PMID:16162815, acts_upstream_of_or_within). ACCEPT<br />
+  — core BP.</li>
+<li>GO:0005789 endoplasmic reticulum membrane (CC, located_in): IEA (GO_REF:0000044 SubCell), IDA<br />
+  (PMID:16162815 x2, ComplexPortal + MGI), TAS (Reactome R-HSA-162730). ACCEPT — core location.</li>
+<li>GO:0017176 phosphatidylinositol N-acetylglucosaminyltransferase activity (MF, contributes_to):<br />
+  IDA (PMID:16162815, BHF-UCL). ACCEPT — PIGY is non-catalytic but <code>contributes_to</code> correctly<br />
+  captures its required contribution to the complex's catalytic activity.</li>
+<li>GO:0005515 protein binding (MF, enables): IPI, PMID:16162815 (PIGA/P37287) and PMID:32296183<br />
+  (HuRI: TMEM72/A0PK05, ERG28/Q9UKR5). Uninformative bare <code>protein binding</code> per curation policy -&gt;<br />
+  MARK_AS_OVER_ANNOTATED (do not REMOVE experimental IPI). The PIGA interaction is biologically the<br />
+  key one (direct, regulatory) but the GO term itself conveys nothing; the informative MF is captured<br />
+  by contributes_to GO:0017176. HuRI interactors (TMEM72, ERG28) are high-throughput Y2H hits without<br />
+  established biological meaning for PIGY.</li>
+<li>GO:0005886 plasma membrane (CC, located_in): IDA (PMID:16162815, MGI). PIGY is an ER-membrane GPI<br />
+  biosynthesis subunit; the abstract localises it to ER. Plasma membrane is inconsistent with an ER<br />
+  GPI-GnT subunit and with the UniProt SUBCELLULAR LOCATION (ER membrane only). This IDA likely<br />
+  reflects a transfected/overexpression artefact or mislocalisation readout. Full text not in cache<br />
+  (abstract-only), so per policy do NOT REMOVE an experimental annotation whose full text is<br />
+  unverifiable -&gt; MARK_AS_OVER_ANNOTATED (not core; ER is the established site).</li>
+</ul>
+<h2 id="core-functions">Core functions</h2>
+<ul>
+<li>MF: contributes_to phosphatidylinositol N-acetylglucosaminyltransferase activity (GO:0017176) as a<br />
+  required non-catalytic subunit of the GPI-GnT complex.</li>
+<li>BP: GPI anchor biosynthetic process (GO:0006506).</li>
+<li>CC / complex: ER membrane (GO:0005789); part of GPI-GnT complex (GO:0000506).</li>
+</ul>
+<h2 id="provenance">Provenance</h2>
+<ul>
+<li>No falcon deep-research file (falcon out of credits, HTTP 402). Review grounded in UniProt<br />
+  (<code>PIGY-uniprot.txt</code>), GOA (<code>PIGY-goa.tsv</code>), cached PMID:16162815 abstract, Reactome R-HSA-162730,<br />
+  and PMID:32296183 (HuRI) metadata.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q3MUY2
+gene_symbol: PIGY
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGY (PIG-Y) is a small (71-residue) two-transmembrane endoplasmic reticulum
+  membrane protein that is a required non-catalytic subunit of the glycosylphosphatidylinositol
+  N-acetylglucosaminyltransferase (GPI-GnT) complex. This complex catalyses the first, committed
+  step of GPI-anchor biosynthesis, transferring N-acetylglucosamine from UDP-GlcNAc onto
+  phosphatidylinositol to form GlcNAc-PI. Within the complex, which additionally comprises the
+  catalytic subunit PIGA together with PIGC, PIGH, PIGP, PIGQ and DPM2, PIGY interacts directly with
+  PIGA and acts as a regulatory accessory subunit rather than as an independent enzyme. Loss of PIGY
+  function causes an inherited GPI-deficiency disorder in the hyperphosphatasia with impaired
+  intellectual development / epileptic encephalopathy spectrum (HPMRS6), with reduced cell-surface
+  display of GPI-anchored proteins.
+existing_annotations:
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: Phylogenetic (IBA) assignment that PIGY is part of the GPI-GnT complex.
+      This is directly supported by the defining experimental work and by UniProt, which lists PIGY
+      as a component of the complex alongside PIGA, PIGC, PIGH, PIGP, PIGQ and DPM2.
+    action: ACCEPT
+    reason: Correct and core; PIGY is an established structural component of the GPI-GnT complex.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: Here, we report that human GPI-GnT requires another component, termed
+        PIG-Y, a 71 amino acid protein with two transmembrane domains.
+    - reference_id: file:human/PIGY/PIGY-uniprot.txt
+      supporting_text: Component of the glycosylphosphatidylinositol-N-
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic (IBA) assignment that PIGY is involved in GPI anchor biosynthesis.
+      As part of the GPI-GnT complex, PIGY participates in the first step of GPI biosynthesis.
+    action: ACCEPT
+    reason: Correct and core; this is PIGY&#39;s central biological role.
+    supported_by:
+    - reference_id: file:human/PIGY/PIGY-uniprot.txt
+      supporting_text: participates in the first step of GPI
+        biosynthesis
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic (UniProt SubCell keyword mapping) assignment to the ER membrane, consistent
+      with the experimentally determined subcellular location of PIGY as a multi-pass ER membrane
+      protein.
+    action: ACCEPT
+    reason: Correct and core; matches experimental IDA and TAS annotations to the same term.
+    supported_by:
+    - reference_id: file:human/PIGY/PIGY-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: enables
+  review:
+    summary: IPI protein-protein interaction annotation (IntAct/UniProt) recording binding to PIGA
+      (UniProtKB:P37287). The direct PIGY-PIGA interaction is biologically the most important, being
+      the interaction through which PIGY regulates GPI-GnT catalytic activity; however the bare
+      &#34;protein binding&#34; term is uninformative about function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per curation guidelines, bare &#34;protein binding&#34; (GO:0005515) conveys no functional
+      information and should not be retained as a core molecular function. The biologically meaningful
+      content (direct interaction with the catalytic subunit PIGA, regulating complex activity) is
+      captured by the contributes_to GO:0017176 annotation and by the complex membership term. The
+      underlying experimental interaction is genuine, so this is over-annotation rather than an
+      incorrect annotation.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: PIG-Y appeared to be directly associated with PIG-A, implying that PIG-Y
+        is the key molecule that regulates GPI-GnT activity by binding directly to the catalytic
+        subunit PIG-A.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: IPI protein-protein interaction annotations (IntAct) from the HuRI human binary
+      interactome map, recording high-throughput yeast two-hybrid interactions of PIGY with TMEM72
+      (UniProtKB:A0PK05) and ERG28 (UniProtKB:Q9UKR5). These are systematic-screen hits without an
+      established functional relationship to PIGY&#39;s role in GPI-GnT.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#34;protein binding&#34; (GO:0005515) is uninformative per curation guidelines, and these
+      particular interactors derive from a large-scale binary interactome screen rather than
+      GPI-pathway-focused work, with no demonstrated biological significance for PIGY function. Not
+      core. The experimental interaction data are retained in IntAct; this is over-annotation for the
+      purposes of representing gene function.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: A reference map of the human binary protein interactome
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000041
+  qualifier: involved_in
+  review:
+    summary: Electronic (UniPathway vocabulary mapping, UPA00196) assignment to GPI anchor
+      biosynthetic process, consistent with PIGY&#39;s role in the first step of GPI biosynthesis.
+    action: ACCEPT
+    reason: Correct and core; redundant with the IBA and IDA annotations to the same BP term.
+    supported_by:
+    - reference_id: file:human/PIGY/PIGY-uniprot.txt
+      supporting_text: Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IPI
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: ComplexPortal IPI annotation (CPX-6502) placing PIGY as part of the GPI-GnT complex,
+      based on the co-precipitation / reconstitution work that identified PIGY as the seventh
+      component.
+    action: ACCEPT
+    reason: Correct and core; experimentally supported complex membership.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: human GPI-GnT requires another component, termed
+        PIG-Y
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: located_in
+  review:
+    summary: Experimental (IDA, ComplexPortal) localisation of PIGY to the ER membrane, where the
+      GPI-GnT complex initiates GPI biosynthesis.
+    action: ACCEPT
+    reason: Correct and core; this is the established site of action of PIGY and the GPI-GnT complex.
+    supported_by:
+    - reference_id: file:human/PIGY/PIGY-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0017176
+    label: phosphatidylinositol N-acetylglucosaminyltransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: contributes_to
+  review:
+    summary: Experimental (IDA) annotation with the contributes_to qualifier, capturing that PIGY is
+      required for the phosphatidylinositol N-acetylglucosaminyltransferase activity of the GPI-GnT
+      complex. PIGY is not itself the catalytic subunit (that is PIGA); it binds directly to PIGA and
+      regulates the complex&#39;s activity, so contributes_to is the appropriate qualifier.
+    action: ACCEPT
+    reason: Correct and represents PIGY&#39;s core molecular contribution. The contributes_to qualifier
+      correctly reflects that PIGY is a required non-catalytic subunit of the enzyme complex rather
+      than an independent catalyst.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: PIG-Y is
+        the key molecule that regulates GPI-GnT activity by binding directly to the catalytic
+        subunit PIG-A
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162730
+  qualifier: located_in
+  review:
+    summary: Traceable author statement (Reactome) localising the GlcNAc-PI-forming reaction and its
+      catalysing complex, including PIGY, to the ER membrane.
+    action: ACCEPT
+    reason: Correct and core; consistent with the experimental IDA and IEA ER membrane annotations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162730
+      supporting_text: The first step of GPI synthesis is the transfer of N-acetylglucosamine from
+        cytosolic UDP-N-acetylglucosamine to phosphatidyl inositol (PI) in the endoplasmic
+        reticulum membrane.
+- term:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: part_of
+  review:
+    summary: Experimental (IDA, MGI) annotation placing PIGY as part of the GPI-GnT complex, from the
+      study that identified PIGY as the seventh required component of the complex.
+    action: ACCEPT
+    reason: Correct and core; experimentally established complex membership.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: A complex of six components was formed without PIG-Y.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: located_in
+  review:
+    summary: Experimental (IDA, MGI) localisation to the plasma membrane. PIGY is an ER-resident
+      GPI-GnT subunit; its established site of function is the ER membrane, and UniProt records
+      only the ER membrane as its subcellular location. A plasma membrane assignment is inconsistent
+      with an ER GPI-biosynthesis subunit and most likely reflects an overexpression/tag-driven
+      readout in the original study.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The functionally relevant, well-established location of PIGY is the ER membrane (multiple
+      IDA/IEA/TAS annotations and UniProt). Plasma membrane localisation does not fit PIGY&#39;s role in
+      the ER-localised GPI-GnT complex. Because this is an experimental annotation whose full text is
+      not available in the cache, it is not removed but flagged as an over-annotation / non-core
+      location.
+    supported_by:
+    - reference_id: file:human/PIGY/PIGY-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:16162815
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: Experimental (IDA, MGI) annotation that PIGY acts upstream of or within GPI anchor
+      biosynthesis, based on the demonstration that the PIGY-null Daudi cell line is severely
+      defective in surface expression of GPI-anchored proteins.
+    action: ACCEPT
+    reason: Correct and core; loss of PIGY abolishes GPI-GnT function and hence GPI-anchor
+      biosynthesis.
+    supported_by:
+    - reference_id: PMID:16162815
+      supporting_text: The Burkitt
+        lymphoma cell line Daudi, severely defective in the surface expression of
+        GPI-anchored proteins, was a null mutant of PIG-Y.
+core_functions:
+- description: Required non-catalytic subunit of the GPI-GnT complex that contributes to the
+    phosphatidylinositol N-acetylglucosaminyltransferase activity catalysing the first step of GPI
+    biosynthesis (GlcNAc transfer from UDP-GlcNAc to phosphatidylinositol), acting by direct binding
+    to and regulation of the catalytic subunit PIGA in the ER membrane.
+  supported_by:
+  - reference_id: PMID:16162815
+    supporting_text: PIG-Y is
+      the key molecule that regulates GPI-GnT activity by binding directly to the catalytic
+      subunit PIG-A
+  contributes_to_molecular_function:
+    id: GO:0017176
+    label: phosphatidylinositol N-acetylglucosaminyltransferase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  in_complex:
+    id: GO:0000506
+    label: glycosylphosphatidylinositol-N-acetylglucosaminyltransferase (GPI-GnT)
+      complex
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000041
+  title: Gene Ontology annotation based on UniPathway vocabulary mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:16162815
+  title: The initial enzyme for glycosylphosphatidylinositol biosynthesis requires
+    PIG-Y, a seventh component.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Defining paper for PIGY; identifies PIGY as the seventh component of the GPI-GnT
+      complex, a 71-aa two-TM ER protein that binds directly to and regulates the catalytic subunit
+      PIGA. Abstract-only in cache (full_text_available false); all supporting quotes verified as
+      verbatim substrings of the cached abstract.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: HuRI large-scale binary (Y2H) interactome map; source of PIGY protein-binding IPI
+      annotations to TMEM72 and ERG28. Correctly cited but provides only bare protein-binding data
+      with no established functional significance for PIGY; interactors are not GPI-pathway related.
+- id: Reactome:R-HSA-162730
+  title: phosphatidylinositol + UDP-N-acetyl-D-glucosamine -&gt; N-acetylglucosaminyl-PI
+    + UDP
+  findings: []
+- id: file:human/PIGY/PIGY-uniprot.txt
+  title: UniProtKB entry Q3MUY2 (PIGY_HUMAN)
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: UniProt/Swiss-Prot record; provides curated FUNCTION, SUBUNIT, SUBCELLULAR
+      LOCATION, PATHWAY and DISEASE annotations used as supporting text.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/TCN1/TCN1-ai-review.html
+++ b/genes/human/TCN1/TCN1-ai-review.html
@@ -1,0 +1,3907 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TCN1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TCN1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P20061" target="_blank" class="term-link">
+                        P20061
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TCN1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P20061" data-a="DESCRIPTION: TCN1 encodes transcobalamin-1, also known as hapto..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>TCN1 encodes transcobalamin-1, also known as haptocorrin (HC), transcobalamin I, or protein R / R-binder. It is a secreted, heavily N-glycosylated (~30% carbohydrate) cobalamin (vitamin B12)-binding glycoprotein of the eukaryotic cobalamin transport protein family (which also includes transcobalamin/TCN2 and gastric intrinsic factor/GIF). Haptocorrin is produced by the salivary glands in response to food and is a major protein of the specific (secondary) granules of neutrophils; it is present in saliva, gastric juice, plasma, bile and other secretions. It binds cobalamin with femtomolar affinity and, unlike its paralogues, has broad corrinoid specificity, binding cobalamin as well as biologically inactive cobalamin analogues (corrinoids). Functionally it protects dietary B12 from the acidic environment of the stomach and carries the majority of circulating plasma B12, and it scavenges corrinoid analogues for hepatobiliary clearance. It is not the carrier that delivers B12 into cells (that role belongs to transcobalamin/TCN2 acting through the CD320 receptor, which does not recognize haptocorrin). TCN1 is not an enzyme; its core molecular function is cobalamin binding. Elevated serum haptocorrin is observed as a tumour marker in some cancers.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0005576" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that TCN1 acts in the extracellular region. Correct: haptocorrin is a secreted protein acting in saliva, gastric juice, plasma and other extracellular fluids, so extracellular region is an appropriate and core localization. GO:0005576 is the exact extracellular CC term also carried elsewhere in the GOA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TCN1 is a secreted cobalamin-binding glycoprotein; extracellular region is the correct cellular component and is corroborated by the UniProt &#34;Secreted&#34; subcellular location, proteomic detection in plasma/saliva/colostrum, and Reactome.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0015889" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference that TCN1 is involved in cobalamin transport. This is the correct core biological process: haptocorrin binds dietary/plasma cobalamin (and corrinoid analogues) and participates in B12 transport, protecting acid-labile cobalamin in the stomach and carrying most plasma B12.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cobalamin transport is the established core biological process of the cobalamin transport protein family; TCN1 binds and carries cobalamin in secretions and plasma.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Binds vitamin B12 with femtomolar affinity and protects it</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23846701" target="_blank" class="term-link">
+                                        PMID:23846701
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a similar overall structure but a different selectivity for corrinoids.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0031419" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of cobalamin binding. This is the core molecular function of TCN1/haptocorrin, directly demonstrated by the crystal structures of human HC bound to cyanocobalamin and cobinamide and by defined cobalamin-binding residues in UniProt. GO:0031419 is the exact current MF term in the GOA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cobalamin binding is directly established experimentally (X-ray structures, defined binding site, femtomolar affinity) and is the central molecular function of the protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Binds vitamin B12 with femtomolar affinity and protects it</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23846701" target="_blank" class="term-link">
+                                        PMID:23846701
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a similar overall structure but a different selectivity for corrinoids.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0005576" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping from the UniProt Swiss-Prot subcellular location (&#34;Secreted&#34;) to extracellular region. Consistent with the curated secreted localization; correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The SubCell &#34;Secreted&#34; -&gt; extracellular region mapping is accurate for this secreted glycoprotein and agrees with the IBA, HDA and Reactome CC annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0015889" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping (IPR002157, cobalamin-binding protein) to cobalamin transport. TCN1 belongs to this family and does participate in cobalamin transport, so the mapping is appropriate.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cobalamin-binding-protein InterPro signature correctly maps to the family&#39;s cobalamin transport process, consistent with the experimental and IBA evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the eukaryotic cobalamin transport proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0031419" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping (IPR002157) to cobalamin binding. Correct and specific: the signature captures the cobalamin-binding fold and TCN1 is experimentally shown to bind cobalamin.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> InterPro cobalamin-binding-protein signature maps precisely to the demonstrated core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Belongs to the eukaryotic cobalamin transport proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32814053
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactome Mapping Provides a Network of Neurodegenerative ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IPI annotation to the uninformative &#34;protein binding&#34; term, supported by a single high-throughput yeast two-hybrid interaction with junctophilin-3 (JPH3, Q8WXH2) from a neurodegenerative-disease interactome screen. The interaction is recorded in UniProt/IntAct but has no functional follow-up and does not describe an informative molecular function for this secreted cobalamin-binding protein. There is no established biology linking secreted haptocorrin to the intracellular junctophilin.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#34;protein binding&#34; is uninformative and this rests on one large-scale Y2H hit (JPH3) without functional characterization; per curation policy the experimental IPI is retained but flagged as an over-annotation rather than removed. It should not be treated as a core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">P20061; Q8WXH2: JPH3; NbExp=3; IntAct=EBI-2557232, EBI-1055254;</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9758881
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0015889" data-r="Reactome:R-HSA-9758881" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation placing TCN1 in &#34;Uptake of dietary cobalamins into enterocytes&#34;. Haptocorrin binds dietary RCbl in saliva/stomach, protecting it, so participation in the cobalamin transport process is correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome captures TCN1&#39;s role in the gastrointestinal step of cobalamin transport; consistent with the core BP.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">from the acidic environment of the stomach.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9758890
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0015889" data-r="Reactome:R-HSA-9758890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation placing TCN1 in &#34;Transport of RCbl within the body&#34;. Haptocorrin carries the majority of circulating plasma cobalamin and scavenges corrinoids for hepatobiliary clearance, so involvement in body-wide cobalamin transport is correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicate cobalamin transport annotation from a different Reactome pathway; correct and core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Binds vitamin B12 with femtomolar affinity and protects it</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140355" target="_blank" class="term-link">
+                                    GO:0140355
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor ligand activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22547309" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22547309
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Vitamin B12 transport from food to the body&#39;s cells--a sophi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0140355" data-r="PMID:22547309" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-assigned EXP annotation to &#34;cargo receptor ligand activity&#34;, reflecting that cobalamin-loaded haptocorrin acts as a ligand whose complex is captured and endocytosed (in the liver via the asialoglycoprotein receptor). This is a defensible molecular-function framing of receptor-mediated clearance, but it is a downstream consequence of cobalamin binding rather than the protein&#39;s central function; the cited reference is an abstract-only review of the multistep B12 transport pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TCN1&#39;s ligand/cargo behaviour follows from its cobalamin binding; the annotation is not wrong but is secondary to the core cobalamin-binding/transport functions and relies on a review rather than a direct TCN1 assay, so it is kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22547309" target="_blank" class="term-link">
+                                        PMID:22547309
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">for specific uptake and transport of this molecule has evolved.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140313" target="_blank" class="term-link">
+                                    GO:0140313
+                                </a>
+                            </span>
+                            <span class="term-label">molecular sequestering activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23846701" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23846701
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for universal corrinoid recognition by the ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0140313" data-r="PMID:23846701" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-assigned EXP annotation to &#34;molecular sequestering activity&#34;, supported by the crystal structure showing broad-specificity binding of cobalamin and cobinamide. This captures haptocorrin&#39;s role in binding/sequestering cobalamin (protecting it) and scavenging inactive corrinoid analogues. It is essentially a restatement of the cobalamin-binding function in sequestering terms.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Sequestering is a valid characterization of HC&#39;s broad corrinoid binding, but it is a facet of the core cobalamin-binding molecular function rather than an independent core activity; retained as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23846701" target="_blank" class="term-link">
+                                        PMID:23846701
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a similar overall structure but a different selectivity for corrinoids.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140313" target="_blank" class="term-link">
+                                    GO:0140313
+                                </a>
+                            </span>
+                            <span class="term-label">molecular sequestering activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27411955
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis of transcobalamin recognition by human CD32...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0140313" data-r="PMID:27411955" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome-assigned EXP annotation to &#34;molecular sequestering activity&#34;. This paper (holo-transcobalamin/CD320 structure) explicitly notes haptocorrin&#39;s role as a high-affinity plasma Cbl-binding scavenger that, unlike transcobalamin, is not recognized by the cellular uptake receptor CD320. Supports HC&#39;s sequestering/ scavenging role but is a facet of cobalamin binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Duplicate molecular sequestering annotation; correctly reflects HC&#39;s scavenging role but is secondary to cobalamin binding, so kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                        PMID:27411955
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Even haptocorrin (HC), a high affinity Cbl-binding protein that shares significant sequence and structural similarities with TC and is also circulating in the plasma, is not recognized by CD320.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035580" target="_blank" class="term-link">
+                                    GO:0035580
+                                </a>
+                            </span>
+                            <span class="term-label">specific granule lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798749
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0035580" data-r="Reactome:R-HSA-6798749" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to specific (secondary) granule lumen. TCN1 is a major constituent of neutrophil secondary/specific granules and is released by neutrophil degranulation, so this localization is correct.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TCN1/haptocorrin is a well-established secondary (specific) granule protein of neutrophils; the granule-lumen localization is supported by UniProt tissue specificity and the original cloning paper.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">in response to ingestion of food. Major constituent of secondary</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2777761" target="_blank" class="term-link">
+                                        PMID:2777761
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is a major protein constituent of secondary granules in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904724" target="_blank" class="term-link">
+                                    GO:1904724
+                                </a>
+                            </span>
+                            <span class="term-label">tertiary granule lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798745
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:1904724" data-r="Reactome:R-HSA-6798745" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation to tertiary granule lumen, from the neutrophil degranulation pathway. TCN1 is primarily a specific/secondary granule protein; Reactome models it among granule-lumen proteins exocytosed during degranulation. Retained as a non-core localization since the primary granule assignment is the specific granule.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Granule-lumen localization is consistent with TCN1 being a neutrophil granule protein released by degranulation, but the tertiary-granule assignment is secondary to its established specific-granule localization; kept as non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2777761" target="_blank" class="term-link">
+                                        PMID:2777761
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">It is a major protein constituent of secondary granules in</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16502470" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16502470
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Human colostrum: identification of minor proteins in the aqu...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0005576" data-r="PMID:16502470" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput proteomic detection (HDA) of TCN1 in the extracellular fluid, here in the aqueous phase of human colostrum. Consistent with the secreted localization; supports extracellular region.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Proteomic identification of TCN1 in an extracellular body fluid corroborates the secreted/extracellular localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16502470" target="_blank" class="term-link">
+                                        PMID:16502470
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">identification of minor proteins in the aqueous phase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3132753
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0005576" data-r="Reactome:R-HSA-3132753" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation (Pancreatic proteases degrade TCN1:RCbl) placing TCN1 in the extracellular region, where the haptocorrin:cobalamin complex is degraded by pancreatic proteases in the small intestine. Correct localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the secreted/extracellular localization of haptocorrin acting in the gastrointestinal lumen.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3132759
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0005576" data-r="Reactome:R-HSA-3132759" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation (TCN1 binds RCbl) placing TCN1 in the extracellular region, where secreted haptocorrin binds free/protein-released RCbl in saliva and stomach. Correct localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the secreted/extracellular localization; this is where TCN1 binds and protects dietary cobalamin.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Produced by the salivary glands of the oral cavity,</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3245898
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0005576" data-r="Reactome:R-HSA-3245898" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation (TCN1 binds corrinoids in the circulation) placing TCN1 in the extracellular region (plasma), where haptocorrin binds inactive corrinoid analogues for hepatobiliary clearance. Correct localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with secreted/plasma localization; corroborated by Reactome&#39;s scavenging/ broad-corrinoid-specificity model of TCN1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798745
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0005576" data-r="Reactome:R-HSA-6798745" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation (Exocytosis of tertiary granule lumen proteins) placing released TCN1 in the extracellular region following neutrophil degranulation. Consistent with the secreted/extracellular localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TCN1 released by degranulation resides in the extracellular region; correct CC.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-6798749
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0005576" data-r="Reactome:R-HSA-6798749" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome TAS annotation (Exocytosis of specific granule lumen proteins) placing released TCN1 in the extracellular region following neutrophil degranulation. Consistent with the secreted/extracellular localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TCN1 released from specific granules by degranulation resides in the extracellular region; correct CC.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN1/TCN1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2777761" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2777761
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of the cDNA encoding transcobalamin I, a neutrophi...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20061" data-a="GO:0015889" data-r="PMID:2777761" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAS annotation to cobalamin transport from the original TCN1 cDNA cloning paper, which describes TCI as a member of the R-binder family of vitamin B12 binding proteins and a major secondary-granule protein. Supports the core cobalamin transport/binding role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Author-stated (TAS) assignment consistent with TCN1&#39;s established role as an R-binder vitamin B12 binding protein; core biological process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2777761" target="_blank" class="term-link">
+                                        PMID:2777761
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">member of the R binder family of vitamin B12 binding</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Binds cobalamin (vitamin B12) with femtomolar affinity and broad corrinoid specificity, binding both cobalamin and biologically inactive cobalamin analogues; this is the central molecular function of secreted haptocorrin.</h3>
+                <span class="vote-buttons" data-g="P20061" data-a="FUNCTION: Binds cobalamin (vitamin B12) with femtomolar affi..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                            cobalamin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TCN1/TCN1-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Binds vitamin B12 with femtomolar affinity and protects it</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23846701" target="_blank" class="term-link">
+                                PMID:23846701
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">a similar overall structure but a different selectivity for corrinoids.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As a secreted cobalamin-binding glycoprotein, participates in cobalamin transport by binding and protecting dietary B12 from the acidic stomach, carrying the majority of circulating plasma B12, and scavenging inactive corrinoids for hepatobiliary clearance; it is not the carrier that delivers B12 into cells (that is TCN2 via CD320).</h3>
+                <span class="vote-buttons" data-g="P20061" data-a="FUNCTION: As a secreted cobalamin-binding glycoprotein, part..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                            cobalamin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TCN1/TCN1-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">from the acidic environment of the stomach.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                PMID:27411955
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Even haptocorrin (HC), a high affinity Cbl-binding protein that shares significant sequence and structural similarities with TC and is also circulating in the plasma, is not recognized by CD320.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16502470" target="_blank" class="term-link">
+                            PMID:16502470
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Human colostrum: identification of minor proteins in the aqueous phase by proteomics.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22547309" target="_blank" class="term-link">
+                            PMID:22547309
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Vitamin B12 transport from food to the body&#39;s cells--a sophisticated, multistep pathway.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23846701" target="_blank" class="term-link">
+                            PMID:23846701
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for universal corrinoid recognition by the cobalamin transport protein haptocorrin.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                            PMID:27411955
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis of transcobalamin recognition by human CD320 receptor.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2777761" target="_blank" class="term-link">
+                            PMID:2777761
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of the cDNA encoding transcobalamin I, a neutrophil granule protein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                            PMID:32814053
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3132753
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Pancreatic proteases degrade TCN1:RCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3132759
+
+                    </span>
+                </div>
+
+                <div class="reference-title">TCN1 binds RCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3245898
+
+                    </span>
+                </div>
+
+                <div class="reference-title">TCN1 binds correnoids in the circulation</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-6798745
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Exocytosis of tertiary granule lumen proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-6798749
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Exocytosis of specific granule lumen proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9758881
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Uptake of dietary cobalamins into enterocytes</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9758890
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Transport of RCbl within the body</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TCN1/TCN1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry P20061 (TCO1_HUMAN), Transcobalamin-1</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TCN1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P20061" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tcn1-transcobalamin-1-haptocorrin-review-notes">TCN1 (Transcobalamin-1 / Haptocorrin) review notes</h1>
+<p>UniProtKB: P20061 (TCO1_HUMAN). Gene TCN1 (syn. TC1), HGNC:11652, chr 11.<br />
+433 aa precursor; signal 1-23; mature chain 24-433. ~30% carbohydrate (heavily<br />
+N-glycosylated). Belongs to the eukaryotic cobalamin transport protein family<br />
+(with TCN2/transcobalamin and GIF/intrinsic factor).</p>
+<h2 id="core-biology">Core biology</h2>
+<ul>
+<li>Secreted broad-specificity cobalamin (vitamin B12)-binding glycoprotein, aka<br />
+  haptocorrin (HC), transcobalamin I, protein R / R-binder.<br />
+  [file:human/TCN1/TCN1-uniprot.txt "SUBCELLULAR LOCATION: Secreted."]</li>
+<li>Binds B12 with femtomolar affinity, protecting it from the acidic stomach.<br />
+  [file:human/TCN1/TCN1-uniprot.txt "Binds vitamin B12 with femtomolar affinity and protects it"]<br />
+  [file:human/TCN1/TCN1-uniprot.txt "from the acidic environment of the stomach."]</li>
+<li>Produced by salivary glands (food-induced) and is a major constituent of the<br />
+  secondary (specific) granules of neutrophils.<br />
+  [file:human/TCN1/TCN1-uniprot.txt "Produced by the salivary glands of the oral cavity,"]<br />
+  [file:human/TCN1/TCN1-uniprot.txt "in response to ingestion of food. Major constituent of secondary"]<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/2777761" title="It is a major protein constituent of secondary granules in">PMID:2777761</a></li>
+<li>"R binder family of vitamin B12 binding proteins." <a href="https://pubmed.ncbi.nlm.nih.gov/2777761">PMID:2777761</a></li>
+</ul>
+<h2 id="binding-specificity-structure">Binding specificity / structure</h2>
+<ul>
+<li>Crystal structures of human HC with cyanocobalamin and cobinamide (Furger 2013,<br />
+  PDB 4KKI/4KKJ). Three transport proteins (TC, IF, HC) share overall structure but<br />
+  differ in corrinoid selectivity; HC has the broadest specificity (binds cobalamin<br />
+  AND inactive corrinoid analogues).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/23846701" title="a similar overall structure but a different selectivity for corrinoids.">PMID:23846701</a><br />
+  Reactome R-HSA-3245898: "broad correnoid specificity of TCN1 ... a role for the<br />
+  latter in scavenging and mediating the hepatobiliary excretion of corrinoids."</li>
+<li>HC is NOT the cellular-delivery carrier: unlike TC (TCN2), haptocorrin is not<br />
+  recognized by the cellular uptake receptor CD320.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27411955" title="haptocorrin (HC), a high affinity Cbl-binding protein that shares significant sequence and structural similarities with TC and is also circulating in the plasma, is not recognized by CD320.">PMID:27411955</a></li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>Secreted / extracellular (GO:0005576 extracellular region present in GOA via IBA,<br />
+  IEA-SubCell, HDA proteomics, and Reactome TAS).</li>
+<li>Neutrophil granule lumen: specific granule lumen (GO:0035580) and tertiary granule<br />
+  lumen (GO:1904724), consistent with degranulation / secondary-granule protein role.</li>
+<li>Identified in body fluids incl. plasma (glycoproteome), saliva, colostrum<br />
+  (PMID:16502470 proteomic detection in colostrum — localization support only).</li>
+</ul>
+<h2 id="goa-mfbpcc-used-for-core_functions-exact-current-terms-from-godb">GOA MF/BP/CC used for core_functions (exact current terms, from go.db)</h2>
+<ul>
+<li>MF: GO:0031419 cobalamin binding (molecular_function) — the core function.</li>
+<li>BP: GO:0015889 cobalamin transport (biological_process).</li>
+<li>CC: GO:0005576 extracellular region (cellular_component).</li>
+</ul>
+<h2 id="annotation-specific-judgments">Annotation-specific judgments</h2>
+<ul>
+<li>GO:0005515 protein binding (IPI, PMID:32814053, JPH3 interactor from an ND<br />
+  interactome Y2H screen): bare "protein binding" is uninformative; single<br />
+  high-throughput Y2H hit with no functional follow-up. Per policy, do NOT REMOVE<br />
+  an experimental IPI whose full text is unverified — MARK_AS_OVER_ANNOTATED.<br />
+  UniProt records the P20061-JPH3 (Q8WXH2) IntAct interaction.</li>
+<li>GO:0140355 cargo receptor ligand activity (EXP, Reactome/PMID:22547309): TCN1 does<br />
+  bind Cbl and its complex is endocytosed (via asialoglycoprotein receptor in liver,<br />
+  not CD320). "Cargo receptor ligand activity" is a defensible Reactome MF framing but<br />
+  is secondary to cobalamin binding; keep as non-core. Abstract-only review; do not remove.</li>
+<li>GO:0140313 molecular sequestering activity (EXP x2, PMID:23846701, PMID:27411955):<br />
+  captures HC's scavenging of Cbl/corrinoids (protecting B12; sequestering inactive<br />
+  analogues). Correct in essence; secondary framing → KEEP_AS_NON_CORE.</li>
+<li>Cobalt/cobalt-ion-transport keyword (GO:0006824) appears only in the UniProt DR/KW<br />
+  block, NOT in the seeded GOA, so it is out of scope for existing_annotations.</li>
+</ul>
+<h2 id="deep-research">Deep research</h2>
+<p>Falcon deep research is OUT OF CREDITS (HTTP 402); no -deep-research-falcon.md was<br />
+generated. Review grounded in TCN1-uniprot.txt, TCN1-goa.tsv, cached publications/<br />
+PMID_*.md, and cached reactome/ entries.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P20061
+gene_symbol: TCN1
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  TCN1 encodes transcobalamin-1, also known as haptocorrin (HC), transcobalamin I,
+  or protein R / R-binder. It is a secreted, heavily N-glycosylated (~30% carbohydrate)
+  cobalamin (vitamin B12)-binding glycoprotein of the eukaryotic cobalamin transport
+  protein family (which also includes transcobalamin/TCN2 and gastric intrinsic
+  factor/GIF). Haptocorrin is produced by the salivary glands in response to food and
+  is a major protein of the specific (secondary) granules of neutrophils; it is present
+  in saliva, gastric juice, plasma, bile and other secretions. It binds cobalamin with
+  femtomolar affinity and, unlike its paralogues, has broad corrinoid specificity,
+  binding cobalamin as well as biologically inactive cobalamin analogues (corrinoids).
+  Functionally it protects dietary B12 from the acidic environment of the stomach and
+  carries the majority of circulating plasma B12, and it scavenges corrinoid analogues
+  for hepatobiliary clearance. It is not the carrier that delivers B12 into cells (that
+  role belongs to transcobalamin/TCN2 acting through the CD320 receptor, which does not
+  recognize haptocorrin). TCN1 is not an enzyme; its core molecular function is cobalamin
+  binding. Elevated serum haptocorrin is observed as a tumour marker in some cancers.
+existing_annotations:
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that TCN1 acts in the extracellular region.
+      Correct: haptocorrin is a secreted protein acting in saliva, gastric juice,
+      plasma and other extracellular fluids, so extracellular region is an appropriate
+      and core localization. GO:0005576 is the exact extracellular CC term also carried
+      elsewhere in the GOA.
+    action: ACCEPT
+    reason: &gt;-
+      TCN1 is a secreted cobalamin-binding glycoprotein; extracellular region is the
+      correct cellular component and is corroborated by the UniProt &#34;Secreted&#34;
+      subcellular location, proteomic detection in plasma/saliva/colostrum, and Reactome.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference that TCN1 is involved in cobalamin transport. This
+      is the correct core biological process: haptocorrin binds dietary/plasma cobalamin
+      (and corrinoid analogues) and participates in B12 transport, protecting acid-labile
+      cobalamin in the stomach and carrying most plasma B12.
+    action: ACCEPT
+    reason: &gt;-
+      Cobalamin transport is the established core biological process of the cobalamin
+      transport protein family; TCN1 binds and carries cobalamin in secretions and plasma.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;Binds vitamin B12 with femtomolar affinity and protects it&#34;
+    - reference_id: PMID:23846701
+      supporting_text: &gt;-
+        a similar overall structure but a different selectivity for corrinoids.
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference of cobalamin binding. This is the core molecular
+      function of TCN1/haptocorrin, directly demonstrated by the crystal structures of
+      human HC bound to cyanocobalamin and cobinamide and by defined cobalamin-binding
+      residues in UniProt. GO:0031419 is the exact current MF term in the GOA.
+    action: ACCEPT
+    reason: &gt;-
+      Cobalamin binding is directly established experimentally (X-ray structures,
+      defined binding site, femtomolar affinity) and is the central molecular function
+      of the protein.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;Binds vitamin B12 with femtomolar affinity and protects it&#34;
+    - reference_id: PMID:23846701
+      supporting_text: &gt;-
+        a similar overall structure but a different selectivity for corrinoids.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic mapping from the UniProt Swiss-Prot subcellular location (&#34;Secreted&#34;)
+      to extracellular region. Consistent with the curated secreted localization; correct.
+    action: ACCEPT
+    reason: &gt;-
+      The SubCell &#34;Secreted&#34; -&gt; extracellular region mapping is accurate for this
+      secreted glycoprotein and agrees with the IBA, HDA and Reactome CC annotations.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      InterPro2GO mapping (IPR002157, cobalamin-binding protein) to cobalamin transport.
+      TCN1 belongs to this family and does participate in cobalamin transport, so the
+      mapping is appropriate.
+    action: ACCEPT
+    reason: &gt;-
+      The cobalamin-binding-protein InterPro signature correctly maps to the family&#39;s
+      cobalamin transport process, consistent with the experimental and IBA evidence.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;Belongs to the eukaryotic cobalamin transport proteins&#34;
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      InterPro2GO mapping (IPR002157) to cobalamin binding. Correct and specific:
+      the signature captures the cobalamin-binding fold and TCN1 is experimentally shown
+      to bind cobalamin.
+    action: ACCEPT
+    reason: &gt;-
+      InterPro cobalamin-binding-protein signature maps precisely to the demonstrated
+      core molecular function.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;Belongs to the eukaryotic cobalamin transport proteins&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  qualifier: enables
+  review:
+    summary: &gt;-
+      IPI annotation to the uninformative &#34;protein binding&#34; term, supported by a single
+      high-throughput yeast two-hybrid interaction with junctophilin-3 (JPH3, Q8WXH2)
+      from a neurodegenerative-disease interactome screen. The interaction is recorded in
+      UniProt/IntAct but has no functional follow-up and does not describe an informative
+      molecular function for this secreted cobalamin-binding protein. There is no
+      established biology linking secreted haptocorrin to the intracellular junctophilin.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Bare &#34;protein binding&#34; is uninformative and this rests on one large-scale Y2H hit
+      (JPH3) without functional characterization; per curation policy the experimental
+      IPI is retained but flagged as an over-annotation rather than removed. It should not
+      be treated as a core function.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;P20061; Q8WXH2: JPH3; NbExp=3; IntAct=EBI-2557232, EBI-1055254;&#34;
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9758881
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation placing TCN1 in &#34;Uptake of dietary cobalamins into
+      enterocytes&#34;. Haptocorrin binds dietary RCbl in saliva/stomach, protecting it, so
+      participation in the cobalamin transport process is correct.
+    action: ACCEPT
+    reason: &gt;-
+      Reactome captures TCN1&#39;s role in the gastrointestinal step of cobalamin transport;
+      consistent with the core BP.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;from the acidic environment of the stomach.&#34;
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9758890
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation placing TCN1 in &#34;Transport of RCbl within the body&#34;.
+      Haptocorrin carries the majority of circulating plasma cobalamin and scavenges
+      corrinoids for hepatobiliary clearance, so involvement in body-wide cobalamin
+      transport is correct.
+    action: ACCEPT
+    reason: &gt;-
+      Duplicate cobalamin transport annotation from a different Reactome pathway; correct
+      and core.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;Binds vitamin B12 with femtomolar affinity and protects it&#34;
+- term:
+    id: GO:0140355
+    label: cargo receptor ligand activity
+  evidence_type: EXP
+  original_reference_id: PMID:22547309
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome-assigned EXP annotation to &#34;cargo receptor ligand activity&#34;, reflecting
+      that cobalamin-loaded haptocorrin acts as a ligand whose complex is captured and
+      endocytosed (in the liver via the asialoglycoprotein receptor). This is a
+      defensible molecular-function framing of receptor-mediated clearance, but it is a
+      downstream consequence of cobalamin binding rather than the protein&#39;s central
+      function; the cited reference is an abstract-only review of the multistep B12
+      transport pathway.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      TCN1&#39;s ligand/cargo behaviour follows from its cobalamin binding; the annotation is
+      not wrong but is secondary to the core cobalamin-binding/transport functions and
+      relies on a review rather than a direct TCN1 assay, so it is kept as non-core.
+    supported_by:
+    - reference_id: PMID:22547309
+      supporting_text: &gt;-
+        for specific uptake and transport of this molecule has evolved.
+- term:
+    id: GO:0140313
+    label: molecular sequestering activity
+  evidence_type: EXP
+  original_reference_id: PMID:23846701
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome-assigned EXP annotation to &#34;molecular sequestering activity&#34;, supported by
+      the crystal structure showing broad-specificity binding of cobalamin and cobinamide.
+      This captures haptocorrin&#39;s role in binding/sequestering cobalamin (protecting it)
+      and scavenging inactive corrinoid analogues. It is essentially a restatement of the
+      cobalamin-binding function in sequestering terms.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Sequestering is a valid characterization of HC&#39;s broad corrinoid binding, but it is
+      a facet of the core cobalamin-binding molecular function rather than an independent
+      core activity; retained as non-core.
+    supported_by:
+    - reference_id: PMID:23846701
+      supporting_text: &gt;-
+        a similar overall structure but a different selectivity for corrinoids.
+- term:
+    id: GO:0140313
+    label: molecular sequestering activity
+  evidence_type: EXP
+  original_reference_id: PMID:27411955
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome-assigned EXP annotation to &#34;molecular sequestering activity&#34;. This paper
+      (holo-transcobalamin/CD320 structure) explicitly notes haptocorrin&#39;s role as a
+      high-affinity plasma Cbl-binding scavenger that, unlike transcobalamin, is not
+      recognized by the cellular uptake receptor CD320. Supports HC&#39;s sequestering/
+      scavenging role but is a facet of cobalamin binding.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Duplicate molecular sequestering annotation; correctly reflects HC&#39;s scavenging role
+      but is secondary to cobalamin binding, so kept as non-core.
+    supported_by:
+    - reference_id: PMID:27411955
+      supporting_text: &gt;-
+        Even haptocorrin (HC), a high affinity Cbl-binding protein that shares significant
+        sequence and structural similarities with TC and is also circulating in the
+        plasma, is not recognized by CD320.
+- term:
+    id: GO:0035580
+    label: specific granule lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798749
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to specific (secondary) granule lumen. TCN1 is a major
+      constituent of neutrophil secondary/specific granules and is released by neutrophil
+      degranulation, so this localization is correct.
+    action: ACCEPT
+    reason: &gt;-
+      TCN1/haptocorrin is a well-established secondary (specific) granule protein of
+      neutrophils; the granule-lumen localization is supported by UniProt tissue
+      specificity and the original cloning paper.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;in response to ingestion of food. Major constituent of secondary&#34;
+    - reference_id: PMID:2777761
+      supporting_text: &#34;It is a major protein constituent of secondary granules in&#34;
+- term:
+    id: GO:1904724
+    label: tertiary granule lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798745
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation to tertiary granule lumen, from the neutrophil
+      degranulation pathway. TCN1 is primarily a specific/secondary granule protein;
+      Reactome models it among granule-lumen proteins exocytosed during degranulation.
+      Retained as a non-core localization since the primary granule assignment is the
+      specific granule.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Granule-lumen localization is consistent with TCN1 being a neutrophil granule
+      protein released by degranulation, but the tertiary-granule assignment is secondary
+      to its established specific-granule localization; kept as non-core.
+    supported_by:
+    - reference_id: PMID:2777761
+      supporting_text: &#34;It is a major protein constituent of secondary granules in&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: HDA
+  original_reference_id: PMID:16502470
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput proteomic detection (HDA) of TCN1 in the extracellular fluid,
+      here in the aqueous phase of human colostrum. Consistent with the secreted
+      localization; supports extracellular region.
+    action: ACCEPT
+    reason: &gt;-
+      Proteomic identification of TCN1 in an extracellular body fluid corroborates the
+      secreted/extracellular localization.
+    supported_by:
+    - reference_id: PMID:16502470
+      supporting_text: &#34;identification of minor proteins in the aqueous phase&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3132753
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation (Pancreatic proteases degrade TCN1:RCbl) placing TCN1 in
+      the extracellular region, where the haptocorrin:cobalamin complex is degraded by
+      pancreatic proteases in the small intestine. Correct localization.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the secreted/extracellular localization of haptocorrin acting in
+      the gastrointestinal lumen.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3132759
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation (TCN1 binds RCbl) placing TCN1 in the extracellular region,
+      where secreted haptocorrin binds free/protein-released RCbl in saliva and stomach.
+      Correct localization.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the secreted/extracellular localization; this is where TCN1 binds
+      and protects dietary cobalamin.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;Produced by the salivary glands of the oral cavity,&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3245898
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation (TCN1 binds corrinoids in the circulation) placing TCN1 in
+      the extracellular region (plasma), where haptocorrin binds inactive corrinoid
+      analogues for hepatobiliary clearance. Correct localization.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with secreted/plasma localization; corroborated by Reactome&#39;s scavenging/
+      broad-corrinoid-specificity model of TCN1.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798745
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation (Exocytosis of tertiary granule lumen proteins) placing
+      released TCN1 in the extracellular region following neutrophil degranulation.
+      Consistent with the secreted/extracellular localization.
+    action: ACCEPT
+    reason: &gt;-
+      TCN1 released by degranulation resides in the extracellular region; correct CC.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798749
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome TAS annotation (Exocytosis of specific granule lumen proteins) placing
+      released TCN1 in the extracellular region following neutrophil degranulation.
+      Consistent with the secreted/extracellular localization.
+    action: ACCEPT
+    reason: &gt;-
+      TCN1 released from specific granules by degranulation resides in the extracellular
+      region; correct CC.
+    supported_by:
+    - reference_id: file:human/TCN1/TCN1-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted.&#34;
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: PMID:2777761
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      TAS annotation to cobalamin transport from the original TCN1 cDNA cloning paper,
+      which describes TCI as a member of the R-binder family of vitamin B12 binding
+      proteins and a major secondary-granule protein. Supports the core cobalamin
+      transport/binding role.
+    action: ACCEPT
+    reason: &gt;-
+      Author-stated (TAS) assignment consistent with TCN1&#39;s established role as an R-binder
+      vitamin B12 binding protein; core biological process.
+    supported_by:
+    - reference_id: PMID:2777761
+      supporting_text: &#34;member of the R binder family of vitamin B12 binding&#34;
+core_functions:
+- description: &gt;-
+    Binds cobalamin (vitamin B12) with femtomolar affinity and broad corrinoid
+    specificity, binding both cobalamin and biologically inactive cobalamin analogues;
+    this is the central molecular function of secreted haptocorrin.
+  molecular_function:
+    id: GO:0031419
+    label: cobalamin binding
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0005576
+    label: extracellular region
+  supported_by:
+  - reference_id: file:human/TCN1/TCN1-uniprot.txt
+    supporting_text: &#34;Binds vitamin B12 with femtomolar affinity and protects it&#34;
+  - reference_id: PMID:23846701
+    supporting_text: &gt;-
+      a similar overall structure but a different selectivity for corrinoids.
+- description: &gt;-
+    As a secreted cobalamin-binding glycoprotein, participates in cobalamin transport by
+    binding and protecting dietary B12 from the acidic stomach, carrying the majority of
+    circulating plasma B12, and scavenging inactive corrinoids for hepatobiliary
+    clearance; it is not the carrier that delivers B12 into cells (that is TCN2 via CD320).
+  molecular_function:
+    id: GO:0031419
+    label: cobalamin binding
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0005576
+    label: extracellular region
+  supported_by:
+  - reference_id: file:human/TCN1/TCN1-uniprot.txt
+    supporting_text: &#34;from the acidic environment of the stomach.&#34;
+  - reference_id: PMID:27411955
+    supporting_text: &gt;-
+      Even haptocorrin (HC), a high affinity Cbl-binding protein that shares significant
+      sequence and structural similarities with TC and is also circulating in the plasma,
+      is not recognized by CD320.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      InterPro2GO pipeline reference; the IPR002157 -&gt; cobalamin binding / cobalamin
+      transport mappings are accurate for this cobalamin transport family member.
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PAN-GO/IBA reference; the three IBA calls (extracellular region, cobalamin
+      transport, cobalamin binding) correctly capture the core function of TCN1.
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      SubCell &#34;Secreted&#34; -&gt; extracellular region mapping is accurate for this secreted
+      glycoprotein.
+- id: PMID:16502470
+  title: &#39;Human colostrum: identification of minor proteins in the aqueous phase by
+    proteomics.&#39;
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      High-throughput proteomics; supports only the extracellular/secreted localization
+      of TCN1 (detected in colostrum), not a specific molecular function.
+- id: PMID:22547309
+  title: Vitamin B12 transport from food to the body&#39;s cells--a sophisticated, multistep
+    pathway.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Abstract-only review of the multistep B12 transport pathway; supports the cobalamin
+      transport context and the cargo/ligand framing but is not a direct TCN1 assay.
+- id: PMID:23846701
+  title: Structural basis for universal corrinoid recognition by the cobalamin transport
+    protein haptocorrin.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Crystal structures of human haptocorrin with cyanocobalamin and cobinamide;
+      directly establishes cobalamin binding and broad corrinoid specificity (core MF).
+- id: PMID:27411955
+  title: Structural basis of transcobalamin recognition by human CD320 receptor.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full-text verified; explicitly states haptocorrin is a high-affinity plasma
+      Cbl-binding protein NOT recognized by the cellular uptake receptor CD320,
+      distinguishing HC from the delivery carrier TCN2.
+- id: PMID:2777761
+  title: Structure of the cDNA encoding transcobalamin I, a neutrophil granule protein.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Original TCN1/TCI cDNA cloning paper; identifies TCI as an R-binder vitamin B12
+      binding protein and a major secondary (specific) granule protein of neutrophils.
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
+    and Uncovers Widespread Protein Aggregation in Affected Brains.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: LOW_QUALITY
+    review_notes: &gt;-
+      Large-scale yeast two-hybrid interactome screen; the single TCN1-JPH3 interaction
+      underlies only an uninformative &#34;protein binding&#34; IPI with no functional follow-up.
+- id: Reactome:R-HSA-3132753
+  title: Pancreatic proteases degrade TCN1:RCbl
+  findings: []
+- id: Reactome:R-HSA-3132759
+  title: TCN1 binds RCbl
+  findings: []
+- id: Reactome:R-HSA-3245898
+  title: TCN1 binds correnoids in the circulation
+  findings: []
+- id: Reactome:R-HSA-6798745
+  title: Exocytosis of tertiary granule lumen proteins
+  findings: []
+- id: Reactome:R-HSA-6798749
+  title: Exocytosis of specific granule lumen proteins
+  findings: []
+- id: Reactome:R-HSA-9758881
+  title: Uptake of dietary cobalamins into enterocytes
+  findings: []
+- id: Reactome:R-HSA-9758890
+  title: Transport of RCbl within the body
+  findings: []
+- id: file:human/TCN1/TCN1-uniprot.txt
+  title: UniProtKB entry P20061 (TCO1_HUMAN), Transcobalamin-1
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/TCN2/TCN2-ai-review.html
+++ b/genes/human/TCN2/TCN2-ai-review.html
@@ -1,0 +1,4885 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TCN2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TCN2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P20062" target="_blank" class="term-link">
+                        P20062
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TCN2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P20062" data-a="DESCRIPTION: Transcobalamin-2 (transcobalamin II, TC II) is the..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Transcobalamin-2 (transcobalamin II, TC II) is the primary secreted plasma cobalamin (vitamin B12)-binding and transport protein. It is a soluble, non-glycosylated 427-residue precursor (18-residue signal peptide, mature chain 19-427) secreted into the circulation, notably by vascular endothelial cells. In plasma it binds a single cobalamin molecule (holo-TC, 1:1 stoichiometry) that has been newly absorbed and exported from the enterocyte, and delivers it to cells throughout the body. The transcobalamin-cobalamin complex is captured from plasma by the ubiquitous cell-surface receptor CD320 (TCblR), a member of the LDL-receptor family, and is internalized by receptor-mediated endocytosis; the complex is delivered to lysosomes where transcobalamin is degraded and cobalamin is released for use as a cofactor (as methylcobalamin by methionine synthase and as adenosylcobalamin by methylmalonyl-CoA mutase). This CD320-dependent route is the physiologically essential pathway that supplies vitamin B12 to peripheral tissues. Transcobalamin-2 is not an enzyme; its molecular function is cobalamin binding, and it acts as the ligand recognized by its uptake receptor. Loss-of-function causes autosomal recessive transcobalamin II deficiency (TCN2D), which presents in early infancy with failure to thrive, severe megaloblastic anemia, pancytopenia, immunodeficiency with recurrent infections, and methylmalonic aciduria (with homocystinuria), and, if untreated, neurological and developmental impairment.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation placing the secreted transcobalamin protein in the extracellular region. Consistent with the biology of a plasma cobalamin transport protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transcobalamin-2 is a secreted plasma protein that acts extracellularly to bind and transport cobalamin. The location is directly supported by protein purification from plasma and by the UniProt secreted subcellular location. The IBA call agrees with experimental evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                                        PMID:8443384
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Transcobalamin II (TCII) is a cobalamin (Cbl, vitamin B12)-binding protein in mammalian plasma that facilitates the cellular uptake of the vitamin.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0015889" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation for involvement in cobalamin transport, the core biological process of transcobalamin-2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cobalamin (vitamin B12) transport is the defining biological role of transcobalamin-2, which delivers newly absorbed cobalamin from the circulation to peripheral cells. This is supported by experimental evidence and by the eukaryotic cobalamin transport protein family assignment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                                        PMID:8443384
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binds Cbl and facilitates the uptake of Cbl in eukaryotic cells by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1708393" target="_blank" class="term-link">
+                                        PMID:1708393
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The cellular uptake of cobalamin (Cbl, vitamin B12) is mediated by transcobalamin II (TCII), a plasma protein that binds Cbl and is secreted by</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0031419" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) annotation for cobalamin binding, the core molecular function of transcobalamin-2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cobalamin binding is the direct, structurally defined molecular function of transcobalamin-2 (one cobalamin buried at the interface of its two domains). The IBA call agrees with multiple experimental (IDA) annotations and crystal structures.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16537422" target="_blank" class="term-link">
+                                        PMID:16537422
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">One Cbl molecule in base-on conformation is buried inside the domain interface.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3782074" target="_blank" class="term-link">
+                                        PMID:3782074
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the final preparation of holo-TCII contained 1 mol of cobalamin/mol of protein.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation mapping the UniProt &#34;Secreted&#34; subcellular-location keyword to the extracellular region.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The SubCell mapping is correct; transcobalamin-2 is a secreted plasma protein and is located in the extracellular region. Redundant with experimental and IBA calls for the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0015889" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro2GO) annotation of cobalamin transport based on the cobalamin-binding protein domain (IPR002157).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro domain-based mapping to cobalamin transport is appropriate for transcobalamin-2 and is corroborated by experimental and IBA evidence for the same process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                                        PMID:8443384
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binds Cbl and facilitates the uptake of Cbl in eukaryotic cells by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0031419" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation (ARBA/InterPro) of cobalamin binding based on the cobalamin-binding protein signature (IPR002157).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The domain-based electronic call correctly assigns the core molecular function. Redundant with, and confirmed by, experimental (IDA) and IBA cobalamin-binding annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16537422" target="_blank" class="term-link">
+                                        PMID:16537422
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">One Cbl molecule in base-on conformation is buried inside the domain interface.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27411955
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis of transcobalamin recognition by human CD32...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005515" data-r="PMID:27411955" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IntAct/UniProt protein-binding (IPI) annotation recording the physical interaction of transcobalamin-2 with CD320 (UniProtKB:Q9NPF0), the transcobalamin receptor, demonstrated by the holo-TC:CD320 co-crystal structure.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The interaction with CD320 is real and experimentally well supported, but the generic term &#34;protein binding&#34; is uninformative and does not capture the biology. The informative molecular function is that transcobalamin-2 acts as the ligand recognized by its endocytic uptake receptor CD320, better represented by GO:0140355 cargo receptor ligand activity (also annotated). Retained (not removed) because it is a valid experimental interaction annotation, but flagged as an over-annotation per curation guidance to avoid bare &#34;protein binding&#34;.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                        PMID:27411955
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cellular uptake of vitamin B12 (cobalamin) requires capture of transcobalamin (TC) from the plasma by CD320, a ubiquitous cell surface receptor of the LDLR family.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9758890
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0015889" data-r="Reactome:R-HSA-9758890" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of cobalamin transport, from the pathway &#34;Transport of RCbl within the body&#34;, capturing transcobalamin-2&#39;s role in moving cobalamin from the enterocyte to peripheral cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly captures the core biological process. Redundant with experimental and IBA cobalamin-transport annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                                        PMID:8443384
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binds Cbl and facilitates the uptake of Cbl in eukaryotic cells by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3782074" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3782074
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and molecular characterization of human transco...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="PMID:3782074" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (EXP) annotation of extracellular region based on purification of transcobalamin-2 from human plasma and determination of its N-terminal sequence and secreted nature.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental localization. Transcobalamin-2 was purified from human plasma (Cohn fraction III) as a secreted cobalamin transport protein, consistent with an extracellular location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3782074" target="_blank" class="term-link">
+                                        PMID:3782074
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">purified from Cohn fraction III of human</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140355" target="_blank" class="term-link">
+                                    GO:0140355
+                                </a>
+                            </span>
+                            <span class="term-label">cargo receptor ligand activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3782074" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3782074
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and molecular characterization of human transco...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0140355" data-r="PMID:3782074" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (EXP, Reactome-assigned) annotation of cargo receptor ligand activity, representing transcobalamin-2 acting as the ligand carrying cobalamin cargo that is recognized and internalized by the CD320 (TCblR) uptake receptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This term captures the informative molecular function of transcobalamin-2 as the cargo-carrying ligand of its cell-surface uptake receptor CD320, which drives receptor-mediated endocytosis of cobalamin into cells. The ligand-for-receptor role is directly established by the holo-TC:CD320 co-crystal structure and by functional cellular-uptake assays; it is more informative than the bare &#34;protein binding&#34; IPI. This is a core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                        PMID:27411955
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated endocytosis, which requires Ca2+-dependent complex formation of TC with its cognate cell surface receptor CD320</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                                        PMID:8443384
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binds Cbl and facilitates the uptake of Cbl in eukaryotic cells by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000074
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="Reactome:R-HSA-3000074" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of extracellular region, from the reaction &#34;TCN2 binds RCbl in the circulation&#34;, where secreted transcobalamin-2 binds cobalamin in plasma.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct extracellular location for the secreted plasma protein. Redundant with experimental and IBA calls for the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000122
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="Reactome:R-HSA-3000122" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of extracellular region, from the reaction &#34;CD320 binds extracellular TCN2:RCbl&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct extracellular location for the secreted transcobalamin-2:cobalamin complex captured by CD320 at the cell surface. Redundant with experimental and IBA calls.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3325546
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="Reactome:R-HSA-3325546" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of extracellular region, from the disease reaction &#34;Defective CD320 does not transport extracellular TCII:Cbl to endosome&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct extracellular location for the secreted transcobalamin-2:cobalamin complex. Redundant with experimental and IBA calls for the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9759202
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="Reactome:R-HSA-9759202" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of extracellular region, from the reaction &#34;LRP2-mediated TCN2:RCbl uptake and delivery to lysosome&#34; (an alternative megalin/LRP2 uptake route, e.g. in renal tubule).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct extracellular location for the secreted transcobalamin-2:cobalamin complex prior to uptake. Redundant with experimental and IBA calls for the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9759209
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="Reactome:R-HSA-9759209" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of extracellular region, from the reaction &#34;LRP2 binds extracellular TCN2:RCbl&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct extracellular location for the secreted transcobalamin-2:cobalamin complex before receptor uptake. Redundant with experimental and IBA calls for the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000112
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005886" data-r="Reactome:R-HSA-3000112" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of plasma membrane, from &#34;CD320-mediated TCN2:RCbl uptake and delivery to lysosome&#34;, reflecting the transcobalamin-2:cobalamin complex being bound at the cell surface by CD320 before endocytosis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Transcobalamin-2 is a soluble secreted protein, not an integral or resident plasma-membrane protein. It is only transiently at the plasma membrane as the ligand of the membrane receptor CD320 during the receptor-binding/endocytosis step. Retained as a valid step in the transport pathway but marked non-core because it is a transient, pathway-context localization rather than an intrinsic residence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                        PMID:27411955
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated endocytosis, which requires Ca2+-dependent complex formation of TC with its cognate cell surface receptor CD320</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000122
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005886" data-r="Reactome:R-HSA-3000122" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of plasma membrane, from &#34;CD320 binds extracellular TCN2:RCbl&#34;, reflecting the transcobalamin-2:cobalamin complex engaging its cell-surface receptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As above, transcobalamin-2 is a secreted soluble protein that only transiently associates with the plasma membrane as the ligand of CD320 during receptor binding. Retained as a valid pathway step but marked non-core rather than an intrinsic localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                        PMID:27411955
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cellular uptake of vitamin B12 (cobalamin) requires capture of transcobalamin (TC) from the plasma by CD320, a ubiquitous cell surface receptor of the LDLR family.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043202" target="_blank" class="term-link">
+                                    GO:0043202
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000112
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0043202" data-r="Reactome:R-HSA-3000112" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of lysosomal lumen, from &#34;CD320-mediated TCN2:RCbl uptake and delivery to lysosome&#34;, where the internalized transcobalamin-2:cobalamin complex is delivered to the lysosome.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The transcobalamin-2:cobalamin complex is trafficked to the lysosome, where transcobalamin-2 is degraded to release cobalamin. This is the terminal destination of the transport pathway, not an intrinsic steady-state location of the protein. Retained as a valid pathway step but marked non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">FUNCTION: Primary vitamin B12-binding and transport protein. Delivers</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043202" target="_blank" class="term-link">
+                                    GO:0043202
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3000263
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0043202" data-r="Reactome:R-HSA-3000263" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of lysosomal lumen, from &#34;TCN2:RCbl is degraded to release RCbl&#34;, where a lysosomal protease degrades transcobalamin-2 to liberate cobalamin.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Represents the terminal lysosomal degradation step of the transport pathway, not an intrinsic localization of transcobalamin-2. Retained as a valid pathway step but marked non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">FUNCTION: Primary vitamin B12-binding and transport protein. Delivers</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043202" target="_blank" class="term-link">
+                                    GO:0043202
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9759202
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0043202" data-r="Reactome:R-HSA-9759202" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of lysosomal lumen, from &#34;LRP2-mediated TCN2:RCbl uptake and delivery to lysosome&#34; (LRP2/megalin uptake route).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As with the CD320 route, the internalized complex is delivered to the lysosome for degradation and cobalamin release; this is a terminal pathway destination rather than an intrinsic localization. Retained as a valid pathway step but marked non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">FUNCTION: Primary vitamin B12-binding and transport protein. Delivers</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8443384
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional human transcobalamin II isoproteins are secreted ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="PMID:8443384" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) annotation of extracellular region; recombinant transcobalamin-2 was constitutively secreted by insect cells, consistent with its native secretion.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported experimental localization. Recombinant transcobalamin-2 was secreted into the culture medium and did not accumulate intracellularly, mirroring its secretion by cultured human endothelial cells.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                                        PMID:8443384
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Transcobalamin II (TCII) is a cobalamin (Cbl, vitamin B12)-binding protein in mammalian plasma that facilitates the cellular uptake of the vitamin.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8443384
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional human transcobalamin II isoproteins are secreted ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0015889" data-r="PMID:8443384" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) annotation of cobalamin transport; recombinant transcobalamin-2 bound cobalamin and facilitated its uptake into cells via the plasma-membrane TCII-Cbl receptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly demonstrated core biological process. Functional recombinant transcobalamin-2 bound Cbl and facilitated its uptake into K562 cells by binding the TCII-Cbl receptor on the plasma membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                                        PMID:8443384
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binds Cbl and facilitates the uptake of Cbl in eukaryotic cells by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27411955
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis of transcobalamin recognition by human CD32...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0031419" data-r="PMID:27411955" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) annotation of cobalamin binding; the holo-TC:CD320 co-crystal structure resolved cobalamin bound to transcobalamin-2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly demonstrated core molecular function. The 2.1 Angstrom co-crystal structure of holo-transcobalamin-2 in complex with CD320 shows cobalamin bound to transcobalamin-2, with the cobalt of Cbl identified in the electron density.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                        PMID:27411955
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Cellular uptake of vitamin B12 (cobalamin) requires capture of transcobalamin (TC) from the plasma by CD320, a ubiquitous cell surface receptor of the LDLR family.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8443384
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional human transcobalamin II isoproteins are secreted ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0031419" data-r="PMID:8443384" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) annotation of cobalamin binding; recombinant transcobalamin-2 bound cobalamin.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly demonstrated core molecular function. Functional recombinant transcobalamin-2 cross-reacted with antiserum to native TCII and bound Cbl.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                                        PMID:8443384
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">binds Cbl and facilitates the uptake of Cbl in eukaryotic cells by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-3299657
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="Reactome:R-HSA-3299657" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome (TAS) annotation of extracellular region, from the disease reaction &#34;Defective TCII does not bind Cbl in the circulation&#34;.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct extracellular location for the secreted plasma protein. Redundant with experimental and IBA calls for the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TCN2/TCN2-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Secreted</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                                    GO:0031419
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16537422" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16537422
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis for mammalian vitamin B12 transport by tran...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0031419" data-r="PMID:16537422" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (IDA) annotation of cobalamin binding; the crystal structure of human holo-transcobalamin resolved one cobalamin buried at the interface of its two domains.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly demonstrated core molecular function with atomic-resolution structural evidence. The holo-TC structure shows a single Cbl in base-on conformation buried at the domain interface, with a barrel histidine as the axial ligand.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16537422" target="_blank" class="term-link">
+                                        PMID:16537422
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">One Cbl molecule in base-on conformation is buried inside the domain interface.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1708393" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1708393
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The cDNA sequence and the deduced amino acid sequence of hum...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0005576" data-r="PMID:1708393" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement (TAS) annotation of extracellular region; the cDNA encodes a secreted 409-residue protein with an 18-residue leader peptide, secreted by endothelial cells.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct extracellular location supported by the cloned cDNA encoding a signal peptide and secreted mature protein, and by demonstrated secretion from human umbilical vein endothelial cells. Redundant with experimental and IBA calls for the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1708393" target="_blank" class="term-link">
+                                        PMID:1708393
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The cellular uptake of cobalamin (Cbl, vitamin B12) is mediated by transcobalamin II (TCII), a plasma protein that binds Cbl and is secreted by</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                    GO:0015889
+                                </a>
+                            </span>
+                            <span class="term-label">cobalamin transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3782074" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:3782074
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and molecular characterization of human transco...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P20062" data-a="GO:0015889" data-r="PMID:3782074" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable-author-statement (TAS) annotation of cobalamin transport, from the characterization of transcobalamin-2 as the plasma cobalamin transport protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correctly captures the core biological process. Transcobalamin-2 was purified as the plasma holo-cobalamin transport protein (1 mol cobalamin/mol protein). Redundant with experimental and IBA cobalamin-transport annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/3782074" target="_blank" class="term-link">
+                                        PMID:3782074
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the final preparation of holo-TCII contained 1 mol of cobalamin/mol of protein.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Binds vitamin B12 (cobalamin) with 1:1 stoichiometry as the primary plasma cobalamin-binding protein, sequestering a single cobalamin molecule at the interface of its two structural domains.</h3>
+                <span class="vote-buttons" data-g="P20062" data-a="FUNCTION: Binds vitamin B12 (cobalamin) with 1:1 stoichiomet..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                            cobalamin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16537422" target="_blank" class="term-link">
+                                PMID:16537422
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">One Cbl molecule in base-on conformation is buried inside the domain interface.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/3782074" target="_blank" class="term-link">
+                                PMID:3782074
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the final preparation of holo-TCII contained 1 mol of cobalamin/mol of protein.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Acts as the cargo-carrying ligand recognized by the cell-surface uptake receptor CD320 (TCblR), enabling receptor-mediated endocytosis of the transcobalamin-cobalamin complex and thereby delivery of vitamin B12 into cells.</h3>
+                <span class="vote-buttons" data-g="P20062" data-a="FUNCTION: Acts as the cargo-carrying ligand recognized by th..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140355" target="_blank" class="term-link">
+                            cargo receptor ligand activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                                PMID:27411955
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated endocytosis, which requires Ca2+-dependent complex formation of TC with its cognate cell surface receptor CD320</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                                PMID:8443384
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">binds Cbl and facilitates the uptake of Cbl in eukaryotic cells by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As a secreted plasma protein, transports newly absorbed cobalamin from the circulation to peripheral cells throughout the body, the physiologically essential route supplying vitamin B12 to tissues.</h3>
+                <span class="vote-buttons" data-g="P20062" data-a="FUNCTION: As a secreted plasma protein, transports newly abs..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031419" target="_blank" class="term-link">
+                            cobalamin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015889" target="_blank" class="term-link">
+                                cobalamin transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1708393" target="_blank" class="term-link">
+                                PMID:1708393
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The cellular uptake of cobalamin (Cbl, vitamin B12) is mediated by transcobalamin II (TCII), a plasma protein that binds Cbl and is secreted by</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                                PMID:8443384
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Transcobalamin II (TCII) is a cobalamin (Cbl, vitamin B12)-binding protein in mammalian plasma that facilitates the cellular uptake of the vitamin.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16537422" target="_blank" class="term-link">
+                            PMID:16537422
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis for mammalian vitamin B12 transport by transcobalamin.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The crystal structure of human holo-transcobalamin reveals a two-domain architecture with one cobalamin buried in base-on conformation at the domain interface, defining the structural basis of cobalamin binding.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1708393" target="_blank" class="term-link">
+                            PMID:1708393
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The cDNA sequence and the deduced amino acid sequence of human transcobalamin II show homology with rat intrinsic factor and human transcobalamin I.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The transcobalamin-2 cDNA encodes an 18-residue leader peptide and a secreted 409-residue protein; the protein is a plasma cobalamin-binding protein secreted by endothelial cells and mediates cellular uptake of cobalamin.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27411955" target="_blank" class="term-link">
+                            PMID:27411955
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis of transcobalamin recognition by human CD320 receptor.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The holo-TC:CD320 co-crystal structure shows transcobalamin-2, carrying bound cobalamin, engaging the LDLR-A domains of the cell-surface receptor CD320, the interaction that drives receptor-mediated cellular uptake of vitamin B12; binding is Ca2+-dependent and reduced at endosomal (low) pH.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/3782074" target="_blank" class="term-link">
+                            PMID:3782074
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Purification and molecular characterization of human transcobalamin II.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Transcobalamin-2 was purified from human plasma as a secreted holo-protein containing one cobalamin per protein molecule, establishing its extracellular localization and 1:1 cobalamin binding.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8443384" target="_blank" class="term-link">
+                            PMID:8443384
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional human transcobalamin II isoproteins are secreted by insect cells using the baculovirus expression system.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Recombinant transcobalamin-2 is constitutively secreted, binds cobalamin, and facilitates cobalamin uptake into cells by binding the plasma-membrane TCII-Cbl receptor, directly demonstrating its cobalamin-binding and transport functions.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TCN2/TCN2-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB P20062 (TCO2_HUMAN) Transcobalamin-2</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt describes transcobalamin-2 as the primary vitamin B12-binding and transport protein that delivers cobalamin to cells, is secreted, and interacts with CD320 via its LDL-receptor class A domains; loss of function causes transcobalamin II deficiency (TCN2D).</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000074
+
+                    </span>
+                </div>
+
+                <div class="reference-title">TCN2 binds RCbl in the circulation</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000112
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CD320-mediated TCN2:RCbl uptake and delivery to lysosome</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000122
+
+                    </span>
+                </div>
+
+                <div class="reference-title">CD320 binds extracellular TCN2:RCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3000263
+
+                    </span>
+                </div>
+
+                <div class="reference-title">TCN2:RCbl is degraded to release RCbl</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3299657
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective TCII does not bind Cbl in the circulation</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-3325546
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defective CD320 does not transport extracellular TCII:Cbl to endosome</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9758890
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Transport of RCbl within the body</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9759202
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LRP2-mediated TCN2:RCbl uptake and delivery to lysosome</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9759209
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LRP2 binds extracellular TCN2:RCbl</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Beyond CD320, how much does the LRP2/megalin-mediated route (e.g. in the renal tubule) contribute to transcobalamin-cobalamin reuptake and tissue cobalamin delivery in vivo?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P20062" data-a="Q: Beyond CD320, how much does the LRP2/megalin-media..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does apo-transcobalamin-2 have a distinct physiological function or receptor engagement compared with holo-transcobalamin-2?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P20062" data-a="Q: Does apo-transcobalamin-2 have a distinct physiolo..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantify the relative contribution of CD320 versus LRP2/megalin to tissue cobalamin delivery using tissue-specific knockout models and labelled-cobalamin uptake assays.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P20062" data-a="EXPERIMENT: Quantify the relative contribution of CD320 versus..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structural and kinetic characterization of cobalamin loading onto apo-transcobalamin-2, including whether an enterocyte export factor is required for efficient loading.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P20062" data-a="EXPERIMENT: Structural and kinetic characterization of cobalam..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TCN2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P20062" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tcn2-transcobalamin-2-transcobalamin-ii-review-notes">TCN2 (Transcobalamin-2 / Transcobalamin II) review notes</h1>
+<p>UniProt: P20062 (TCO2_HUMAN). HGNC:11653. Gene TCN2 (synonym TC2). 427 aa precursor;<br />
+signal peptide 1-18, mature chain 19-427. Secreted. Chromosome 22.<br />
+Deep research: falcon out of credits (HTTP 402); no deep-research file. Grounded in<br />
+UniProt record, GOA, and cached PMIDs/Reactome.</p>
+<h2 id="core-biology-verified">Core biology (verified)</h2>
+<p>TCN2 is the <strong>primary plasma vitamin B12 (cobalamin, Cbl)-binding and transport<br />
+protein</strong>. It is secreted (notably by vascular endothelial cells), circulates in<br />
+plasma, binds newly absorbed cobalamin exported from the enterocyte, and delivers it to<br />
+peripheral cells. The holo-TC (TC:Cbl) complex is captured from plasma by the ubiquitous<br />
+cell-surface receptor <strong>CD320 (TCblR)</strong>, a member of the LDL-receptor family, and taken<br />
+up by <strong>receptor-mediated endocytosis</strong>; TC:Cbl is delivered to lysosomes where TC is<br />
+degraded and Cbl released for downstream cofactor use (methylcobalamin for methionine<br />
+synthase; adenosylcobalamin for methylmalonyl-CoA mutase). This CD320 route is the<br />
+physiologically essential pathway supplying B12 to tissues. TCN2 is <strong>not an enzyme</strong>;<br />
+its molecular function is cobalamin binding, enabling cobalamin transport / acting as<br />
+the ligand for its uptake receptor.</p>
+<ul>
+<li>Function (UniProt CC): "Primary vitamin B12-binding and transport protein. Delivers<br />
+  cobalamin to cells." [ECO:0000269|PubMed:8443384]</li>
+<li>SUBUNIT: "Interacts with CD320 (via LDL-receptor class A domains)."<br />
+  [ECO:0000269|PubMed:27411955]</li>
+<li>SUBCELLULAR LOCATION: "Secreted" [ECO:0000269|PubMed:3782074, 8443384]</li>
+<li>SIMILARITY: "Belongs to the eukaryotic cobalamin transport proteins family."</li>
+</ul>
+<h2 id="evidence-from-cached-publications">Evidence from cached publications</h2>
+<ul>
+<li>
+<p><strong>PMID:3782074</strong> (Quadros et al. 1986, JBC) — Purification &amp; molecular characterization<br />
+  of human TCII from plasma; determined N-terminal 19 aa; holo-TCII contained 1 mol<br />
+  cobalamin/mol protein; single 43 kDa polypeptide. UniProt RP: "PROTEIN SEQUENCE OF<br />
+  19-37, AND SUBCELLULAR LOCATION." Basis for secreted/extracellular localization and<br />
+  cobalamin binding (1:1). Abstract-only cache.<br />
+  Verbatim: "the final preparation of holo-TCII contained 1 mol of cobalamin/mol of<br />
+  protein."</p>
+</li>
+<li>
+<p><strong>PMID:8443384</strong> (Quadros et al. 1993, Blood) — Recombinant human TCII secreted by<br />
+  insect (baculovirus) cells; binds Cbl and facilitates cellular uptake by binding to<br />
+  the TCII-Cbl receptor on the plasma membrane of K562 cells. UniProt FUNCTION source.<br />
+  Verbatim: "Transcobalamin II (TCII) is a cobalamin (Cbl, vitamin B12)-binding protein<br />
+  in mammalian plasma that facilitates the cellular uptake of the vitamin."<br />
+  Verbatim: "binds Cbl and facilitates the uptake of Cbl in eukaryotic cells by binding<br />
+  to the receptor for TCII-Cbl on the plasma membrane of K562 cells."</p>
+</li>
+<li>
+<p><strong>PMID:16537422</strong> (Wuerges et al. 2006, PNAS) — Crystal structures of human &amp; bovine<br />
+  holo-TC; two-domain architecture (N-terminal alpha6-alpha6 barrel + smaller C-terminal<br />
+  domain); one Cbl buried at the domain interface; base-on conformation; His of barrel<br />
+  becomes axial ligand. Direct structural evidence for cobalamin binding.<br />
+  Verbatim: "One Cbl molecule in base-on conformation is buried inside the domain<br />
+  interface."<br />
+  Verbatim: "the plasma transport, and cellular uptake uses cell surface receptors and<br />
+  three Cbl-transporting proteins, haptocorrin, intrinsic factor, and transcobalamin<br />
+  (TC)." [note: exact substring is "plasma transport, and cellular uptake"]</p>
+</li>
+<li>
+<p><strong>PMID:27411955</strong> (Alam et al. 2016, Nat Commun) — Crystal structure of human holo-TC<br />
+  in complex with CD320 ectodomain. Establishes TC as the ligand captured by CD320 for<br />
+  receptor-mediated endocytosis; pH-dependent release in endosome. Full text available.<br />
+  Basis for the IPI protein-binding (interactor CD320/Q9NPF0) and cargo-receptor-ligand.<br />
+  Verbatim: "Cellular uptake of vitamin B12 (cobalamin) requires capture of<br />
+  transcobalamin (TC) from the plasma by CD320, a ubiquitous cell surface receptor of<br />
+  the LDLR family."<br />
+  Verbatim: "transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated<br />
+  endocytosis, which requires Ca2+-dependent complex formation of TC with its cognate<br />
+  cell surface receptor CD320"</p>
+</li>
+<li>
+<p><strong>PMID:1708393</strong> (Platica et al. 1991, JBC) — cDNA/deduced aa sequence; leader peptide<br />
+  18 aa + secreted protein of 409 aa; homology to TCI and rat intrinsic factor. TAS<br />
+  basis (via PINC) for extracellular localization. Abstract-only.<br />
+  Verbatim: "The cellular uptake of cobalamin (Cbl, vitamin B12) is mediated by<br />
+  transcobalamin II (TCII), a plasma protein that binds Cbl and is secreted by human<br />
+  umbilical vein endothelial (HUVE) cells."</p>
+</li>
+</ul>
+<h2 id="goa-annotations-29-goa-rows-27-stub-entries-grouped">GOA annotations (29 GOA rows → 27 stub entries; grouped)</h2>
+<p>MF:<br />
+- GO:0031419 cobalamin binding — IBA (GO_REF:0000033), IEA (GO_REF:0000120), IDA<br />
+  x3 (PMID:27411955, PMID:8443384, PMID:16537422). CORE. ACCEPT experimental/IBA.<br />
+- GO:0140355 cargo receptor ligand activity — EXP (PMID:3782074, assigned Reactome).<br />
+  Captures TC being the ligand recognized by CD320 for endocytic uptake. Supportable<br />
+  (Alam 2016 structural + Reactome CD320 model). ACCEPT (core—ligand for its uptake<br />
+  receptor). Note: EXP reference PMID:3782074 is the purification paper; the functional<br />
+  ligand-for-receptor role is directly shown by PMID:27411955/8443384.<br />
+- GO:0005515 protein binding — IPI (PMID:27411955), interactor UniProtKB:Q9NPF0 (CD320).<br />
+  Bare "protein binding" — uninformative per policy → MARK_AS_OVER_ANNOTATED (the<br />
+  informative capture of the CD320 interaction is GO:0140355 cargo receptor ligand<br />
+  activity). Do NOT REMOVE (experimental IPI).</p>
+<p>BP:<br />
+- GO:0015889 cobalamin transport — IBA (GO_REF:0000033), IEA (GO_REF:0000002 InterPro),<br />
+  TAS (Reactome R-HSA-9758890), IDA (PMID:8443384), TAS (PMID:3782074). CORE. ACCEPT.</p>
+<p>CC:<br />
+- GO:0005576 extracellular region — IBA (GO_REF:0000033), IEA (GO_REF:0000044<br />
+  SubCell), EXP (PMID:3782074), IDA (PMID:8443384), TAS PMID:1708393, TAS Reactome<br />
+  (R-HSA-3000074, 3000122, 3325546, 9759202, 9759209, 3299657). Secreted protein → CORE<br />
+  location. ACCEPT experimental; ACCEPT/route-context for TAS/IEA/IBA.<br />
+- GO:0005886 plasma membrane — TAS Reactome (R-HSA-3000112, 3000122). TCN2 is not itself<br />
+  a PM protein; it is transiently AT the PM as the ligand of CD320 during receptor<br />
+  binding/endocytosis. KEEP_AS_NON_CORE (transient transport-pathway localization, not a<br />
+  resident membrane protein).<br />
+- GO:0043202 lysosomal lumen — TAS Reactome (R-HSA-3000112, 3000263, 9759202). TC:Cbl is<br />
+  delivered to lysosomes and degraded there. KEEP_AS_NON_CORE (transient<br />
+  transport-pathway localization; the terminal degradation compartment).</p>
+<h2 id="core-function-summary">Core function summary</h2>
+<ol>
+<li>Cobalamin (vitamin B12) binding — GO:0031419 (MF). 1:1 holo-TC; structurally defined.</li>
+<li>Cobalamin transport — GO:0015889 (BP). Delivers newly absorbed B12 to peripheral cells.</li>
+<li>Cargo receptor ligand activity — GO:0140355 (MF). TC:Cbl is the ligand captured by<br />
+   CD320 (TCblR) for receptor-mediated endocytic uptake.<br />
+Location: extracellular region GO:0005576 (secreted plasma protein).</li>
+</ol>
+<h2 id="disease">Disease</h2>
+<p>Transcobalamin II deficiency (TCN2D, MIM:275350): autosomal recessive; early-infancy<br />
+failure to thrive, megaloblastic anemia, pancytopenia, agammaglobulinemia,<br />
+immunodeficiency/recurrent infections, methylmalonic aciduria; untreated → neurological<br />
+(psychomotor/mental developmental delay). (UniProt DISEASE, PMID:14632784, 19373259,<br />
+32841161, 33023511.)<br />
+</content></p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P20062
+gene_symbol: TCN2
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: Transcobalamin-2 (transcobalamin II, TC II) is the primary secreted plasma
+  cobalamin (vitamin B12)-binding and transport protein. It is a soluble, non-glycosylated
+  427-residue precursor (18-residue signal peptide, mature chain 19-427) secreted into
+  the circulation, notably by vascular endothelial cells. In plasma it binds a single
+  cobalamin molecule (holo-TC, 1:1 stoichiometry) that has been newly absorbed and exported
+  from the enterocyte, and delivers it to cells throughout the body. The transcobalamin-cobalamin
+  complex is captured from plasma by the ubiquitous cell-surface receptor CD320 (TCblR),
+  a member of the LDL-receptor family, and is internalized by receptor-mediated endocytosis;
+  the complex is delivered to lysosomes where transcobalamin is degraded and cobalamin
+  is released for use as a cofactor (as methylcobalamin by methionine synthase and as
+  adenosylcobalamin by methylmalonyl-CoA mutase). This CD320-dependent route is the physiologically
+  essential pathway that supplies vitamin B12 to peripheral tissues. Transcobalamin-2
+  is not an enzyme; its molecular function is cobalamin binding, and it acts as the ligand
+  recognized by its uptake receptor. Loss-of-function causes autosomal recessive transcobalamin
+  II deficiency (TCN2D), which presents in early infancy with failure to thrive, severe
+  megaloblastic anemia, pancytopenia, immunodeficiency with recurrent infections, and
+  methylmalonic aciduria (with homocystinuria), and, if untreated, neurological and developmental
+  impairment.
+alternative_products:
+- name: &#39;1&#39;
+  id: P20062-1
+- name: &#39;2&#39;
+  id: P20062-2
+  sequence_note: VSP_043711
+existing_annotations:
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetic (IBA) annotation placing the secreted transcobalamin protein
+      in the extracellular region. Consistent with the biology of a plasma cobalamin
+      transport protein.
+    action: ACCEPT
+    reason: Transcobalamin-2 is a secreted plasma protein that acts extracellularly to
+      bind and transport cobalamin. The location is directly supported by protein purification
+      from plasma and by the UniProt secreted subcellular location. The IBA call agrees
+      with experimental evidence.
+    supported_by:
+    - reference_id: PMID:8443384
+      supporting_text: Transcobalamin II (TCII) is a cobalamin (Cbl, vitamin B12)-binding
+        protein in mammalian plasma that facilitates the cellular uptake of the vitamin.
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted&#34;
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetic (IBA) annotation for involvement in cobalamin transport, the
+      core biological process of transcobalamin-2.
+    action: ACCEPT
+    reason: Cobalamin (vitamin B12) transport is the defining biological role of transcobalamin-2,
+      which delivers newly absorbed cobalamin from the circulation to peripheral cells.
+      This is supported by experimental evidence and by the eukaryotic cobalamin transport
+      protein family assignment.
+    supported_by:
+    - reference_id: PMID:8443384
+      supporting_text: binds Cbl and facilitates the uptake of Cbl in eukaryotic cells
+        by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.
+    - reference_id: PMID:1708393
+      supporting_text: The cellular uptake of cobalamin (Cbl, vitamin B12) is mediated
+        by transcobalamin II (TCII), a plasma protein that binds Cbl and is secreted by
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: Phylogenetic (IBA) annotation for cobalamin binding, the core molecular function
+      of transcobalamin-2.
+    action: ACCEPT
+    reason: Cobalamin binding is the direct, structurally defined molecular function of
+      transcobalamin-2 (one cobalamin buried at the interface of its two domains). The
+      IBA call agrees with multiple experimental (IDA) annotations and crystal structures.
+    supported_by:
+    - reference_id: PMID:16537422
+      supporting_text: One Cbl molecule in base-on conformation is buried inside the domain
+        interface.
+    - reference_id: PMID:3782074
+      supporting_text: the final preparation of holo-TCII contained 1 mol of cobalamin/mol
+        of protein.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic annotation mapping the UniProt &#34;Secreted&#34; subcellular-location
+      keyword to the extracellular region.
+    action: ACCEPT
+    reason: The SubCell mapping is correct; transcobalamin-2 is a secreted plasma protein
+      and is located in the extracellular region. Redundant with experimental and IBA
+      calls for the same term.
+    supported_by:
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted&#34;
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: Electronic (InterPro2GO) annotation of cobalamin transport based on the cobalamin-binding
+      protein domain (IPR002157).
+    action: ACCEPT
+    reason: The InterPro domain-based mapping to cobalamin transport is appropriate for
+      transcobalamin-2 and is corroborated by experimental and IBA evidence for the same
+      process.
+    supported_by:
+    - reference_id: PMID:8443384
+      supporting_text: binds Cbl and facilitates the uptake of Cbl in eukaryotic cells
+        by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Electronic annotation (ARBA/InterPro) of cobalamin binding based on the cobalamin-binding
+      protein signature (IPR002157).
+    action: ACCEPT
+    reason: The domain-based electronic call correctly assigns the core molecular function.
+      Redundant with, and confirmed by, experimental (IDA) and IBA cobalamin-binding annotations.
+    supported_by:
+    - reference_id: PMID:16537422
+      supporting_text: One Cbl molecule in base-on conformation is buried inside the domain
+        interface.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:27411955
+  qualifier: enables
+  review:
+    summary: IntAct/UniProt protein-binding (IPI) annotation recording the physical interaction
+      of transcobalamin-2 with CD320 (UniProtKB:Q9NPF0), the transcobalamin receptor,
+      demonstrated by the holo-TC:CD320 co-crystal structure.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction with CD320 is real and experimentally well supported, but the
+      generic term &#34;protein binding&#34; is uninformative and does not capture the biology.
+      The informative molecular function is that transcobalamin-2 acts as the ligand recognized
+      by its endocytic uptake receptor CD320, better represented by GO:0140355 cargo receptor
+      ligand activity (also annotated). Retained (not removed) because it is a valid experimental
+      interaction annotation, but flagged as an over-annotation per curation guidance to
+      avoid bare &#34;protein binding&#34;.
+    supported_by:
+    - reference_id: PMID:27411955
+      supporting_text: Cellular uptake of vitamin B12 (cobalamin) requires capture of transcobalamin
+        (TC) from the plasma by CD320, a ubiquitous cell surface receptor of the LDLR family.
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9758890
+  qualifier: involved_in
+  review:
+    summary: Reactome (TAS) annotation of cobalamin transport, from the pathway &#34;Transport
+      of RCbl within the body&#34;, capturing transcobalamin-2&#39;s role in moving cobalamin
+      from the enterocyte to peripheral cells.
+    action: ACCEPT
+    reason: Correctly captures the core biological process. Redundant with experimental
+      and IBA cobalamin-transport annotations.
+    supported_by:
+    - reference_id: PMID:8443384
+      supporting_text: binds Cbl and facilitates the uptake of Cbl in eukaryotic cells
+        by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: EXP
+  original_reference_id: PMID:3782074
+  qualifier: located_in
+  review:
+    summary: Experimental (EXP) annotation of extracellular region based on purification
+      of transcobalamin-2 from human plasma and determination of its N-terminal sequence
+      and secreted nature.
+    action: ACCEPT
+    reason: Directly supported experimental localization. Transcobalamin-2 was purified
+      from human plasma (Cohn fraction III) as a secreted cobalamin transport protein,
+      consistent with an extracellular location.
+    supported_by:
+    - reference_id: PMID:3782074
+      supporting_text: purified from Cohn fraction III of human
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted&#34;
+- term:
+    id: GO:0140355
+    label: cargo receptor ligand activity
+  evidence_type: EXP
+  original_reference_id: PMID:3782074
+  qualifier: enables
+  review:
+    summary: Experimental (EXP, Reactome-assigned) annotation of cargo receptor ligand
+      activity, representing transcobalamin-2 acting as the ligand carrying cobalamin cargo
+      that is recognized and internalized by the CD320 (TCblR) uptake receptor.
+    action: ACCEPT
+    reason: This term captures the informative molecular function of transcobalamin-2 as
+      the cargo-carrying ligand of its cell-surface uptake receptor CD320, which drives
+      receptor-mediated endocytosis of cobalamin into cells. The ligand-for-receptor role
+      is directly established by the holo-TC:CD320 co-crystal structure and by functional
+      cellular-uptake assays; it is more informative than the bare &#34;protein binding&#34; IPI.
+      This is a core molecular function.
+    supported_by:
+    - reference_id: PMID:27411955
+      supporting_text: transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated
+        endocytosis, which requires Ca2+-dependent complex formation of TC with its cognate
+        cell surface receptor CD320
+    - reference_id: PMID:8443384
+      supporting_text: binds Cbl and facilitates the uptake of Cbl in eukaryotic cells
+        by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000074
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of extracellular region, from the reaction &#34;TCN2
+      binds RCbl in the circulation&#34;, where secreted transcobalamin-2 binds cobalamin
+      in plasma.
+    action: ACCEPT
+    reason: Correct extracellular location for the secreted plasma protein. Redundant with
+      experimental and IBA calls for the same term.
+    supported_by:
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000122
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of extracellular region, from the reaction &#34;CD320
+      binds extracellular TCN2:RCbl&#34;.
+    action: ACCEPT
+    reason: Correct extracellular location for the secreted transcobalamin-2:cobalamin
+      complex captured by CD320 at the cell surface. Redundant with experimental and IBA
+      calls.
+    supported_by:
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3325546
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of extracellular region, from the disease reaction
+      &#34;Defective CD320 does not transport extracellular TCII:Cbl to endosome&#34;.
+    action: ACCEPT
+    reason: Correct extracellular location for the secreted transcobalamin-2:cobalamin
+      complex. Redundant with experimental and IBA calls for the same term.
+    supported_by:
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9759202
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of extracellular region, from the reaction &#34;LRP2-mediated
+      TCN2:RCbl uptake and delivery to lysosome&#34; (an alternative megalin/LRP2 uptake route,
+      e.g. in renal tubule).
+    action: ACCEPT
+    reason: Correct extracellular location for the secreted transcobalamin-2:cobalamin
+      complex prior to uptake. Redundant with experimental and IBA calls for the same term.
+    supported_by:
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9759209
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of extracellular region, from the reaction &#34;LRP2
+      binds extracellular TCN2:RCbl&#34;.
+    action: ACCEPT
+    reason: Correct extracellular location for the secreted transcobalamin-2:cobalamin
+      complex before receptor uptake. Redundant with experimental and IBA calls for the
+      same term.
+    supported_by:
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted&#34;
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000112
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of plasma membrane, from &#34;CD320-mediated TCN2:RCbl
+      uptake and delivery to lysosome&#34;, reflecting the transcobalamin-2:cobalamin complex
+      being bound at the cell surface by CD320 before endocytosis.
+    action: KEEP_AS_NON_CORE
+    reason: Transcobalamin-2 is a soluble secreted protein, not an integral or resident
+      plasma-membrane protein. It is only transiently at the plasma membrane as the ligand
+      of the membrane receptor CD320 during the receptor-binding/endocytosis step. Retained
+      as a valid step in the transport pathway but marked non-core because it is a transient,
+      pathway-context localization rather than an intrinsic residence.
+    supported_by:
+    - reference_id: PMID:27411955
+      supporting_text: transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated
+        endocytosis, which requires Ca2+-dependent complex formation of TC with its cognate
+        cell surface receptor CD320
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000122
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of plasma membrane, from &#34;CD320 binds extracellular
+      TCN2:RCbl&#34;, reflecting the transcobalamin-2:cobalamin complex engaging its cell-surface
+      receptor.
+    action: KEEP_AS_NON_CORE
+    reason: As above, transcobalamin-2 is a secreted soluble protein that only transiently
+      associates with the plasma membrane as the ligand of CD320 during receptor binding.
+      Retained as a valid pathway step but marked non-core rather than an intrinsic localization.
+    supported_by:
+    - reference_id: PMID:27411955
+      supporting_text: Cellular uptake of vitamin B12 (cobalamin) requires capture of transcobalamin
+        (TC) from the plasma by CD320, a ubiquitous cell surface receptor of the LDLR family.
+- term:
+    id: GO:0043202
+    label: lysosomal lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000112
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of lysosomal lumen, from &#34;CD320-mediated TCN2:RCbl
+      uptake and delivery to lysosome&#34;, where the internalized transcobalamin-2:cobalamin
+      complex is delivered to the lysosome.
+    action: KEEP_AS_NON_CORE
+    reason: The transcobalamin-2:cobalamin complex is trafficked to the lysosome, where
+      transcobalamin-2 is degraded to release cobalamin. This is the terminal destination
+      of the transport pathway, not an intrinsic steady-state location of the protein.
+      Retained as a valid pathway step but marked non-core.
+    supported_by:
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;FUNCTION: Primary vitamin B12-binding and transport protein. Delivers&#34;
+- term:
+    id: GO:0043202
+    label: lysosomal lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3000263
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of lysosomal lumen, from &#34;TCN2:RCbl is degraded
+      to release RCbl&#34;, where a lysosomal protease degrades transcobalamin-2 to liberate
+      cobalamin.
+    action: KEEP_AS_NON_CORE
+    reason: Represents the terminal lysosomal degradation step of the transport pathway,
+      not an intrinsic localization of transcobalamin-2. Retained as a valid pathway step
+      but marked non-core.
+    supported_by:
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;FUNCTION: Primary vitamin B12-binding and transport protein. Delivers&#34;
+- term:
+    id: GO:0043202
+    label: lysosomal lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9759202
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of lysosomal lumen, from &#34;LRP2-mediated TCN2:RCbl
+      uptake and delivery to lysosome&#34; (LRP2/megalin uptake route).
+    action: KEEP_AS_NON_CORE
+    reason: As with the CD320 route, the internalized complex is delivered to the lysosome
+      for degradation and cobalamin release; this is a terminal pathway destination rather
+      than an intrinsic localization. Retained as a valid pathway step but marked non-core.
+    supported_by:
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;FUNCTION: Primary vitamin B12-binding and transport protein. Delivers&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IDA
+  original_reference_id: PMID:8443384
+  qualifier: located_in
+  review:
+    summary: Experimental (IDA) annotation of extracellular region; recombinant transcobalamin-2
+      was constitutively secreted by insect cells, consistent with its native secretion.
+    action: ACCEPT
+    reason: Directly supported experimental localization. Recombinant transcobalamin-2
+      was secreted into the culture medium and did not accumulate intracellularly, mirroring
+      its secretion by cultured human endothelial cells.
+    supported_by:
+    - reference_id: PMID:8443384
+      supporting_text: Transcobalamin II (TCII) is a cobalamin (Cbl, vitamin B12)-binding
+        protein in mammalian plasma that facilitates the cellular uptake of the vitamin.
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted&#34;
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: IDA
+  original_reference_id: PMID:8443384
+  qualifier: involved_in
+  review:
+    summary: Experimental (IDA) annotation of cobalamin transport; recombinant transcobalamin-2
+      bound cobalamin and facilitated its uptake into cells via the plasma-membrane TCII-Cbl
+      receptor.
+    action: ACCEPT
+    reason: Directly demonstrated core biological process. Functional recombinant transcobalamin-2
+      bound Cbl and facilitated its uptake into K562 cells by binding the TCII-Cbl receptor
+      on the plasma membrane.
+    supported_by:
+    - reference_id: PMID:8443384
+      supporting_text: binds Cbl and facilitates the uptake of Cbl in eukaryotic cells
+        by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IDA
+  original_reference_id: PMID:27411955
+  qualifier: enables
+  review:
+    summary: Experimental (IDA) annotation of cobalamin binding; the holo-TC:CD320 co-crystal
+      structure resolved cobalamin bound to transcobalamin-2.
+    action: ACCEPT
+    reason: Directly demonstrated core molecular function. The 2.1 Angstrom co-crystal
+      structure of holo-transcobalamin-2 in complex with CD320 shows cobalamin bound to
+      transcobalamin-2, with the cobalt of Cbl identified in the electron density.
+    supported_by:
+    - reference_id: PMID:27411955
+      supporting_text: Cellular uptake of vitamin B12 (cobalamin) requires capture of transcobalamin
+        (TC) from the plasma by CD320, a ubiquitous cell surface receptor of the LDLR family.
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IDA
+  original_reference_id: PMID:8443384
+  qualifier: enables
+  review:
+    summary: Experimental (IDA) annotation of cobalamin binding; recombinant transcobalamin-2
+      bound cobalamin.
+    action: ACCEPT
+    reason: Directly demonstrated core molecular function. Functional recombinant transcobalamin-2
+      cross-reacted with antiserum to native TCII and bound Cbl.
+    supported_by:
+    - reference_id: PMID:8443384
+      supporting_text: binds Cbl and facilitates the uptake of Cbl in eukaryotic cells
+        by binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-3299657
+  qualifier: located_in
+  review:
+    summary: Reactome (TAS) annotation of extracellular region, from the disease reaction
+      &#34;Defective TCII does not bind Cbl in the circulation&#34;.
+    action: ACCEPT
+    reason: Correct extracellular location for the secreted plasma protein. Redundant with
+      experimental and IBA calls for the same term.
+    supported_by:
+    - reference_id: file:human/TCN2/TCN2-uniprot.txt
+      supporting_text: &#34;SUBCELLULAR LOCATION: Secreted&#34;
+- term:
+    id: GO:0031419
+    label: cobalamin binding
+  evidence_type: IDA
+  original_reference_id: PMID:16537422
+  qualifier: enables
+  review:
+    summary: Experimental (IDA) annotation of cobalamin binding; the crystal structure
+      of human holo-transcobalamin resolved one cobalamin buried at the interface of its
+      two domains.
+    action: ACCEPT
+    reason: Directly demonstrated core molecular function with atomic-resolution structural
+      evidence. The holo-TC structure shows a single Cbl in base-on conformation buried
+      at the domain interface, with a barrel histidine as the axial ligand.
+    supported_by:
+    - reference_id: PMID:16537422
+      supporting_text: One Cbl molecule in base-on conformation is buried inside the domain
+        interface.
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: PMID:1708393
+  qualifier: located_in
+  review:
+    summary: Traceable-author-statement (TAS) annotation of extracellular region; the cDNA
+      encodes a secreted 409-residue protein with an 18-residue leader peptide, secreted
+      by endothelial cells.
+    action: ACCEPT
+    reason: Correct extracellular location supported by the cloned cDNA encoding a signal
+      peptide and secreted mature protein, and by demonstrated secretion from human umbilical
+      vein endothelial cells. Redundant with experimental and IBA calls for the same term.
+    supported_by:
+    - reference_id: PMID:1708393
+      supporting_text: The cellular uptake of cobalamin (Cbl, vitamin B12) is mediated
+        by transcobalamin II (TCII), a plasma protein that binds Cbl and is secreted by
+- term:
+    id: GO:0015889
+    label: cobalamin transport
+  evidence_type: TAS
+  original_reference_id: PMID:3782074
+  qualifier: involved_in
+  review:
+    summary: Traceable-author-statement (TAS) annotation of cobalamin transport, from the
+      characterization of transcobalamin-2 as the plasma cobalamin transport protein.
+    action: ACCEPT
+    reason: Correctly captures the core biological process. Transcobalamin-2 was purified
+      as the plasma holo-cobalamin transport protein (1 mol cobalamin/mol protein). Redundant
+      with experimental and IBA cobalamin-transport annotations.
+    supported_by:
+    - reference_id: PMID:3782074
+      supporting_text: the final preparation of holo-TCII contained 1 mol of cobalamin/mol
+        of protein.
+core_functions:
+- description: Binds vitamin B12 (cobalamin) with 1:1 stoichiometry as the primary plasma
+    cobalamin-binding protein, sequestering a single cobalamin molecule at the interface
+    of its two structural domains.
+  molecular_function:
+    id: GO:0031419
+    label: cobalamin binding
+  supported_by:
+  - reference_id: PMID:16537422
+    supporting_text: One Cbl molecule in base-on conformation is buried inside the domain
+      interface.
+  - reference_id: PMID:3782074
+    supporting_text: the final preparation of holo-TCII contained 1 mol of cobalamin/mol
+      of protein.
+- description: Acts as the cargo-carrying ligand recognized by the cell-surface uptake
+    receptor CD320 (TCblR), enabling receptor-mediated endocytosis of the transcobalamin-cobalamin
+    complex and thereby delivery of vitamin B12 into cells.
+  molecular_function:
+    id: GO:0140355
+    label: cargo receptor ligand activity
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0005576
+    label: extracellular region
+  supported_by:
+  - reference_id: PMID:27411955
+    supporting_text: transcobalamin (TC)-bound Cbl is transported into cells by receptor-mediated
+      endocytosis, which requires Ca2+-dependent complex formation of TC with its cognate
+      cell surface receptor CD320
+  - reference_id: PMID:8443384
+    supporting_text: binds Cbl and facilitates the uptake of Cbl in eukaryotic cells by
+      binding to the receptor for TCII-Cbl on the plasma membrane of K562 cells.
+- description: As a secreted plasma protein, transports newly absorbed cobalamin from the
+    circulation to peripheral cells throughout the body, the physiologically essential
+    route supplying vitamin B12 to tissues.
+  molecular_function:
+    id: GO:0031419
+    label: cobalamin binding
+  directly_involved_in:
+  - id: GO:0015889
+    label: cobalamin transport
+  locations:
+  - id: GO:0005576
+    label: extracellular region
+  supported_by:
+  - reference_id: PMID:1708393
+    supporting_text: The cellular uptake of cobalamin (Cbl, vitamin B12) is mediated by
+      transcobalamin II (TCII), a plasma protein that binds Cbl and is secreted by
+  - reference_id: PMID:8443384
+    supporting_text: Transcobalamin II (TCII) is a cobalamin (Cbl, vitamin B12)-binding
+      protein in mammalian plasma that facilitates the cellular uptake of the vitamin.
+proposed_new_terms: []
+suggested_questions:
+- question: Beyond CD320, how much does the LRP2/megalin-mediated route (e.g. in the renal
+    tubule) contribute to transcobalamin-cobalamin reuptake and tissue cobalamin delivery
+    in vivo?
+- question: Does apo-transcobalamin-2 have a distinct physiological function or receptor
+    engagement compared with holo-transcobalamin-2?
+suggested_experiments:
+- description: Quantify the relative contribution of CD320 versus LRP2/megalin to tissue
+    cobalamin delivery using tissue-specific knockout models and labelled-cobalamin uptake
+    assays.
+- description: Structural and kinetic characterization of cobalamin loading onto apo-transcobalamin-2,
+    including whether an enterocyte export factor is required for efficient loading.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:16537422
+  title: Structural basis for mammalian vitamin B12 transport by transcobalamin.
+  findings:
+  - statement: The crystal structure of human holo-transcobalamin reveals a two-domain
+      architecture with one cobalamin buried in base-on conformation at the domain interface,
+      defining the structural basis of cobalamin binding.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; primary structural evidence (PDB 2BB5) for cobalamin
+      binding by transcobalamin-2. Abstract-only in cache but supporting quotes are verbatim
+      from the abstract.
+- id: PMID:1708393
+  title: The cDNA sequence and the deduced amino acid sequence of human transcobalamin
+    II show homology with rat intrinsic factor and human transcobalamin I.
+  findings:
+  - statement: The transcobalamin-2 cDNA encodes an 18-residue leader peptide and a secreted
+      409-residue protein; the protein is a plasma cobalamin-binding protein secreted by
+      endothelial cells and mediates cellular uptake of cobalamin.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; establishes secreted nature and cobalamin-transport
+      role. Abstract-only in cache.
+- id: PMID:27411955
+  title: Structural basis of transcobalamin recognition by human CD320 receptor.
+  findings:
+  - statement: The holo-TC:CD320 co-crystal structure shows transcobalamin-2, carrying
+      bound cobalamin, engaging the LDLR-A domains of the cell-surface receptor CD320,
+      the interaction that drives receptor-mediated cellular uptake of vitamin B12; binding
+      is Ca2+-dependent and reduced at endosomal (low) pH.
+    reference_section_type: RESULTS
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; full text available. Basis for both the protein-binding
+      IPI (interactor CD320/Q9NPF0) and the cargo receptor ligand activity.
+- id: PMID:3782074
+  title: Purification and molecular characterization of human transcobalamin II.
+  findings:
+  - statement: Transcobalamin-2 was purified from human plasma as a secreted holo-protein
+      containing one cobalamin per protein molecule, establishing its extracellular localization
+      and 1:1 cobalamin binding.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; source of the EXP extracellular-region and cargo receptor
+      ligand annotations. Abstract-only in cache.
+- id: PMID:8443384
+  title: Functional human transcobalamin II isoproteins are secreted by insect cells using
+    the baculovirus expression system.
+  findings:
+  - statement: Recombinant transcobalamin-2 is constitutively secreted, binds cobalamin,
+      and facilitates cobalamin uptake into cells by binding the plasma-membrane TCII-Cbl
+      receptor, directly demonstrating its cobalamin-binding and transport functions.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; UniProt FUNCTION source. Directly supports cobalamin
+      binding, cobalamin transport, and secreted localization. Abstract-only in cache.
+- id: file:human/TCN2/TCN2-uniprot.txt
+  title: UniProtKB P20062 (TCO2_HUMAN) Transcobalamin-2
+  findings:
+  - statement: UniProt describes transcobalamin-2 as the primary vitamin B12-binding and
+      transport protein that delivers cobalamin to cells, is secreted, and interacts with
+      CD320 via its LDL-receptor class A domains; loss of function causes transcobalamin
+      II deficiency (TCN2D).
+    reference_section_type: OTHER
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Curated UniProt record for P20062; supports secreted localization, function,
+      CD320 interaction, and disease.
+- id: Reactome:R-HSA-3000074
+  title: TCN2 binds RCbl in the circulation
+  findings: []
+- id: Reactome:R-HSA-3000112
+  title: CD320-mediated TCN2:RCbl uptake and delivery to lysosome
+  findings: []
+- id: Reactome:R-HSA-3000122
+  title: CD320 binds extracellular TCN2:RCbl
+  findings: []
+- id: Reactome:R-HSA-3000263
+  title: TCN2:RCbl is degraded to release RCbl
+  findings: []
+- id: Reactome:R-HSA-3299657
+  title: Defective TCII does not bind Cbl in the circulation
+  findings: []
+- id: Reactome:R-HSA-3325546
+  title: Defective CD320 does not transport extracellular TCII:Cbl to endosome
+  findings: []
+- id: Reactome:R-HSA-9758890
+  title: Transport of RCbl within the body
+  findings: []
+- id: Reactome:R-HSA-9759202
+  title: LRP2-mediated TCN2:RCbl uptake and delivery to lysosome
+  findings: []
+- id: Reactome:R-HSA-9759209
+  title: LRP2 binds extracellular TCN2:RCbl
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/modules/cobalamin_absorption_transport.html
+++ b/pages/modules/cobalamin_absorption_transport.html
@@ -1,0 +1,989 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cobalamin (vitamin B12) absorption and transport; TCN1/CBLIF/CUBN/AMN/TCN2/CD320 - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / Cobalamin (vitamin B12) absorption and transport; TCN1/CBLIF/CUBN/AMN/TCN2/CD320
+    </nav>
+
+    <header class="header">
+        <h1>Cobalamin (vitamin B12) absorption and transport; TCN1/CBLIF/CUBN/AMN/TCN2/CD320</h1>            <p class="description">Dietary cobalamin (vitamin B12) reaches the cytoplasm of peripheral cells through a relay of binding proteins and endocytic receptors. In saliva and the acidic stomach, cobalamin is first bound and protected by haptocorrin (TCN1); in the duodenum pancreatic proteases degrade haptocorrin and the cobalamin is transferred to gastric intrinsic factor (CBLIF/GIF), secreted by parietal cells. The intrinsic-factor-cobalamin complex is then recognised in the ileum by the cubam receptor, a complex of the large peripheral membrane protein cubilin (CUBN) and its transmembrane partner amnionless (AMN), which internalises it by receptor-mediated endocytosis; the cobalamin is released and exported to the blood. In plasma, newly absorbed cobalamin is bound by transcobalamin (TCN2), the physiologically essential delivery carrier, and the transcobalamin-cobalamin complex is taken up by peripheral cells through the cell-surface receptor CD320 (TCblR). Inherited defects along this route cause B12-deficiency disorders: CBLIF (hereditary intrinsic factor deficiency / juvenile pernicious anaemia), CUBN and AMN (Imerslund-Grasbeck syndrome, megaloblastic anaemia with proteinuria), TCN2 (transcobalamin deficiency, severe infantile megaloblastic anaemia with immunodeficiency) and CD320 (a usually mild/transient methylmalonic acidaemia detected on newborn screening).</p>        <div class="meta-row"><span class="pill">MODULE:cobalamin_absorption_transport</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/cobalamin_absorption_transport.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>cobalamin transport</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0015889" target="_blank" rel="noopener">GO:0015889</a></span>                <span class="descriptor">
+            <span>receptor-mediated endocytosis</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006898" target="_blank" rel="noopener">GO:0006898</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0015889" target="_blank" rel="noopener">GO:0015889</a><div><strong>cobalamin transport</strong></div><div>The module is grounded in cobalamin transport (GO:0015889); it covers the binding-protein and receptor relay that carries dietary B12 from the gut lumen into peripheral cells.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-3000137</span><div><strong>CUBN:AMN-mediated CBLIF:RCbl uptake and delivery to lysosome</strong></div><div>The ileal intrinsic-factor-cobalamin uptake step follows the human Reactome &#34;CUBN:AMN-mediated CBLIF:RCbl uptake&#34; reaction; the plasma-transport/CD320 steps follow R-HSA-3000074/3000112/3000122.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/TCN1/TCN1-ai-review.yaml</span><div><strong>TCN1 gene review (human)</strong></div><div>The haptocorrin cobalamin-binding step (UniProtKB:P20061, GO:0031419) matches the completed human TCN1 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/CBLIF/CBLIF-ai-review.yaml</span><div><strong>CBLIF gene review (human)</strong></div><div>The intrinsic-factor cobalamin-binding step (UniProtKB:P27352, GO:0031419) matches the completed human CBLIF review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/CUBN/CUBN-ai-review.yaml</span><div><strong>CUBN gene review (human)</strong></div><div>The cubilin cargo-receptor step (UniProtKB:O60494, GO:0038024) matches the completed human CUBN review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/AMN/AMN-ai-review.yaml</span><div><strong>AMN gene review (human)</strong></div><div>The amnionless cubam co-receptor step (UniProtKB:Q9BXJ7, GO:0038024) matches the completed human AMN review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/TCN2/TCN2-ai-review.yaml</span><div><strong>TCN2 gene review (human)</strong></div><div>The transcobalamin plasma-transport step (UniProtKB:P20062, GO:0031419) matches the completed human TCN2 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/CD320/CD320-ai-review.yaml</span><div><strong>CD320 gene review (human)</strong></div><div>The CD320 transcobalamin-receptor uptake step (UniProtKB:Q9NPF0, GO:0038024) matches the completed human CD320 review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">5</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">4</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:cobalamin_absorption_transport</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(6/6 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        5 complete review(s) &middot;
+                        0 with deep research &middot;
+                        0 missing review &middot;
+                        6 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>AMN
+                                        <span class="muted term-id">Q9BXJ7</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>CBLIF
+                                        <span class="muted term-id">P27352</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>CD320
+                                        <span class="muted term-id">Q9NPF0</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>CUBN
+                                        <span class="muted term-id">O60494</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">64/65</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>TCN1
+                                        <span class="muted term-id">P20061</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>TCN2
+                                        <span class="muted term-id">P20062</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cobalamin_absorption_transport">Cobalamin (B12) absorption and transport</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">cobalamin_absorption_transport</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. gastric/salivary cobalamin protection (haptocorrin)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-tcn1_step">cobalamin bound by haptocorrin (TCN1)</a><span class="pill type">Reaction</span><span class="tree-id">tcn1_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-tcn1_activity">TCN1: haptocorrin (transcobalamin I)</a>
+                                <span class="tree-id">Family: Transcobalamin/haptocorrin family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. intrinsic-factor binding for ileal absorption</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cblif_step">cobalamin bound by intrinsic factor (CBLIF)</a><span class="pill type">Reaction</span><span class="tree-id">cblif_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-cblif_activity">CBLIF: gastric intrinsic factor</a>
+                                <span class="tree-id">Family: Transcobalamin/intrinsic-factor family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. ileal receptor-mediated uptake (cubam)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cubam_step">IF-cobalamin internalised by the cubam receptor (CUBN/AMN)</a><span class="pill type">Protein Complex</span><span class="tree-id">cubam_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-cubn_activity">CUBN: cubilin (cubam ligand-binding subunit)</a>
+                                <span class="tree-id">Family: Cubilin family</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-amn_activity">AMN: amnionless (cubam membrane-anchor/endocytic subunit)</a>
+                                <span class="tree-id">Family: Amnionless family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. plasma cobalamin transport (transcobalamin)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-tcn2_step">absorbed cobalamin bound by transcobalamin (TCN2)</a><span class="pill type">Reaction</span><span class="tree-id">tcn2_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-tcn2_activity">TCN2: transcobalamin</a>
+                                <span class="tree-id">Family: Transcobalamin family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">5. cellular uptake (CD320 receptor)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cd320_step">TC-cobalamin internalised by CD320 (TCblR)</a><span class="pill type">Reaction</span><span class="tree-id">cd320_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-cd320_activity">CD320: transcobalamin receptor (TCblR)</a>
+                                <span class="tree-id">Family: CD320 / LDLR-family transcobalamin receptor</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>extracellular region</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005576" target="_blank" rel="noopener">GO:0005576</a></span>                <span class="descriptor">
+            <span>apical plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016324" target="_blank" rel="noopener">GO:0016324</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-cobalamin_absorption_transport">
+        <div class="node-heading">
+            <span class="node-title">Cobalamin (B12) absorption and transport</span><span class="pill type">Metabolic Pathway</span><span class="pill">cobalamin_absorption_transport</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>cobalamin transport</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0015889" target="_blank" rel="noopener">GO:0015889</a></span>                <span class="descriptor">
+            <span>receptor-mediated endocytosis</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006898" target="_blank" rel="noopener">GO:0006898</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>extracellular region</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005576" target="_blank" rel="noopener">GO:0005576</a></span>                <span class="descriptor">
+            <span>apical plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016324" target="_blank" rel="noopener">GO:0016324</a></span>        </div>
+
+            </div>
+        <p class="muted small">Cobalamin (vitamin B12) absorption and transport, grounded to the human proteins TCN1 (UniProtKB:P20061, GO:0031419), CBLIF (P27352, GO:0031419), the cubam receptor (CUBN O60494 + AMN Q9BXJ7, GO:0038024), TCN2 (P20062, GO:0031419) and CD320 (Q9NPF0, GO:0038024). GO molecular-function/location terms were taken from the completed human gene reviews and verified against the local go.db; Reactome reaction ids/titles were verified against the local reactome cache. Each step uses a PANTHER family selector with the human protein as representative; the soluble transcobalamin-family carriers TCN1, CBLIF and TCN2 share PTHR10559, and the ileal cubam receptor is modelled as a PROTEIN_COMPLEX node (cubilin ligand-binding subunit + amnionless membrane anchor). This is a small-molecule trafficking pathway (binding proteins + endocytic receptors, not enzymes). Downstream, internalised cobalamin is released in the lysosome and processed in the cytosol by MMACHC (cblC) and MMADHC (cblD), then routed to adenosylcobalamin (MMAB/MMAA -&gt; MMUT, methylmalonyl-CoA mutase) and methylcobalamin (MTR/MTRR, methionine synthase) — separate modules (MMAA/MMAB/MMUT already in the propionyl-CoA module; MTR/MTRR reviewed). Disorders span the route: CBLIF (juvenile pernicious anaemia), CUBN/AMN (Imerslund-Grasbeck syndrome), TCN2 (transcobalamin deficiency) and CD320 (newborn-screen methylmalonic acidaemia).</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-tcn1_step">tcn1_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-cblif_step">cblif_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">After pancreatic proteases degrade haptocorrin in the duodenum, cobalamin is transferred to intrinsic factor (CBLIF).</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-cblif_step">cblif_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-cubam_step">cubam_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">The IF-cobalamin complex is the ligand internalised by the ileal cubam receptor.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-cubam_step">cubam_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-tcn2_step">tcn2_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Cobalamin absorbed via cubam is exported to the blood and bound by transcobalamin (TCN2).</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-tcn2_step">tcn2_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-cd320_step">cd320_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">The TC-cobalamin complex is taken up by peripheral cells through the CD320 receptor.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: gastric/salivary cobalamin protection (haptocorrin)</div>
+                <section class="node-detail depth-1" id="node-tcn1_step">
+        <div class="node-heading">
+            <span class="node-title">cobalamin bound by haptocorrin (TCN1)</span><span class="pill type">Reaction</span><span class="pill">tcn1_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-tcn1_activity">
+        <div class="annoton-title">TCN1: haptocorrin (transcobalamin I)</div>
+        <div class="small muted">tcn1_activity</div>            <div class="small"><strong>Participant:</strong> Family: Transcobalamin/haptocorrin family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Transcobalamin/haptocorrin family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10559" target="_blank" rel="noopener">PANTHER:PTHR10559</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>TCN1 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P20061/entry" target="_blank" rel="noopener">UniProtKB:P20061</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>cobalamin binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0031419" target="_blank" rel="noopener">GO:0031419</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>cobalamin (vitamin B12)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>haptocorrin-cobalamin complex</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>extracellular region</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005576" target="_blank" rel="noopener">GO:0005576</a></span>        </div>            <p class="role-description">Binds and protects dietary cobalamin in saliva/stomach; degraded by pancreatic proteases in the duodenum, handing cobalamin to intrinsic factor.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: intrinsic-factor binding for ileal absorption</div>
+                <section class="node-detail depth-1" id="node-cblif_step">
+        <div class="node-heading">
+            <span class="node-title">cobalamin bound by intrinsic factor (CBLIF)</span><span class="pill type">Reaction</span><span class="pill">cblif_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-cblif_activity">
+        <div class="annoton-title">CBLIF: gastric intrinsic factor</div>
+        <div class="small muted">cblif_activity</div>            <div class="small"><strong>Participant:</strong> Family: Transcobalamin/intrinsic-factor family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Transcobalamin/intrinsic-factor family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10559" target="_blank" rel="noopener">PANTHER:PTHR10559</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>CBLIF (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P27352/entry" target="_blank" rel="noopener">UniProtKB:P27352</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>cobalamin binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0031419" target="_blank" rel="noopener">GO:0031419</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>cobalamin (vitamin B12)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>intrinsic factor-cobalamin (IF-Cbl) complex</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>extracellular region</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005576" target="_blank" rel="noopener">GO:0005576</a></span>        </div>            <p class="role-description">Binds cobalamin handed over from haptocorrin; the IF-Cbl complex is recognised by the cubam receptor in the ileum.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: ileal receptor-mediated uptake (cubam)</div>
+                <section class="node-detail depth-1" id="node-cubam_step">
+        <div class="node-heading">
+            <span class="node-title">IF-cobalamin internalised by the cubam receptor (CUBN/AMN)</span><span class="pill type">Protein Complex</span><span class="pill">cubam_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-cubn_activity">
+        <div class="annoton-title">CUBN: cubilin (cubam ligand-binding subunit)</div>
+        <div class="small muted">cubn_activity</div>            <div class="small"><strong>Participant:</strong> Family: Cubilin family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Cubilin family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR24251" target="_blank" rel="noopener">PANTHER:PTHR24251</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>CUBN (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/O60494/entry" target="_blank" rel="noopener">UniProtKB:O60494</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>cargo receptor activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0038024" target="_blank" rel="noopener">GO:0038024</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>intrinsic factor-cobalamin (IF-Cbl) complex</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>internalised IF-Cbl (endocytosed)</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>apical plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016324" target="_blank" rel="noopener">GO:0016324</a></span>        </div>            <p class="role-description">Ligand-binding subunit of cubam; binds IF-Cbl (and many renal ligands). Deficiency = Imerslund-Grasbeck syndrome (megaloblastic anaemia 1, with proteinuria).</p></article>                    <article class="annoton-card" id="annoton-amn_activity">
+        <div class="annoton-title">AMN: amnionless (cubam membrane-anchor/endocytic subunit)</div>
+        <div class="small muted">amn_activity</div>            <div class="small"><strong>Participant:</strong> Family: Amnionless family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Amnionless family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR14995" target="_blank" rel="noopener">PANTHER:PTHR14995</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>AMN (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9BXJ7/entry" target="_blank" rel="noopener">UniProtKB:Q9BXJ7</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>cargo receptor activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0038024" target="_blank" rel="noopener">GO:0038024</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>cubilin (CUBN)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>membrane-anchored, endocytosis-competent cubam receptor</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>apical plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016324" target="_blank" rel="noopener">GO:0016324</a></span>        </div>            <p class="role-description">Anchors cubilin to the apical membrane and provides the endocytosis signals for internalisation of the cubilin-IF-Cbl complex.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 4: plasma cobalamin transport (transcobalamin)</div>
+                <section class="node-detail depth-1" id="node-tcn2_step">
+        <div class="node-heading">
+            <span class="node-title">absorbed cobalamin bound by transcobalamin (TCN2)</span><span class="pill type">Reaction</span><span class="pill">tcn2_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-tcn2_activity">
+        <div class="annoton-title">TCN2: transcobalamin</div>
+        <div class="small muted">tcn2_activity</div>            <div class="small"><strong>Participant:</strong> Family: Transcobalamin family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Transcobalamin family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR10559" target="_blank" rel="noopener">PANTHER:PTHR10559</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>TCN2 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P20062/entry" target="_blank" rel="noopener">UniProtKB:P20062</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>cobalamin binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0031419" target="_blank" rel="noopener">GO:0031419</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>cobalamin (absorbed, in plasma)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>transcobalamin-cobalamin (TC-Cbl) complex</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>extracellular region</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005576" target="_blank" rel="noopener">GO:0005576</a></span>        </div>            <p class="role-description">Binds newly absorbed cobalamin in plasma; the TC-Cbl complex delivers B12 to peripheral cells.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 5: cellular uptake (CD320 receptor)</div>
+                <section class="node-detail depth-1" id="node-cd320_step">
+        <div class="node-heading">
+            <span class="node-title">TC-cobalamin internalised by CD320 (TCblR)</span><span class="pill type">Reaction</span><span class="pill">cd320_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-cd320_activity">
+        <div class="annoton-title">CD320: transcobalamin receptor (TCblR)</div>
+        <div class="small muted">cd320_activity</div>            <div class="small"><strong>Participant:</strong> Family: CD320 / LDLR-family transcobalamin receptor</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>CD320 / LDLR-family transcobalamin receptor</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR24270" target="_blank" rel="noopener">PANTHER:PTHR24270</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>CD320 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9NPF0/entry" target="_blank" rel="noopener">UniProtKB:Q9NPF0</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>cargo receptor activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0038024" target="_blank" rel="noopener">GO:0038024</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>transcobalamin-cobalamin (TC-Cbl) complex</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>internalised TC-Cbl (endocytosed for cellular B12 supply)</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>plasma membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005886" target="_blank" rel="noopener">GO:0005886</a></span>        </div>            <p class="role-description">Cell-surface receptor internalising the TC-Cbl complex, supplying cobalamin to peripheral cells. Variant = mild/transient newborn-screen methylmalonic acidaemia.</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/cobalamin_intracellular_processing.html
+++ b/pages/modules/cobalamin_intracellular_processing.html
@@ -1,0 +1,883 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cobalamin (B12) intracellular processing and trafficking; ABCD4/LMBRD1/MMACHC/MMADHC - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / Cobalamin (B12) intracellular processing and trafficking; ABCD4/LMBRD1/MMACHC/MMADHC
+    </nav>
+
+    <header class="header">
+        <h1>Cobalamin (B12) intracellular processing and trafficking; ABCD4/LMBRD1/MMACHC/MMADHC</h1>            <p class="description">Once the transcobalamin-cobalamin complex has been endocytosed via CD320 and degraded in the lysosome, the freed cobalamin (vitamin B12) must be exported to the cytosol, stripped of its upper axial ligand, and routed to one of its two coenzyme forms. The lysosomal export step is carried out by a two-protein system: the ABC transporter ABCD4 (cblJ), which provides the ATP-dependent transmembrane cobalamin-transport activity, together with the lysosomal membrane protein LMBRD1 (cblF), which is required to target ABCD4 to the lysosome and acts as its escort subunit. In the cytosol the cblC protein MMACHC processes the cobalamin — reductive decyanation of cyanocobalamin and dealkylation of alkylcobalamins remove the beta-axial ligand to give cob(II)alamin. The cblD protein MMADHC then binds MMACHC-cob(II)alamin and acts as the branch-point/trafficking adaptor that directs cobalamin either to the mitochondrion for adenosylcobalamin synthesis (feeding methylmalonyl-CoA mutase, MMUT) or to the cytosolic methylcobalamin route (feeding methionine synthase, MTR). Defects in each step cause combined or isolated methylmalonic aciduria and homocystinuria: cblJ (ABCD4), cblF (LMBRD1), cblC (MMACHC) and cblD (MMADHC).</p>        <div class="meta-row"><span class="pill">MODULE:cobalamin_intracellular_processing</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/cobalamin_intracellular_processing.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>cobalamin metabolic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009235" target="_blank" rel="noopener">GO:0009235</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0009235" target="_blank" rel="noopener">GO:0009235</a><div><strong>cobalamin metabolic process</strong></div><div>The module is grounded in cobalamin metabolic process (GO:0009235); it covers lysosomal cobalamin export and the cytosolic decyanation/dealkylation and branch-point trafficking that prepare B12 for its two coenzyme forms.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-9759218</span><div><strong>Cobalamin (Cbl) metabolism</strong></div><div>Step order and intermediates follow the human Reactome &#34;Cobalamin (Cbl) metabolism&#34; pathway (reactions R-HSA-5223313 lysosomal export, R-HSA-3149494/3149563 MMACHC/MMADHC processing).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/ABCD4/ABCD4-ai-review.yaml</span><div><strong>ABCD4 gene review (human)</strong></div><div>The lysosomal ABC cobalamin-transporter step (UniProtKB:O14678, GO:0015420) matches the completed human ABCD4 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/LMBRD1/LMBRD1-ai-review.yaml</span><div><strong>LMBRD1 gene review (human)</strong></div><div>The lysosomal cobalamin-export escort step (UniProtKB:Q9NUN5, GO:0015889 / lysosomal membrane) matches the completed human LMBRD1 review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/MMACHC/MMACHC-ai-review.yaml</span><div><strong>MMACHC gene review (human)</strong></div><div>The cytosolic decyanation/dealkylation step (UniProtKB:Q9Y4U1, GO:0033787) matches the previously completed human MMACHC review (already on main).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/MMADHC/MMADHC-ai-review.yaml</span><div><strong>MMADHC gene review (human)</strong></div><div>The cblD branch-point trafficking step (UniProtKB:Q9H3L0, GO:0140104) matches the completed human MMADHC review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">4</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">4</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:cobalamin_intracellular_processing</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(4/4 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        4 complete review(s) &middot;
+                        0 with deep research &middot;
+                        0 missing review &middot;
+                        4 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>ABCD4
+                                        <span class="muted term-id">O14678</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>LMBRD1
+                                        <span class="muted term-id">Q9NUN5</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>MMACHC
+                                        <span class="muted term-id">Q9Y4U1</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>MMADHC
+                                        <span class="muted term-id">Q9H3L0</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cobalamin_intracellular_processing">Cobalamin (B12) intracellular processing and trafficking</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">cobalamin_intracellular_processing</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. lysosomal cobalamin export (ABC transporter + escort)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-lysosomal_export_step">cobalamin export from lysosomal lumen to cytosol (ABCD4:LMBRD1)</a><span class="pill type">Protein Complex</span><span class="tree-id">lysosomal_export_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-abcd4_activity">ABCD4: lysosomal ABC cobalamin transporter (cblJ)</a>
+                                <span class="tree-id">Family: ABC transporter subfamily D (ABCD4)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-lmbrd1_activity">LMBRD1: lysosomal cobalamin-export escort (cblF)</a>
+                                <span class="tree-id">Family: LMBR1-domain family (LMBRD1)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. cytosolic decyanation/dealkylation (removes the beta-axial ligand)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-mmachc_step">cobalamin decyanation/dealkylation to cob(II)alamin (MMACHC)</a><span class="pill type">Reaction</span><span class="tree-id">mmachc_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-mmachc_activity">MMACHC: cyanocobalamin reductase / cobalamin dealkylase (cblC)</a>
+                                <span class="tree-id">Family: MMACHC / CblC family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. branch-point trafficking (AdoCbl vs MeCbl)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-mmadhc_step">cob(II)alamin routed to the AdoCbl or MeCbl branch (MMADHC)</a><span class="pill type">Reaction</span><span class="tree-id">mmadhc_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-mmadhc_activity">MMADHC: cobalamin branch-point trafficking protein (cblD)</a>
+                                <span class="tree-id">Family: MMADHC / CblD family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>lysosomal membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005765" target="_blank" rel="noopener">GO:0005765</a></span>                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-cobalamin_intracellular_processing">
+        <div class="node-heading">
+            <span class="node-title">Cobalamin (B12) intracellular processing and trafficking</span><span class="pill type">Metabolic Pathway</span><span class="pill">cobalamin_intracellular_processing</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>cobalamin metabolic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009235" target="_blank" rel="noopener">GO:0009235</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>lysosomal membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005765" target="_blank" rel="noopener">GO:0005765</a></span>                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>
+
+            </div>
+        <p class="muted small">Cobalamin intracellular processing/trafficking, grounded to the human proteins ABCD4 (UniProtKB:O14678, GO:0015420) and LMBRD1 (Q9NUN5, lysosomal export escort; its standalone transporter MF is an over-annotation, so it is modelled by its BP/escort role via `processes`), MMACHC (Q9Y4U1, GO:0033787; reviewed previously, already on main) and MMADHC (Q9H3L0, GO:0140104). GO molecular-function/BP/location terms were taken from the completed human gene reviews and verified against the local go.db; Reactome reaction ids/titles were verified against the local reactome cache. Each step uses a PANTHER family selector with the human protein as representative; the lysosomal export step is a PROTEIN_COMPLEX node (ABCD4 catalytic transporter + LMBRD1 escort). Upstream, cobalamin is delivered and endocytosed by the absorption/transport module (TCN1/CBLIF/CUBN/AMN/TCN2/CD320). Downstream, MMADHC routes cob(II)alamin to (i) the mitochondrial adenosylcobalamin branch — MMAB (cblB) adenosyltransferase with the MMAA (cblA) chaperone, supplying methylmalonyl-CoA mutase MMUT (all reviewed in the propionyl-CoA module) — or (ii) the cytosolic methylcobalamin branch — methionine synthase MTR (cblG) with its reductase MTRR (cblE) (both reviewed). Disorders: cblJ (ABCD4), cblF (LMBRD1), cblC (MMACHC) and cblD (MMADHC) cause combined or isolated methylmalonic aciduria and homocystinuria.</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-lysosomal_export_step">lysosomal_export_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-mmachc_step">mmachc_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Cobalamin exported to the cytosol by ABCD4:LMBRD1 is processed by MMACHC.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-mmachc_step">mmachc_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-mmadhc_step">mmadhc_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">MMACHC-bound cob(II)alamin is handed to MMADHC for routing to the two coenzyme branches.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: lysosomal cobalamin export (ABC transporter + escort)</div>
+                <section class="node-detail depth-1" id="node-lysosomal_export_step">
+        <div class="node-heading">
+            <span class="node-title">cobalamin export from lysosomal lumen to cytosol (ABCD4:LMBRD1)</span><span class="pill type">Protein Complex</span><span class="pill">lysosomal_export_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-abcd4_activity">
+        <div class="annoton-title">ABCD4: lysosomal ABC cobalamin transporter (cblJ)</div>
+        <div class="small muted">abcd4_activity</div>            <div class="small"><strong>Participant:</strong> Family: ABC transporter subfamily D (ABCD4)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>ABC transporter subfamily D (ABCD4)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR11384" target="_blank" rel="noopener">PANTHER:PTHR11384</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>ABCD4 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/O14678/entry" target="_blank" rel="noopener">UniProtKB:O14678</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>ABC-type vitamin B12 transporter activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0015420" target="_blank" rel="noopener">GO:0015420</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>cobalamin (lysosomal lumen)</span></span>                            <span class="descriptor">
+            <span>ATP</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>cobalamin (cytosol)</span></span>                            <span class="descriptor">
+            <span>ADP + phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>lysosomal membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005765" target="_blank" rel="noopener">GO:0005765</a></span>        </div>            <p class="role-description">ATP-driven transmembrane cobalamin transporter releasing B12 from the lysosome to the cytosol. Deficiency = cblJ-type MMA + homocystinuria.</p></article>                    <article class="annoton-card" id="annoton-lmbrd1_activity">
+        <div class="annoton-title">LMBRD1: lysosomal cobalamin-export escort (cblF)</div>
+        <div class="small muted">lmbrd1_activity</div>            <div class="small"><strong>Participant:</strong> Family: LMBR1-domain family (LMBRD1)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>LMBR1-domain family (LMBRD1)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR16130" target="_blank" rel="noopener">PANTHER:PTHR16130</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>LMBRD1 (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9NUN5/entry" target="_blank" rel="noopener">UniProtKB:Q9NUN5</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cobalamin transport</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0015889" target="_blank" rel="noopener">GO:0015889</a></span>                <span class="descriptor">
+            <span>protein localization to lysosome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0061462" target="_blank" rel="noopener">GO:0061462</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>lysosomal membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005765" target="_blank" rel="noopener">GO:0005765</a></span>        </div>            <p class="role-description">Non-catalytic escort/targeting subunit that recruits ABCD4 to the lysosomal membrane; the LMBRD1:ABCD4 complex effects cobalamin export. (Its own transporter MF annotations are over-annotations — captured here as a BP/escort role.)</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-5223313</span><div>ABCD4:LMBRD1 transports RCbl from lysosomal lumen to cytosol (human Reactome reaction)</div></div>                <div class="evidence-card small"><span class="source-id">file:human/LMBRD1/LMBRD1-ai-review.yaml</span><div>lysosomal membrane escort that targets ABCD4 to the lysosome; has no intrinsic transport/ATPase activity itself (that is ABCD4); deficiency = cblF MMA + homocystinuria</div></div>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: cytosolic decyanation/dealkylation (removes the beta-axial ligand)</div>
+                <section class="node-detail depth-1" id="node-mmachc_step">
+        <div class="node-heading">
+            <span class="node-title">cobalamin decyanation/dealkylation to cob(II)alamin (MMACHC)</span><span class="pill type">Reaction</span><span class="pill">mmachc_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-mmachc_activity">
+        <div class="annoton-title">MMACHC: cyanocobalamin reductase / cobalamin dealkylase (cblC)</div>
+        <div class="small muted">mmachc_activity</div>            <div class="small"><strong>Participant:</strong> Family: MMACHC / CblC family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>MMACHC / CblC family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR31457" target="_blank" rel="noopener">PANTHER:PTHR31457</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>MMACHC (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9Y4U1/entry" target="_blank" rel="noopener">UniProtKB:Q9Y4U1</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>cyanocobalamin reductase (cyanide-eliminating) (NADP+) activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0033787" target="_blank" rel="noopener">GO:0033787</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>cyanocobalamin / alkylcobalamin</span></span>                            <span class="descriptor">
+            <span>NADPH</span></span>                            <span class="descriptor">
+            <span>glutathione (for dealkylation)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>cob(II)alamin</span></span>                            <span class="descriptor">
+            <span>cyanide / alkyl-glutathione</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Processes incoming cobalamin by removing its upper axial ligand, yielding cob(II)alamin for downstream coenzyme synthesis. (Reviewed previously; already on main.)</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: branch-point trafficking (AdoCbl vs MeCbl)</div>
+                <section class="node-detail depth-1" id="node-mmadhc_step">
+        <div class="node-heading">
+            <span class="node-title">cob(II)alamin routed to the AdoCbl or MeCbl branch (MMADHC)</span><span class="pill type">Reaction</span><span class="pill">mmadhc_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-mmadhc_activity">
+        <div class="annoton-title">MMADHC: cobalamin branch-point trafficking protein (cblD)</div>
+        <div class="small muted">mmadhc_activity</div>            <div class="small"><strong>Participant:</strong> Family: MMADHC / CblD family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>MMADHC / CblD family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR13192" target="_blank" rel="noopener">PANTHER:PTHR13192</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>MMADHC (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9H3L0/entry" target="_blank" rel="noopener">UniProtKB:Q9H3L0</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>molecular carrier activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0140104" target="_blank" rel="noopener">GO:0140104</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>MMACHC-cob(II)alamin</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>cob(II)alamin routed to the mitochondrial (AdoCbl) or cytosolic (MeCbl) branch</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytosol</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005829" target="_blank" rel="noopener">GO:0005829</a></span>        </div>            <p class="role-description">Branch-point/trafficking adaptor downstream of MMACHC; its mutation position determines isolated MMA, isolated homocystinuria, or combined disease.</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/gpi_anchor_core_glycan_assembly.html
+++ b/pages/modules/gpi_anchor_core_glycan_assembly.html
@@ -1,0 +1,991 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GPI anchor biosynthesis II — de-N-acetylation, inositol acylation and mannosylation; PIGL/PIGW/PIGM/PIGX/PIGV/PIGB - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / GPI anchor biosynthesis II — de-N-acetylation, inositol acylation and mannosylation; PIGL/PIGW/PIGM/PIGX/PIGV/PIGB
+    </nav>
+
+    <header class="header">
+        <h1>GPI anchor biosynthesis II — de-N-acetylation, inositol acylation and mannosylation; PIGL/PIGW/PIGM/PIGX/PIGV/PIGB</h1>            <p class="description">After the GPI-GlcNAc transferase complex makes GlcNAc-PI, the glycosylphosphatidylinositol (GPI) precursor is elaborated by de-N-acetylation, inositol acylation and the sequential addition of three mannoses, on the endoplasmic-reticulum membrane. PIGL de-N-acetylates GlcNAc-PI to glucosaminyl-phosphatidylinositol (GlcN-PI); the intermediate is then flipped to the ER lumen and PIGW acylates the inositol ring (from acyl-CoA) to GlcN-(acyl)PI, a form required for later transamidase recognition. Three dolichyl-phosphate-mannose (Dol-P-Man)- dependent mannosyltransferases then build the trimannosyl core: GPI mannosyltransferase I (the catalytic PIGM with its stabilising subunit PIGX) adds the first mannose (alpha-1,4); PIGV (GPI-MT-II) adds the second (alpha-1,6); and PIGB (GPI-MT-III) adds the third (alpha-1,2), the mannose that later receives the bridging ethanolamine-phosphate for protein attachment. Defects across this segment cause GPI-deficiency disease: PIGL (CHIME syndrome), PIGW and PIGM/PIGV (hyperphosphatasia with mental retardation / Mabry syndrome and related inherited GPI-deficiency encephalopathies), and PIGB (a developmental and epileptic encephalopathy, GPIBD).</p>        <div class="meta-row"><span class="pill">MODULE:gpi_anchor_core_glycan_assembly</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/gpi_anchor_core_glycan_assembly.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a><div><strong>GPI anchor biosynthetic process</strong></div><div>The module is grounded in GPI anchor biosynthetic process (GO:0006506); it covers the de-N-acetylation, inositol-acylation and trimannosylation of the GPI precursor.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-162710</span><div><strong>Synthesis of glycosylphosphatidylinositol (GPI)</strong></div><div>Step order and intermediates follow the human Reactome &#34;Synthesis of glycosylphosphatidylinositol (GPI)&#34; sub-pathway (reactions R-HSA-162857/162683/162830/162873/162821).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGL/PIGL-ai-review.yaml</span><div><strong>PIGL gene review (human)</strong></div><div>The GlcNAc-PI de-N-acetylation step (UniProtKB:Q9Y2B2, GO:0000225) matches the completed human PIGL review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGW/PIGW-ai-review.yaml</span><div><strong>PIGW gene review (human)</strong></div><div>The inositol-acylation step (UniProtKB:Q7Z7B1, GO:0032216) matches the completed human PIGW review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGM/PIGM-ai-review.yaml</span><div><strong>PIGM gene review (human)</strong></div><div>The first-mannose (alpha-1,4) step (UniProtKB:Q9H3S5, GO:0180041) matches the completed human PIGM review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGX/PIGX-ai-review.yaml</span><div><strong>PIGX gene review (human)</strong></div><div>The GPI-MT-I stabilising-subunit role (UniProtKB:Q8TBF5, GPI-MT-I complex GO:1990529) matches the completed human PIGX review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGV/PIGV-ai-review.yaml</span><div><strong>PIGV gene review (human)</strong></div><div>The second-mannose (alpha-1,6) step (UniProtKB:Q9NUD9, GO:0120563) matches the completed human PIGV review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGB/PIGB-ai-review.yaml</span><div><strong>PIGB gene review (human)</strong></div><div>The third-mannose (alpha-1,2) step (UniProtKB:Q92521, GO:0120564) matches the completed human PIGB review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">5</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">4</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:gpi_anchor_core_glycan_assembly</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(6/6 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        6 complete review(s) &middot;
+                        0 with deep research &middot;
+                        0 missing review &middot;
+                        6 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>PIGB
+                                        <span class="muted term-id">Q92521</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGL
+                                        <span class="muted term-id">Q9Y2B2</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGM
+                                        <span class="muted term-id">Q9H3S5</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGV
+                                        <span class="muted term-id">Q9NUD9</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGW
+                                        <span class="muted term-id">Q7Z7B1</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGX
+                                        <span class="muted term-id">Q8TBF5</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-gpi_anchor_core_glycan_assembly">GPI anchor core glycan assembly (de-N-acetylation, inositol acylation, mannosylation)</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">gpi_anchor_core_glycan_assembly</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. de-N-acetylation (GlcNAc-PI to GlcN-PI)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pigl_step">GlcNAc-PI to glucosaminyl-PI (GlcN-PI)</a><span class="pill type">Reaction</span><span class="tree-id">pigl_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigl_activity">PIGL: GlcNAc-PI de-N-acetylase</a>
+                                <span class="tree-id">Family: PIGL de-N-acetylase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. inositol acylation</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pigw_step">GlcN-PI to GlcN-(acyl)PI</a><span class="pill type">Reaction</span><span class="tree-id">pigw_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigw_activity">PIGW: GPI inositol acyltransferase</a>
+                                <span class="tree-id">Family: PIGW inositol-acyltransferase family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. first mannose (alpha-1,4) — GPI-MT-I complex</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-gpi_mt1_step">GlcN-(acyl)PI to Man1-GlcN-(acyl)PI</a><span class="pill type">Protein Complex</span><span class="tree-id">gpi_mt1_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigm_activity">PIGM: GPI mannosyltransferase I (catalytic)</a>
+                                <span class="tree-id">Family: GPI mannosyltransferase I family (PIGM)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigx_activity">PIGX: GPI-MT-I stabilising subunit</a>
+                                <span class="tree-id">Family: PIGX family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. second mannose (alpha-1,6)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pigv_step">Man1-GlcN-(acyl)PI to Man2-GlcN-(acyl)PI</a><span class="pill type">Reaction</span><span class="tree-id">pigv_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigv_activity">PIGV: GPI mannosyltransferase II</a>
+                                <span class="tree-id">Family: GPI mannosyltransferase II family (PIGV)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">5. third mannose (alpha-1,2)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pigb_step">Man2-GlcN-(acyl)PI to Man3-GlcN-(acyl)PI</a><span class="pill type">Reaction</span><span class="tree-id">pigb_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigb_activity">PIGB: GPI mannosyltransferase III</a>
+                                <span class="tree-id">Family: GPI mannosyltransferase III family (PIGB)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-gpi_anchor_core_glycan_assembly">
+        <div class="node-heading">
+            <span class="node-title">GPI anchor core glycan assembly (de-N-acetylation, inositol acylation, mannosylation)</span><span class="pill type">Metabolic Pathway</span><span class="pill">gpi_anchor_core_glycan_assembly</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>
+
+            </div>
+        <p class="muted small">GPI core-glycan-assembly segment, grounded to the human enzymes PIGL (UniProtKB:Q9Y2B2, GO:0000225, EC 3.5.1.89), PIGW (Q7Z7B1, GO:0032216), the GPI-MT-I complex (catalytic PIGM Q9H3S5 GO:0180041 + stabilising PIGX Q8TBF5; complex GO:1990529), PIGV (Q9NUD9, GO:0120563) and PIGB (Q92521, GO:0120564). GO molecular-function/BP/location terms were taken from the completed human gene reviews and verified against the local go.db; Reactome reaction ids/titles were verified against the local reactome cache. Each step uses a PANTHER family selector with the human enzyme as representative; GPI-MT-I is a PROTEIN_COMPLEX node (PIGM catalytic + PIGX stabiliser, the latter modelled by its BP role as it has no catalytic MF). The three mannosyltransferases are Dol-P-Man-dependent (donor supplied by the DPM1/2/3 module). Note the pathway interleaves with the ethanolamine-phosphate additions: PIGN adds EtNP to the first mannose between the PIGM and PIGV steps (covered in the GPI EtNP module), and PIGO/PIGG add EtNP to the third/second mannoses after PIGB. Upstream is the GPI-GnT module (GlcNAc-PI); downstream the EtNP-modified Man3 GPI is transferred to protein by the GPI transamidase (PIGK/PIGS/PIGT/ PIGU/GPAA1) and remodelled (PGAP1/2/3) — separate modules. Disorders: CHIME syndrome (PIGL), GPIBD/hyperphosphatasia (PIGW), GPI-deficiency with thrombosis/seizures (PIGM), Mabry syndrome (PIGV), GPIBD encephalopathy (PIGB).</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pigl_step">pigl_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pigw_step">pigw_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">GlcN-PI from PIGL is inositol-acylated by PIGW.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pigw_step">pigw_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-gpi_mt1_step">gpi_mt1_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">GlcN-(acyl)PI from PIGW receives the first mannose from GPI-MT-I (PIGM/PIGX).</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-gpi_mt1_step">gpi_mt1_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pigv_step">pigv_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Man1-GlcN-(acyl)PI (after EtNP addition to Man1 by PIGN) receives the second mannose from PIGV.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pigv_step">pigv_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pigb_step">pigb_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Man2-GlcN-(acyl)PI receives the third mannose from PIGB.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: de-N-acetylation (GlcNAc-PI to GlcN-PI)</div>
+                <section class="node-detail depth-1" id="node-pigl_step">
+        <div class="node-heading">
+            <span class="node-title">GlcNAc-PI to glucosaminyl-PI (GlcN-PI)</span><span class="pill type">Reaction</span><span class="pill">pigl_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pigl_activity">
+        <div class="annoton-title">PIGL: GlcNAc-PI de-N-acetylase</div>
+        <div class="small muted">pigl_activity</div>            <div class="small"><strong>Participant:</strong> Family: PIGL de-N-acetylase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PIGL de-N-acetylase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12993" target="_blank" rel="noopener">PANTHER:PTHR12993</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGL (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9Y2B2/entry" target="_blank" rel="noopener">UniProtKB:Q9Y2B2</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>N-acetylglucosaminylphosphatidylinositol deacetylase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0000225" target="_blank" rel="noopener">GO:0000225</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>GlcNAc-PI</span></span>                            <span class="descriptor">
+            <span>H2O</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>GlcN-PI (glucosaminyl-PI)</span></span>                            <span class="descriptor">
+            <span>acetate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">De-N-acetylates GlcNAc-PI; deficiency = CHIME syndrome.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: inositol acylation</div>
+                <section class="node-detail depth-1" id="node-pigw_step">
+        <div class="node-heading">
+            <span class="node-title">GlcN-PI to GlcN-(acyl)PI</span><span class="pill type">Reaction</span><span class="pill">pigw_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pigw_activity">
+        <div class="annoton-title">PIGW: GPI inositol acyltransferase</div>
+        <div class="small muted">pigw_activity</div>            <div class="small"><strong>Participant:</strong> Family: PIGW inositol-acyltransferase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PIGW inositol-acyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR20661" target="_blank" rel="noopener">PANTHER:PTHR20661</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGW (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q7Z7B1/entry" target="_blank" rel="noopener">UniProtKB:Q7Z7B1</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>glucosaminyl-phosphatidylinositol O-acyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0032216" target="_blank" rel="noopener">GO:0032216</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>GlcN-PI</span></span>                            <span class="descriptor">
+            <span>fatty acyl-CoA (usually palmitoyl-CoA)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>GlcN-(acyl)PI</span></span>                            <span class="descriptor">
+            <span>CoA</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Inositol acylation; deficiency = GPIBD (hyperphosphatasia/epilepsy).</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: first mannose (alpha-1,4) — GPI-MT-I complex</div>
+                <section class="node-detail depth-1" id="node-gpi_mt1_step">
+        <div class="node-heading">
+            <span class="node-title">GlcN-(acyl)PI to Man1-GlcN-(acyl)PI</span><span class="pill type">Protein Complex</span><span class="pill">gpi_mt1_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pigm_activity">
+        <div class="annoton-title">PIGM: GPI mannosyltransferase I (catalytic)</div>
+        <div class="small muted">pigm_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI mannosyltransferase I family (PIGM)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI mannosyltransferase I family (PIGM)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12886" target="_blank" rel="noopener">PANTHER:PTHR12886</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGM (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9H3S5/entry" target="_blank" rel="noopener">UniProtKB:Q9H3S5</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dol-P-Man:GlcN-acyl-PI alpha-1,4-mannosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0180041" target="_blank" rel="noopener">GO:0180041</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>GlcN-(acyl)PI</span></span>                            <span class="descriptor">
+            <span>dolichyl-phosphate-mannose (Dol-P-Man)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>Man1-GlcN-(acyl)PI</span></span>                            <span class="descriptor">
+            <span>dolichyl phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Catalytic subunit of GPI mannosyltransferase I.</p></article>                    <article class="annoton-card" id="annoton-pigx_activity">
+        <div class="annoton-title">PIGX: GPI-MT-I stabilising subunit</div>
+        <div class="small muted">pigx_activity</div>            <div class="small"><strong>Participant:</strong> Family: PIGX family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PIGX family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR28650" target="_blank" rel="noopener">PANTHER:PTHR28650</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGX (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8TBF5/entry" target="_blank" rel="noopener">UniProtKB:Q8TBF5</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Stabilises catalytic PIGM in the GPI-MT-I complex.</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:human/PIGX/PIGX-ai-review.yaml</span><div>non-catalytic stabilising subunit of GPI-MT-I (GO:1990529) that binds and protects catalytic PIGM</div></div>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 4: second mannose (alpha-1,6)</div>
+                <section class="node-detail depth-1" id="node-pigv_step">
+        <div class="node-heading">
+            <span class="node-title">Man1-GlcN-(acyl)PI to Man2-GlcN-(acyl)PI</span><span class="pill type">Reaction</span><span class="pill">pigv_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pigv_activity">
+        <div class="annoton-title">PIGV: GPI mannosyltransferase II</div>
+        <div class="small muted">pigv_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI mannosyltransferase II family (PIGV)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI mannosyltransferase II family (PIGV)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12468" target="_blank" rel="noopener">PANTHER:PTHR12468</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGV (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9NUD9/entry" target="_blank" rel="noopener">UniProtKB:Q9NUD9</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dol-P-Man:Man(1)GlcN-acyl-PI alpha-1,6-mannosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0120563" target="_blank" rel="noopener">GO:0120563</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>Man1-GlcN-(acyl)PI (EtNP-modified on Man1 by PIGN)</span></span>                            <span class="descriptor">
+            <span>dolichyl-phosphate-mannose (Dol-P-Man)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>Man2-GlcN-(acyl)PI</span></span>                            <span class="descriptor">
+            <span>dolichyl phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Adds the second mannose. (The first mannose receives an EtNP from PIGN before this step — see the GPI ethanolamine-phosphate module.)</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 5: third mannose (alpha-1,2)</div>
+                <section class="node-detail depth-1" id="node-pigb_step">
+        <div class="node-heading">
+            <span class="node-title">Man2-GlcN-(acyl)PI to Man3-GlcN-(acyl)PI</span><span class="pill type">Reaction</span><span class="pill">pigb_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pigb_activity">
+        <div class="annoton-title">PIGB: GPI mannosyltransferase III</div>
+        <div class="small muted">pigb_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI mannosyltransferase III family (PIGB)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI mannosyltransferase III family (PIGB)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR22760" target="_blank" rel="noopener">PANTHER:PTHR22760</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGB (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q92521/entry" target="_blank" rel="noopener">UniProtKB:Q92521</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dol-P-Man:Man(2)GlcN-acyl-PI alpha-1,2-mannosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0120564" target="_blank" rel="noopener">GO:0120564</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>Man2-GlcN-(acyl)PI</span></span>                            <span class="descriptor">
+            <span>dolichyl-phosphate-mannose (Dol-P-Man)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>Man3-GlcN-(acyl)PI</span></span>                            <span class="descriptor">
+            <span>dolichyl phosphate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Adds the third mannose, which receives the protein-bridging EtNP (via PIGO) in the next module.</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/gpi_anchor_glcnac_transferase.html
+++ b/pages/modules/gpi_anchor_glcnac_transferase.html
@@ -1,0 +1,866 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GPI anchor biosynthesis I — GlcNAc transferase (GPI-GnT) complex; PIGA/PIGC/PIGH/PIGP/PIGQ/PIGY - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / GPI anchor biosynthesis I — GlcNAc transferase (GPI-GnT) complex; PIGA/PIGC/PIGH/PIGP/PIGQ/PIGY
+    </nav>
+
+    <header class="header">
+        <h1>GPI anchor biosynthesis I — GlcNAc transferase (GPI-GnT) complex; PIGA/PIGC/PIGH/PIGP/PIGQ/PIGY</h1>            <p class="description">Glycosylphosphatidylinositol (GPI) anchor biosynthesis begins on the cytoplasmic face of the endoplasmic-reticulum membrane with the transfer of N-acetylglucosamine from UDP-GlcNAc onto phosphatidylinositol (PI) to form GlcNAc-PI, the first and committed step. This reaction is carried out by the multi-subunit GPI-N-acetylglucosaminyltransferase (GPI-GnT) complex, in which PIGA is the catalytic phosphatidylinositol N-acetylglucosaminyltransferase and PIGC, PIGH, PIGP, PIGQ (GPI1) and PIGY are required non-catalytic subunits (the Dol-P-Man synthase subunit DPM2 also associates with and regulates the complex). GPI anchors ultimately tether ~150 human proteins to the cell surface; the GlcNAc-PI product is subsequently de-N-acetylated and elaborated by the downstream Pig/Pgap enzymes. Defects in this first step cause GPI-deficiency disease: acquired somatic PIGA mutations in haematopoietic stem cells cause paroxysmal nocturnal haemoglobinuria (PNH), germline PIGA hypomorphs cause multiple congenital anomalies-hypotonia-seizures syndrome 2 (MCAHS2), and biallelic PIGC/PIGH/PIGP/PIGQ/PIGY defects cause inherited GPI-deficiency developmental and epileptic encephalopathies (GPIBD).</p>        <div class="meta-row"><span class="pill">MODULE:gpi_anchor_glcnac_transferase</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/gpi_anchor_glcnac_transferase.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a><div><strong>GPI anchor biosynthetic process</strong></div><div>The module is grounded in GPI anchor biosynthetic process (GO:0006506); it covers the first, committed step (GlcNAc-PI synthesis) catalysed by the GPI-GnT complex.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-162710</span><div><strong>Synthesis of glycosylphosphatidylinositol (GPI)</strong></div><div>The GlcNAc-PI-forming reaction follows the human Reactome &#34;Synthesis of glycosylphosphatidylinositol (GPI)&#34; sub-pathway (reaction R-HSA-162730).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGA/PIGA-ai-review.yaml</span><div><strong>PIGA gene review (human)</strong></div><div>The catalytic GlcNAc-transferase step (UniProtKB:P37287, GO:0017176) matches the completed human PIGA review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGC/PIGC-ai-review.yaml</span><div><strong>PIGC gene review (human)</strong></div><div>The PIGC accessory-subunit role (UniProtKB:Q92535, GPI-GnT complex GO:0000506) matches the completed human PIGC review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGH/PIGH-ai-review.yaml</span><div><strong>PIGH gene review (human)</strong></div><div>The PIGH accessory-subunit role (UniProtKB:Q14442, GPI-GnT complex GO:0000506) matches the completed human PIGH review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGP/PIGP-ai-review.yaml</span><div><strong>PIGP gene review (human)</strong></div><div>The PIGP accessory-subunit role (UniProtKB:P57054, GPI-GnT complex GO:0000506) matches the completed human PIGP review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGQ/PIGQ-ai-review.yaml</span><div><strong>PIGQ gene review (human)</strong></div><div>The PIGQ/GPI1 stabilising-subunit role (UniProtKB:Q9BRB3, GPI-GnT complex GO:0000506) matches the completed human PIGQ review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGY/PIGY-ai-review.yaml</span><div><strong>PIGY gene review (human)</strong></div><div>The PIGY small-subunit role (UniProtKB:Q3MUY2, GPI-GnT complex GO:0000506) matches the completed human PIGY review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">1</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:gpi_anchor_glcnac_transferase</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(6/6 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        6 complete review(s) &middot;
+                        0 with deep research &middot;
+                        0 missing review &middot;
+                        6 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>PIGA
+                                        <span class="muted term-id">P37287</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGC
+                                        <span class="muted term-id">Q92535</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGH
+                                        <span class="muted term-id">Q14442</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGP
+                                        <span class="muted term-id">P57054</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGQ
+                                        <span class="muted term-id">Q9BRB3</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGY
+                                        <span class="muted term-id">Q3MUY2</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-gpi_anchor_glcnac_transferase">GPI anchor biosynthesis, GlcNAc transferase (GPI-GnT) complex</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">gpi_anchor_glcnac_transferase</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. GlcNAc-PI synthesis (first committed step)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-gpi_gnt_step">phosphatidylinositol + UDP-GlcNAc to GlcNAc-PI</a><span class="pill type">Protein Complex</span><span class="tree-id">gpi_gnt_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-piga_activity">PIGA: catalytic GlcNAc transferase subunit</a>
+                                <span class="tree-id">Family: PIGA glycosyltransferase family</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigc_activity">PIGC: GPI-GnT accessory subunit</a>
+                                <span class="tree-id">Family: PIGC family</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigh_activity">PIGH: GPI-GnT accessory subunit</a>
+                                <span class="tree-id">Family: PIGH family</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigp_activity">PIGP: GPI-GnT accessory subunit</a>
+                                <span class="tree-id">Family: PIGP family</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigq_activity">PIGQ: GPI-GnT stabilising subunit (GPI1)</a>
+                                <span class="tree-id">Family: PIGQ/GPI1 family</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigy_activity">PIGY: GPI-GnT small subunit</a>
+                                <span class="tree-id">Family: PIGY family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-gpi_anchor_glcnac_transferase">
+        <div class="node-heading">
+            <span class="node-title">GPI anchor biosynthesis, GlcNAc transferase (GPI-GnT) complex</span><span class="pill type">Metabolic Pathway</span><span class="pill">gpi_anchor_glcnac_transferase</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>
+
+            </div>
+        <p class="muted small">First step of GPI-anchor biosynthesis (GlcNAc-PI synthesis), grounded to the human GPI-GnT complex: catalytic PIGA (UniProtKB:P37287, GO:0017176, EC 2.4.1.198) plus the required non-catalytic subunits PIGC (Q92535), PIGH (Q14442), PIGP (P57054), PIGQ/GPI1 (Q9BRB3) and PIGY (Q3MUY2), all part of the GPI-GnT complex (GO:0000506). The regulatory DPM2 subunit (also a Dol-P-Man synthase subunit) associates with the complex and is reviewed elsewhere. GO molecular-function/BP/location terms were taken from the completed human gene reviews and verified against the local go.db; the reaction (R-HSA-162730) and its parent pathway (R-HSA-162710) were verified against the local reactome cache. The step is modelled as a single PROTEIN_COMPLEX node: only PIGA carries a molecular-function term (the catalytic GlcNAc transferase); the accessory subunits are represented by their GPI-anchor-biosynthesis biological-process role (they have no independent catalytic MF — PIGP and PIGY carry the complex activity only with a `contributes_to` qualifier in GOA). Downstream, GlcNAc-PI is de-N-acetylated (PIGL), inositol-acylated (PIGW), mannosylated and EtNP-modified (PIGM/PIGX, PIGV, PIGB, PIGN, PIGO, PIGF, PIGG), then the completed GPI is transferred to protein by the GPI transamidase (PIGK/PIGS/PIGT/PIGU/GPAA1) and remodelled (PGAP1/2/3/…) — separate modules to follow. Disorders: PNH (somatic PIGA), MCAHS2 (germline PIGA), and inherited GPI-deficiency epileptic encephalopathies (PIGC/PIGH/PIGP/PIGQ/PIGY).</p>                <div class="part-marker">
+                    Part 1: GlcNAc-PI synthesis (first committed step)</div>
+                <section class="node-detail depth-1" id="node-gpi_gnt_step">
+        <div class="node-heading">
+            <span class="node-title">phosphatidylinositol + UDP-GlcNAc to GlcNAc-PI</span><span class="pill type">Protein Complex</span><span class="pill">gpi_gnt_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-piga_activity">
+        <div class="annoton-title">PIGA: catalytic GlcNAc transferase subunit</div>
+        <div class="small muted">piga_activity</div>            <div class="small"><strong>Participant:</strong> Family: PIGA glycosyltransferase family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PIGA glycosyltransferase family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR45871" target="_blank" rel="noopener">PANTHER:PTHR45871</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGA (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P37287/entry" target="_blank" rel="noopener">UniProtKB:P37287</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>phosphatidylinositol N-acetylglucosaminyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0017176" target="_blank" rel="noopener">GO:0017176</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>phosphatidylinositol (PI)</span></span>                            <span class="descriptor">
+            <span>UDP-GlcNAc</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>GlcNAc-PI (N-acetyl-D-glucosaminyl-phosphatidylinositol)</span></span>                            <span class="descriptor">
+            <span>UDP</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Catalytic subunit of GPI-GnT. Somatic loss = PNH; germline hypomorph = MCAHS2.</p></article>                    <article class="annoton-card" id="annoton-pigc_activity">
+        <div class="annoton-title">PIGC: GPI-GnT accessory subunit</div>
+        <div class="small muted">pigc_activity</div>            <div class="small"><strong>Participant:</strong> Family: PIGC family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PIGC family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12982" target="_blank" rel="noopener">PANTHER:PTHR12982</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGC (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q92535/entry" target="_blank" rel="noopener">UniProtKB:Q92535</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Required accessory subunit of the GPI-GnT complex.</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:human/PIGC/PIGC-ai-review.yaml</span><div>required non-catalytic subunit of the GPI-GnT complex (GO:0000506); deficiency = GPIBD16 epileptic encephalopathy</div></div>        </div></article>                    <article class="annoton-card" id="annoton-pigh_activity">
+        <div class="annoton-title">PIGH: GPI-GnT accessory subunit</div>
+        <div class="small muted">pigh_activity</div>            <div class="small"><strong>Participant:</strong> Family: PIGH family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PIGH family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR15231" target="_blank" rel="noopener">PANTHER:PTHR15231</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGH (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q14442/entry" target="_blank" rel="noopener">UniProtKB:Q14442</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Required accessory subunit of the GPI-GnT complex.</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:human/PIGH/PIGH-ai-review.yaml</span><div>required non-catalytic subunit of the GPI-GnT complex (GO:0000506); deficiency = GPIBD17</div></div>        </div></article>                    <article class="annoton-card" id="annoton-pigp_activity">
+        <div class="annoton-title">PIGP: GPI-GnT accessory subunit</div>
+        <div class="small muted">pigp_activity</div>            <div class="small"><strong>Participant:</strong> Family: PIGP family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PIGP family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR46346" target="_blank" rel="noopener">PANTHER:PTHR46346</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGP (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P57054/entry" target="_blank" rel="noopener">UniProtKB:P57054</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Required accessory subunit of the GPI-GnT complex.</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:human/PIGP/PIGP-ai-review.yaml</span><div>required small non-catalytic subunit of the GPI-GnT complex (GO:0000506); deficiency = GPIBD</div></div>        </div></article>                    <article class="annoton-card" id="annoton-pigq_activity">
+        <div class="annoton-title">PIGQ: GPI-GnT stabilising subunit (GPI1)</div>
+        <div class="small muted">pigq_activity</div>            <div class="small"><strong>Participant:</strong> Family: PIGQ/GPI1 family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PIGQ/GPI1 family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR21329" target="_blank" rel="noopener">PANTHER:PTHR21329</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGQ (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9BRB3/entry" target="_blank" rel="noopener">UniProtKB:Q9BRB3</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Stabilising accessory subunit (GPI1) of the GPI-GnT complex.</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:human/PIGQ/PIGQ-ai-review.yaml</span><div>stabilising non-catalytic subunit (GPI1) of the GPI-GnT complex (GO:0000506); deficiency = GPIBD</div></div>        </div></article>                    <article class="annoton-card" id="annoton-pigy_activity">
+        <div class="annoton-title">PIGY: GPI-GnT small subunit</div>
+        <div class="small muted">pigy_activity</div>            <div class="small"><strong>Participant:</strong> Family: PIGY family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PIGY family</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR39235" target="_blank" rel="noopener">PANTHER:PTHR39235</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGY (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q3MUY2/entry" target="_blank" rel="noopener">UniProtKB:Q3MUY2</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Small accessory subunit that interacts directly with catalytic PIGA.</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:human/PIGY/PIGY-ai-review.yaml</span><div>small non-catalytic subunit interacting directly with PIGA in the GPI-GnT complex (GO:0000506); deficiency = GPIBD</div></div>        </div></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -285,7 +285,7 @@
 
     <section class="toolbar">
         <input class="search" type="search" placeholder="Filter modules" data-module-search>
-        <div class="count"><span data-visible-count>138</span> / 138 modules</div>
+        <div class="count"><span data-visible-count>142</span> / 142 modules</div>
     </section>
 
     <div class="table-wrap">
@@ -793,6 +793,52 @@
                         0
                     </td>
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/cholesterol_synthesis_post_lanosterol.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="Cobalamin (B12) intracellular processing and trafficking; ABCD4/LMBRD1/MMACHC/MMADHC">
+                        <a class="module-name" href="cobalamin_intracellular_processing.html">Cobalamin (B12) intracellular processing and trafficking; ABCD4/LMBRD1/MMACHC/MMADHC</a><span class="module-id">MODULE:cobalamin_intracellular_processing</span>                        <span class="module-desc">Once the transcobalamin-cobalamin complex has been endocytosed via CD320 and degraded in the lysosome, the freed cobalamin (vitamin B12) must be...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">Once the transcobalamin-cobalamin complex has been endocytosed via CD320 and degraded in the lysosome, the freed cobalamin (vitamin B12) must be exported to the cytosol, stripped of its upper axial ligand, and routed to one of its two coenzyme forms. The lysosomal export step is carried out by a two-protein system: the ABC transporter ABCD4 (cblJ), which provides the ATP-dependent transmembrane cobalamin-transport activity, together with the lysosomal membrane protein LMBRD1 (cblF), which is required to target ABCD4 to the lysosome and acts as its escort subunit. In the cytosol the cblC protein MMACHC processes the cobalamin — reductive decyanation of cyanocobalamin and dealkylation of alkylcobalamins remove the beta-axial ligand to give cob(II)alamin. The cblD protein MMADHC then binds MMACHC-cob(II)alamin and acts as the branch-point/trafficking adaptor that directs cobalamin either to the mitochondrion for adenosylcobalamin synthesis (feeding methylmalonyl-CoA mutase, MMUT) or to the cytosolic methylcobalamin route (feeding methionine synthase, MTR). Defects in each step cause combined or isolated methylmalonic aciduria and homocystinuria: cblJ (ABCD4), cblF (LMBRD1), cblC (MMACHC) and cblD (MMADHC).</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">cobalamin metabolic process</span>                        </div>                    </td>
+                    <td class="num">4</td>
+                    <td class="num">4</td>
+                    <td class="num">3</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">2</td>                    <td class="num" data-sort-value="4">
+                        4/4
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/cobalamin_intracellular_processing.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="Cobalamin (vitamin B12) absorption and transport; TCN1/CBLIF/CUBN/AMN/TCN2/CD320">
+                        <a class="module-name" href="cobalamin_absorption_transport.html">Cobalamin (vitamin B12) absorption and transport; TCN1/CBLIF/CUBN/AMN/TCN2/CD320</a><span class="module-id">MODULE:cobalamin_absorption_transport</span>                        <span class="module-desc">Dietary cobalamin (vitamin B12) reaches the cytoplasm of peripheral cells through a relay of binding proteins and endocytic receptors. In saliva...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">Dietary cobalamin (vitamin B12) reaches the cytoplasm of peripheral cells through a relay of binding proteins and endocytic receptors. In saliva and the acidic stomach, cobalamin is first bound and protected by haptocorrin (TCN1); in the duodenum pancreatic proteases degrade haptocorrin and the cobalamin is transferred to gastric intrinsic factor (CBLIF/GIF), secreted by parietal cells. The intrinsic-factor-cobalamin complex is then recognised in the ileum by the cubam receptor, a complex of the large peripheral membrane protein cubilin (CUBN) and its transmembrane partner amnionless (AMN), which internalises it by receptor-mediated endocytosis; the cobalamin is released and exported to the blood. In plasma, newly absorbed cobalamin is bound by transcobalamin (TCN2), the physiologically essential delivery carrier, and the transcobalamin-cobalamin complex is taken up by peripheral cells through the cell-surface receptor CD320 (TCblR). Inherited defects along this route cause B12-deficiency disorders: CBLIF (hereditary intrinsic factor deficiency / juvenile pernicious anaemia), CUBN and AMN (Imerslund-Grasbeck syndrome, megaloblastic anaemia with proteinuria), TCN2 (transcobalamin deficiency, severe infantile megaloblastic anaemia with immunodeficiency) and CD320 (a usually mild/transient methylmalonic acidaemia detected on newborn screening).</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="2">                        <div class="concepts">                            <span class="pill">cobalamin transport</span>                            <span class="pill">receptor-mediated endocytosis</span>                        </div>                    </td>
+                    <td class="num">6</td>
+                    <td class="num">6</td>
+                    <td class="num">5</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">4</td>                    <td class="num" data-sort-value="6">
+                        6/6
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/cobalamin_absorption_transport.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="Cortisol-cortisone shuttle — pre-receptor glucocorticoid interconversion; HSD11B1/HSD11B2">
                         <a class="module-name" href="cortisol_cortisone_shuttle.html">Cortisol-cortisone shuttle — pre-receptor glucocorticoid interconversion; HSD11B1/HSD11B2</a><span class="module-id">MODULE:cortisol_cortisone_shuttle</span>                        <span class="module-desc">Tissue glucocorticoid action is set not only by circulating cortisol but by local, pre-receptor interconversion between active cortisol and...</span>                        <details class="module-desc-more">
@@ -1416,6 +1462,52 @@ Design intent: the module is organized as a driver layer (PUFA-phospholipid supp
                         0
                     </td>
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/gpcr_camp_pka_signaling.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="GPI anchor biosynthesis I — GlcNAc transferase (GPI-GnT) complex; PIGA/PIGC/PIGH/PIGP/PIGQ/PIGY">
+                        <a class="module-name" href="gpi_anchor_glcnac_transferase.html">GPI anchor biosynthesis I — GlcNAc transferase (GPI-GnT) complex; PIGA/PIGC/PIGH/PIGP/PIGQ/PIGY</a><span class="module-id">MODULE:gpi_anchor_glcnac_transferase</span>                        <span class="module-desc">Glycosylphosphatidylinositol (GPI) anchor biosynthesis begins on the cytoplasmic face of the endoplasmic-reticulum membrane with the transfer of...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">Glycosylphosphatidylinositol (GPI) anchor biosynthesis begins on the cytoplasmic face of the endoplasmic-reticulum membrane with the transfer of N-acetylglucosamine from UDP-GlcNAc onto phosphatidylinositol (PI) to form GlcNAc-PI, the first and committed step. This reaction is carried out by the multi-subunit GPI-N-acetylglucosaminyltransferase (GPI-GnT) complex, in which PIGA is the catalytic phosphatidylinositol N-acetylglucosaminyltransferase and PIGC, PIGH, PIGP, PIGQ (GPI1) and PIGY are required non-catalytic subunits (the Dol-P-Man synthase subunit DPM2 also associates with and regulates the complex). GPI anchors ultimately tether ~150 human proteins to the cell surface; the GlcNAc-PI product is subsequently de-N-acetylated and elaborated by the downstream Pig/Pgap enzymes. Defects in this first step cause GPI-deficiency disease: acquired somatic PIGA mutations in haematopoietic stem cells cause paroxysmal nocturnal haemoglobinuria (PNH), germline PIGA hypomorphs cause multiple congenital anomalies-hypotonia-seizures syndrome 2 (MCAHS2), and biallelic PIGC/PIGH/PIGP/PIGQ/PIGY defects cause inherited GPI-deficiency developmental and epileptic encephalopathies (GPIBD).</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">GPI anchor biosynthetic process</span>                        </div>                    </td>
+                    <td class="num">2</td>
+                    <td class="num">6</td>
+                    <td class="num">1</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>                    <td class="num" data-sort-value="6">
+                        6/6
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/gpi_anchor_glcnac_transferase.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="GPI anchor biosynthesis II — de-N-acetylation, inositol acylation and mannosylation; PIGL/PIGW/PIGM/PIGX/PIGV/PIGB">
+                        <a class="module-name" href="gpi_anchor_core_glycan_assembly.html">GPI anchor biosynthesis II — de-N-acetylation, inositol acylation and mannosylation; PIGL/PIGW/PIGM/PIGX/PIGV/PIGB</a><span class="module-id">MODULE:gpi_anchor_core_glycan_assembly</span>                        <span class="module-desc">After the GPI-GlcNAc transferase complex makes GlcNAc-PI, the glycosylphosphatidylinositol (GPI) precursor is elaborated by de-N-acetylation,...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">After the GPI-GlcNAc transferase complex makes GlcNAc-PI, the glycosylphosphatidylinositol (GPI) precursor is elaborated by de-N-acetylation, inositol acylation and the sequential addition of three mannoses, on the endoplasmic-reticulum membrane. PIGL de-N-acetylates GlcNAc-PI to glucosaminyl-phosphatidylinositol (GlcN-PI); the intermediate is then flipped to the ER lumen and PIGW acylates the inositol ring (from acyl-CoA) to GlcN-(acyl)PI, a form required for later transamidase recognition. Three dolichyl-phosphate-mannose (Dol-P-Man)- dependent mannosyltransferases then build the trimannosyl core: GPI mannosyltransferase I (the catalytic PIGM with its stabilising subunit PIGX) adds the first mannose (alpha-1,4); PIGV (GPI-MT-II) adds the second (alpha-1,6); and PIGB (GPI-MT-III) adds the third (alpha-1,2), the mannose that later receives the bridging ethanolamine-phosphate for protein attachment. Defects across this segment cause GPI-deficiency disease: PIGL (CHIME syndrome), PIGW and PIGM/PIGV (hyperphosphatasia with mental retardation / Mabry syndrome and related inherited GPI-deficiency encephalopathies), and PIGB (a developmental and epileptic encephalopathy, GPIBD).</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">GPI anchor biosynthetic process</span>                        </div>                    </td>
+                    <td class="num">6</td>
+                    <td class="num">6</td>
+                    <td class="num">5</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">4</td>                    <td class="num" data-sort-value="6">
+                        6/6
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/gpi_anchor_core_glycan_assembly.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="Galactose catabolism (Leloir pathway)">
                         <a class="module-name" href="galactose_leloir_pathway.html">Galactose catabolism (Leloir pathway)</a><span class="module-id">MODULE:galactose_leloir_pathway</span>                        <span class="module-desc">The Leloir pathway, the main route by which dietary D-galactose (chiefly from the milk sugar lactose) is converted to glucose-1-phosphate and...</span>                        <details class="module-desc-more">

--- a/pages/projects/UNIPROT_CAUTION_NOTE/uniprot_wide_queries.html
+++ b/pages/projects/UNIPROT_CAUTION_NOTE/uniprot_wide_queries.html
@@ -1431,7 +1431,7 @@
 <td><a href="http://amigo.geneontology.org/amigo/term/GO:0015439">GO:0015439</a> ABC-type heme transporte(EXP); <a href="http://amigo.geneontology.org/amigo/term/GO:0015562">GO:0015562</a> efflux transmembrane tra(IDA)</td>
 </tr>
 <tr>
-<td>ABCD4</td>
+<td><a href="../../../genes/human/ABCD4/ABCD4-ai-review.html">ABCD4</a></td>
 <td>Homo sapiens (Human)</td>
 <td>O14678</td>
 <td>PMID:27456980</td>
@@ -1439,7 +1439,7 @@
 <td><a href="http://amigo.geneontology.org/amigo/term/GO:0005515">GO:0005515</a> protein binding(IPI); <a href="http://amigo.geneontology.org/amigo/term/GO:0042802">GO:0042802</a> identical protein bindin(IPI)</td>
 </tr>
 <tr>
-<td>ABCD4</td>
+<td><a href="../../../genes/human/ABCD4/ABCD4-ai-review.html">ABCD4</a></td>
 <td>Homo sapiens (Human)</td>
 <td>O14678</td>
 <td>PMID:9266848</td>
@@ -1447,7 +1447,7 @@
 <td><a href="http://amigo.geneontology.org/amigo/term/GO:0005524">GO:0005524</a> ATP binding(NAS); <a href="http://amigo.geneontology.org/amigo/term/GO:0042626">GO:0042626</a> ATPase-coupled transmemb(NAS)</td>
 </tr>
 <tr>
-<td>ABCD4</td>
+<td><a href="../../../genes/human/ABCD4/ABCD4-ai-review.html">ABCD4</a></td>
 <td>Homo sapiens (Human)</td>
 <td>O14678</td>
 <td>PMID:28572511</td>
@@ -1455,7 +1455,7 @@
 <td><a href="http://amigo.geneontology.org/amigo/term/GO:0005515">GO:0005515</a> protein binding(IPI)</td>
 </tr>
 <tr>
-<td>ABCD4</td>
+<td><a href="../../../genes/human/ABCD4/ABCD4-ai-review.html">ABCD4</a></td>
 <td>Homo sapiens (Human)</td>
 <td>O14678</td>
 <td>PMID:33845046</td>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3238 |
| Gene review HTML pages | 3238 |
| Project pages | 1111 |
| Module pages | 143 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
