### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/PIGF/PIGF-ai-review.html
+++ b/genes/human/PIGF/PIGF-ai-review.html
@@ -1,0 +1,2778 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGF - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGF</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q07326" target="_blank" class="term-link">
+                        Q07326
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGF";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q07326" data-a="DESCRIPTION: PIGF (phosphatidylinositol-glycan biosynthesis cla..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGF (phosphatidylinositol-glycan biosynthesis class F protein) is a multi-pass endoplasmic reticulum membrane protein that acts as a non-catalytic accessory (stabilizing) subunit of the glycosylphosphatidylinositol (GPI) ethanolamine-phosphate transferases. It forms complexes with the catalytic transferases PIGO and PIGG, stabilizing them and being required for their activity; PIGO (with PIGF) adds the bridging ethanolamine phosphate (EtNP) to the third mannose of the GPI intermediate, and PIGG (with PIGF) adds EtNP to the second mannose. Through these complexes PIGF participates in the late steps of GPI-anchor biosynthesis in the ER. PIGF itself has no independent enzymatic activity, and the two transferases compete for the shared PIGF stabilizer. Loss-of-function of PIGF causes an autosomal-recessive inherited GPI-deficiency disorder (GPIBD) that clinically overlaps DOORS syndrome, with global developmental delay, impaired intellectual development, seizures, and nail/terminal phalanx hypoplasia.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred localization of PIGF to the ER membrane, where the GPI-anchor biosynthetic machinery resides. This is consistent with the direct biochemistry and with UniProt&#39;s subcellular location assignment.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGF is a multi-pass ER membrane protein that acts within the ER-localized GPI EtNP-transferase complexes; the IBA localization is well supported and represents a core aspect of the protein&#39;s biology.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The core GPI is assembled on the endoplasmic reticulum (ER) membrane and is transferred en bloc to the precursor proteins immediately after their ER translocation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGF/PIGF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically inferred involvement of PIGF in GPI-anchor biosynthesis. PIGF is required for the two late EtNP-transfer steps of the pathway by stabilizing the catalytic transferases PIGO and PIGG.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core biological process of PIGF and is directly supported by experimental characterization of the human protein and its complexes; the IBA call is at the correct level of specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Two EtNPs are sequentially transferred to the 6-positions of Man3 and then Man2 by PIGO</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Both PIGO and PIGG are stabilized by association with PIGF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0005789" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation of ER membrane localization, transferred from the mouse ortholog (O09101), Ensembl compara, InterPro (IPR009580, the Pig-F family domain) and UniProt-SubCell. Concordant with the IBA/ISS/TAS ER-membrane calls.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization for a multi-pass ER membrane protein of the GPI-biosynthetic machinery; the electronic mapping agrees with the experimentally supported location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGF/PIGF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation of GPI-anchor biosynthesis involvement, transferred from the mouse ortholog, InterPro (IPR009580) and UniPathway (UPA00196, GPI-anchor biosynthesis). Agrees with the core function established experimentally.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro/UniPathway mapping to GPI-anchor biosynthesis is biologically correct and matches the experimentally supported role of PIGF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGF/PIGF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">glycosylphosphatidylinositol-anchor biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput binary (yeast two-hybrid) interaction from the HuRI human interactome map. The recorded partners here (AQP6, GPR152, LYVE1, MANBAL, TIMMDC1, TMEM130, TMEM14B, TMEM86B) are largely unrelated membrane proteins rather than the functionally relevant PIGO/PIGG partners, and &#39;protein binding&#39; is an uninformative molecular-function term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Bare &#39;protein binding&#39; (GO:0005515) conveys no specific molecular function, and these are systematic Y2H hits (a screen of the whole interactome, not a PIGF-focused study) to unrelated membrane proteins; per curation policy this IPI is retained but flagged as over-annotation rather than removed. The functionally meaningful interactions of PIGF are with PIGO and PIGG (captured in the process annotations and core_functions).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                                        PMID:32296183
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we present a human &#39;all-by-all&#39; reference interactome map of human binary protein interactions, or &#39;HuRI&#39;</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32156170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Biosynthesis and biology of mammalian GPI-anchored proteins.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0005789" data-r="PMID:32156170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated ER-membrane localization (ComplexPortal annotation citing the Kinoshita 2020 GPI-biosynthesis review), reflecting that GPI biosynthesis including the PIGF-containing EtNP-transferase complexes occurs on the ER membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and well-supported localization; consistent with all other ER-membrane annotations for this protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The core GPI is assembled on the endoplasmic reticulum (ER) membrane and is transferred en bloc to the precursor proteins immediately after their ER translocation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33386993" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33386993
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIGF deficiency causes a phenotype overlapping with DOORS sy...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0006506" data-r="PMID:33386993" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (mutant phenotype) evidence that PIGF is required for GPI-anchor biosynthesis. A homozygous PIGF missense variant (p.Pro172Arg) in patients with a DOORS-syndrome-overlapping phenotype caused defective GPI biosynthesis demonstrated by flow cytometry.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct human loss-of-function evidence firmly places PIGF in GPI-anchor biosynthesis and links its deficiency to an inherited GPI-deficiency disorder; this is a core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33386993" target="_blank" class="term-link">
+                                        PMID:33386993
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We demonstrate impaired glycosylphosphatidylinositol (GPI) biosynthesis through flow cytometry analysis.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33386993" target="_blank" class="term-link">
+                                        PMID:33386993
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">We thus describe the causal role of a novel disease gene, PIGF, in DOORS syndrome and highlight the overlap between this condition and GPI deficiency disorders.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162742
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0005789" data-r="Reactome:R-HSA-162742" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author-statement placing PIGF (as part of the EtNP-transfer reaction converting the H6/H7 intermediate to H8) at the ER membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the established ER-membrane localization of the GPI-biosynthetic machinery; correct localization annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The core GPI is assembled on the endoplasmic reticulum (ER) membrane and is transferred en bloc to the precursor proteins immediately after their ER translocation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0005789" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity-based (ISS) transfer of ER-membrane localization from the mouse ortholog (O09101). Concordant with the direct human evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization; the ortholog-based inference matches the experimentally supported ER-membrane location of PIGF.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGF/PIGF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0006506" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity-based (ISS) transfer of GPI-anchor biosynthesis involvement from the mouse ortholog (O09101). Matches the experimentally established core function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The ortholog-based inference is biologically correct; PIGF&#39;s core process is GPI-anchor biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGF/PIGF-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">glycosylphosphatidylinositol-anchor biosynthesis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8463218" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8463218
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning of a human gene, PIG-F, a component of glycosylphosp...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q07326" data-a="GO:0006506" data-r="PMID:8463218" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Traceable author statement from the original cloning of human PIG-F, which identified it as a component of GPI-anchor biosynthesis functioning at the step of EtNP transfer to the GPI intermediate bearing three mannoses (i.e. the PIGO-mediated EtNP transfer to the third mannose).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the foundational identification of PIGF as a GPI-anchor biosynthesis component; the process annotation is core and correct.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8463218" target="_blank" class="term-link">
+                                        PMID:8463218
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIG-F takes a part in the step of transfer of ethanolamine phosphate to the GPI intermediate containing three residues of mannose.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Non-catalytic accessory (stabilizing) subunit required for the activity of the GPI ethanolamine-phosphate transferases PIGO and PIGG; participates in the late (EtNP-transfer) steps of GPI-anchor biosynthesis in the ER membrane.</h3>
+                <span class="vote-buttons" data-g="Q07326" data-a="FUNCTION: Non-catalytic accessory (stabilizing) subunit requ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link">
+                                PMID:15632136
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">which is known to bind to and stabilize</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                PMID:32156170
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Both PIGO and PIGG are stabilized by association with PIGF</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8463218" target="_blank" class="term-link">
+                            PMID:8463218
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cloning of a human gene, PIG-F, a component of glycosylphosphatidylinositol anchor biosynthesis, by a novel expression cloning strategy.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Original expression cloning of human PIG-F, identified as a GPI-anchor biosynthesis component acting at the EtNP-transfer step on the three-mannose GPI intermediate.</div>
+
+                        <div class="finding-text">"PIG-F takes a part in the step of transfer of ethanolamine phosphate to the GPI intermediate containing three residues of mannose."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link">
+                            PMID:15632136
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">GPI7 is the second partner of PIG-F and involved in modification of glycosylphosphatidylinositol.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">hGPI7 (PIGG) forms a complex with and is stabilized by PIG-F, which also binds and stabilizes PIG-O; PIGO and PIGG compete for the shared PIG-F stabilizer.</div>
+
+                        <div class="finding-text">"hGPI7 was associated with and stabilized by PIG-F, which is known to bind to and stabilize PIG-O, a protein homologous to hGPI7."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                            PMID:32156170
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis and biology of mammalian GPI-anchored proteins.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PIGO and PIGG are the catalytic EtNP transferases (to Man3 and Man2 respectively) and both are stabilized by association with PIGF; GPI biosynthesis occurs on the ER membrane.</div>
+
+                        <div class="finding-text">"Both PIGO and PIGG are stabilized by association with PIGF"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Source of the HuRI high-throughput binary (Y2H) interaction dataset from which the PIGF &#39;protein binding&#39; IPI annotations to unrelated membrane proteins derive.</div>
+
+                        <div class="finding-text">"we present a human &#39;all-by-all&#39; reference interactome map of human binary protein interactions, or &#39;HuRI&#39;"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33386993" target="_blank" class="term-link">
+                            PMID:33386993
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIGF deficiency causes a phenotype overlapping with DOORS syndrome.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A homozygous PIGF missense variant (p.Pro172Arg) causes impaired GPI biosynthesis (shown by flow cytometry) and a DOORS-syndrome-overlapping inherited GPI-deficiency phenotype.</div>
+
+                        <div class="finding-text">"We demonstrate impaired glycosylphosphatidylinositol (GPI) biosynthesis through flow cytometry analysis."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162742
+
+                    </span>
+                </div>
+
+                <div class="reference-title">(ethanolamineP) mannose (a1-2) mannose (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI -&gt; (ethanolamineP) mannose (a1-2) (ethanolamineP) mannose (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGF/PIGF-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt entry Q07326 (PIGF_HUMAN)</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt describes PIGF as the stabilizing subunit of the EtNP transferase 2 and 3 complexes (with PIGG and PIGO), an ER membrane multi-pass protein, required to stabilize PIGG and PIGO.</div>
+
+                        <div class="finding-text">"Stabilizing subunit of the ethanolamine phosphate transferase"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGF-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q07326" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigf-q07326-review-notes">PIGF (Q07326) review notes</h1>
+<p>Deep research: falcon was OUT OF CREDITS (HTTP 402); no <code>-deep-research-falcon.md</code> generated.<br />
+Review grounded in <code>PIGF-uniprot.txt</code>, the seeded <code>PIGF-goa.tsv</code>, and cached <code>publications/PMID_*.md</code>.</p>
+<h2 id="core-biology-verified">Core biology (verified)</h2>
+<ul>
+<li>PIGF is a <strong>non-catalytic accessory (stabilizing) subunit</strong> of the GPI ethanolamine-phosphate<br />
+  transferases PIGO and PIGG. It is NOT an independent enzyme.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/15632136" title="hGPI7 was associated with and stabilized by PIG-F, which is known to bind to and stabilize PIG-O, a protein homologous to hGPI7">PMID:15632136</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/32156170" title="Both PIGO and PIGG are stabilized by association with PIGF">PMID:32156170</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/32156170" title="Two EtNPs are sequentially transferred to the 6-positions of Man3 and then Man2 by PIGO">PMID:32156170</a> (PIGO adds EtNP to Man3, PIGG to Man2; PIGF is the shared stabilizer)</li>
+<li>UniProt: "Stabilizing subunit of the ethanolamine phosphate transferase 3 and ethanolamine phosphate transferase 2 complexes"; "PIGF is required to stabilize PIGG and PIGO".</li>
+<li>Core BP: <strong>GPI anchor biosynthetic process (GO:0006506)</strong>.</li>
+<li>Location: <strong>ER membrane (GO:0005789)</strong>; multi-pass membrane protein (6 TM helices in UniProt features).</li>
+<li>Disease: homozygous p.Pro172Arg causes an inherited GPI-deficiency disorder (OORS / DOORS-overlap).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/33386993" title="We demonstrate impaired glycosylphosphatidylinositol (GPI) biosynthesis through flow cytometry analysis">PMID:33386993</a></li>
+</ul>
+<h2 id="goa-molecular-function">GOA molecular function</h2>
+<ul>
+<li>The seeded GOA TSV carries <strong>NO catalytic MF term</strong> for PIGF. The only MF line is<br />
+<code>GO:0005515 protein binding</code> (IPI, PMID:32296183 HuRI Y2H). Per instructions I did NOT invent a<br />
+  catalytic activity. NOTE: the UniProt DR block lists <code>GO:0051377 mannose-ethanolamine
+  phosphotransferase activity; IBA:GO_Central</code>, but that term is NOT in the GOA TSV, so it was<br />
+  intentionally not added as a core_function <code>function</code>.</li>
+<li>core_functions therefore omits <code>function</code> and records BP under <code>directly_involved_in</code><br />
+  (GO:0006506) + location (GO:0005789).</li>
+</ul>
+<h2 id="protein-binding-ipi-pmid32296183">protein binding IPI (PMID:32296183)</h2>
+<ul>
+<li>8 IPI lines to AQP6, GPR152, LYVE1, MANBAL, TIMMDC1, TMEM130, TMEM14B, TMEM86B — all HuRI<br />
+  high-throughput Y2H hits to unrelated membrane proteins, none of them PIGO/PIGG.</li>
+<li>Action: MARK_AS_OVER_ANNOTATED (bare uninformative <code>protein binding</code>; not REMOVE per policy).</li>
+</ul>
+<h2 id="panther-family-id">PANTHER family id</h2>
+<ul>
+<li><strong>No PTHR##### family id</strong> is present in the UniProt cross-references. The GOA WITH/FROM only<br />
+  shows a PANTHER <em>node</em> id <code>PANTHER:PTN009167560</code> (from the IBA), and UniProt has a <code>PAN-GO</code> line<br />
+  but no <code>PANTHER; PTHR#####</code> DR line.</li>
+</ul>
+<h2 id="other-identifiers">Other identifiers</h2>
+<ul>
+<li>InterPro IPR009580 (GPI_biosynthesis_protein_Pig-F); Pfam PF06699 (PIG-F). eggNOG KOG3144.</li>
+<li>Isoforms: Q07326-1 (canonical), Q07326-2 (VSP_004361).</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q07326
+gene_symbol: PIGF
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PIGF (phosphatidylinositol-glycan biosynthesis class F protein) is a multi-pass
+  endoplasmic reticulum membrane protein that acts as a non-catalytic accessory
+  (stabilizing) subunit of the glycosylphosphatidylinositol (GPI) ethanolamine-phosphate
+  transferases. It forms complexes with the catalytic transferases PIGO and PIGG,
+  stabilizing them and being required for their activity; PIGO (with PIGF) adds the
+  bridging ethanolamine phosphate (EtNP) to the third mannose of the GPI intermediate,
+  and PIGG (with PIGF) adds EtNP to the second mannose. Through these complexes PIGF
+  participates in the late steps of GPI-anchor biosynthesis in the ER. PIGF itself
+  has no independent enzymatic activity, and the two transferases compete for the shared
+  PIGF stabilizer. Loss-of-function of PIGF causes an autosomal-recessive inherited
+  GPI-deficiency disorder (GPIBD) that clinically overlaps DOORS syndrome, with global
+  developmental delay, impaired intellectual development, seizures, and nail/terminal
+  phalanx hypoplasia.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q07326-1
+- name: &#39;2&#39;
+  id: Q07326-2
+  sequence_note: VSP_004361
+existing_annotations:
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: Phylogenetically inferred localization of PIGF to the ER membrane, where
+      the GPI-anchor biosynthetic machinery resides. This is consistent with the direct
+      biochemistry and with UniProt&#39;s subcellular location assignment.
+    action: ACCEPT
+    reason: PIGF is a multi-pass ER membrane protein that acts within the ER-localized
+      GPI EtNP-transferase complexes; the IBA localization is well supported and represents
+      a core aspect of the protein&#39;s biology.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: The core GPI is assembled on the endoplasmic reticulum (ER)
+        membrane and is transferred en bloc to the precursor proteins immediately
+        after their ER translocation
+    - reference_id: file:human/PIGF/PIGF-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetically inferred involvement of PIGF in GPI-anchor biosynthesis.
+      PIGF is required for the two late EtNP-transfer steps of the pathway by stabilizing
+      the catalytic transferases PIGO and PIGG.
+    action: ACCEPT
+    reason: This is the core biological process of PIGF and is directly supported by
+      experimental characterization of the human protein and its complexes; the IBA
+      call is at the correct level of specificity.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: Two EtNPs are sequentially transferred to the 6-positions of
+        Man3 and then Man2 by PIGO
+    - reference_id: PMID:32156170
+      supporting_text: Both PIGO and PIGG are stabilized by association with PIGF
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Electronic annotation of ER membrane localization, transferred from the
+      mouse ortholog (O09101), Ensembl compara, InterPro (IPR009580, the Pig-F family
+      domain) and UniProt-SubCell. Concordant with the IBA/ISS/TAS ER-membrane calls.
+    action: ACCEPT
+    reason: Correct localization for a multi-pass ER membrane protein of the GPI-biosynthetic
+      machinery; the electronic mapping agrees with the experimentally supported location.
+    supported_by:
+    - reference_id: file:human/PIGF/PIGF-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Electronic annotation of GPI-anchor biosynthesis involvement, transferred
+      from the mouse ortholog, InterPro (IPR009580) and UniPathway (UPA00196, GPI-anchor
+      biosynthesis). Agrees with the core function established experimentally.
+    action: ACCEPT
+    reason: The InterPro/UniPathway mapping to GPI-anchor biosynthesis is biologically
+      correct and matches the experimentally supported role of PIGF.
+    supported_by:
+    - reference_id: file:human/PIGF/PIGF-uniprot.txt
+      supporting_text: glycosylphosphatidylinositol-anchor biosynthesis
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  qualifier: enables
+  review:
+    summary: High-throughput binary (yeast two-hybrid) interaction from the HuRI human
+      interactome map. The recorded partners here (AQP6, GPR152, LYVE1, MANBAL, TIMMDC1,
+      TMEM130, TMEM14B, TMEM86B) are largely unrelated membrane proteins rather than
+      the functionally relevant PIGO/PIGG partners, and &#39;protein binding&#39; is an uninformative
+      molecular-function term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Bare &#39;protein binding&#39; (GO:0005515) conveys no specific molecular function,
+      and these are systematic Y2H hits (a screen of the whole interactome, not a PIGF-focused
+      study) to unrelated membrane proteins; per curation policy this IPI is retained
+      but flagged as over-annotation rather than removed. The functionally meaningful
+      interactions of PIGF are with PIGO and PIGG (captured in the process annotations
+      and core_functions).
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: we present a human &#39;all-by-all&#39; reference interactome map of
+        human binary protein interactions, or &#39;HuRI&#39;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32156170
+  qualifier: located_in
+  review:
+    summary: Author-stated ER-membrane localization (ComplexPortal annotation citing
+      the Kinoshita 2020 GPI-biosynthesis review), reflecting that GPI biosynthesis
+      including the PIGF-containing EtNP-transferase complexes occurs on the ER membrane.
+    action: ACCEPT
+    reason: Correct and well-supported localization; consistent with all other ER-membrane
+      annotations for this protein.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: The core GPI is assembled on the endoplasmic reticulum (ER)
+        membrane and is transferred en bloc to the precursor proteins immediately
+        after their ER translocation
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:33386993
+  qualifier: involved_in
+  review:
+    summary: Experimental (mutant phenotype) evidence that PIGF is required for GPI-anchor
+      biosynthesis. A homozygous PIGF missense variant (p.Pro172Arg) in patients with
+      a DOORS-syndrome-overlapping phenotype caused defective GPI biosynthesis demonstrated
+      by flow cytometry.
+    action: ACCEPT
+    reason: Direct human loss-of-function evidence firmly places PIGF in GPI-anchor
+      biosynthesis and links its deficiency to an inherited GPI-deficiency disorder;
+      this is a core annotation.
+    supported_by:
+    - reference_id: PMID:33386993
+      supporting_text: We demonstrate impaired glycosylphosphatidylinositol (GPI) biosynthesis
+        through flow cytometry analysis.
+    - reference_id: PMID:33386993
+      supporting_text: We thus describe the causal role of a novel disease gene, PIGF,
+        in DOORS syndrome and highlight the overlap between this condition and GPI
+        deficiency disorders.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162742
+  qualifier: located_in
+  review:
+    summary: Reactome traceable-author-statement placing PIGF (as part of the EtNP-transfer
+      reaction converting the H6/H7 intermediate to H8) at the ER membrane.
+    action: ACCEPT
+    reason: Consistent with the established ER-membrane localization of the GPI-biosynthetic
+      machinery; correct localization annotation.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: The core GPI is assembled on the endoplasmic reticulum (ER)
+        membrane and is transferred en bloc to the precursor proteins immediately
+        after their ER translocation
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: Sequence-similarity-based (ISS) transfer of ER-membrane localization from
+      the mouse ortholog (O09101). Concordant with the direct human evidence.
+    action: ACCEPT
+    reason: Correct localization; the ortholog-based inference matches the experimentally
+      supported ER-membrane location of PIGF.
+    supported_by:
+    - reference_id: file:human/PIGF/PIGF-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: Sequence-similarity-based (ISS) transfer of GPI-anchor biosynthesis involvement
+      from the mouse ortholog (O09101). Matches the experimentally established core
+      function.
+    action: ACCEPT
+    reason: The ortholog-based inference is biologically correct; PIGF&#39;s core process
+      is GPI-anchor biosynthesis.
+    supported_by:
+    - reference_id: file:human/PIGF/PIGF-uniprot.txt
+      supporting_text: glycosylphosphatidylinositol-anchor biosynthesis
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: TAS
+  original_reference_id: PMID:8463218
+  qualifier: involved_in
+  review:
+    summary: Traceable author statement from the original cloning of human PIG-F, which
+      identified it as a component of GPI-anchor biosynthesis functioning at the step
+      of EtNP transfer to the GPI intermediate bearing three mannoses (i.e. the PIGO-mediated
+      EtNP transfer to the third mannose).
+    action: ACCEPT
+    reason: This is the foundational identification of PIGF as a GPI-anchor biosynthesis
+      component; the process annotation is core and correct.
+    supported_by:
+    - reference_id: PMID:8463218
+      supporting_text: PIG-F takes a part in the step of transfer of ethanolamine
+        phosphate to the GPI intermediate containing three residues of mannose.
+core_functions:
+- description: Non-catalytic accessory (stabilizing) subunit required for the activity
+    of the GPI ethanolamine-phosphate transferases PIGO and PIGG; participates in the
+    late (EtNP-transfer) steps of GPI-anchor biosynthesis in the ER membrane.
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:15632136
+    supporting_text: which is known to bind to and stabilize
+  - reference_id: PMID:32156170
+    supporting_text: Both PIGO and PIGG are stabilized by association with PIGF
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:8463218
+  title: Cloning of a human gene, PIG-F, a component of glycosylphosphatidylinositol
+    anchor biosynthesis, by a novel expression cloning strategy.
+  findings:
+  - statement: Original expression cloning of human PIG-F, identified as a GPI-anchor
+      biosynthesis component acting at the EtNP-transfer step on the three-mannose
+      GPI intermediate.
+    supporting_text: PIG-F takes a part in the step of transfer of ethanolamine phosphate
+      to the GPI intermediate containing three residues of mannose.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Foundational cloning paper; abstract-only cache but supports the
+      GPI-biosynthesis process annotation.
+- id: PMID:15632136
+  title: GPI7 is the second partner of PIG-F and involved in modification of glycosylphosphatidylinositol.
+  findings:
+  - statement: hGPI7 (PIGG) forms a complex with and is stabilized by PIG-F, which
+      also binds and stabilizes PIG-O; PIGO and PIGG compete for the shared PIG-F stabilizer.
+    supporting_text: hGPI7 was associated with and stabilized by PIG-F, which is known
+      to bind to and stabilize PIG-O, a protein homologous to hGPI7.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Directly establishes PIGF as the shared stabilizing subunit of PIGO
+      and PIGG; abstract-only cache but the key mechanistic claim is in the abstract.
+- id: PMID:32156170
+  title: Biosynthesis and biology of mammalian GPI-anchored proteins.
+  findings:
+  - statement: PIGO and PIGG are the catalytic EtNP transferases (to Man3 and Man2
+      respectively) and both are stabilized by association with PIGF; GPI biosynthesis
+      occurs on the ER membrane.
+    supporting_text: Both PIGO and PIGG are stabilized by association with PIGF
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Authoritative review (full text available) that lays out the pathway
+      and PIGF&#39;s accessory role and ER localization.
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings:
+  - statement: Source of the HuRI high-throughput binary (Y2H) interaction dataset
+      from which the PIGF &#39;protein binding&#39; IPI annotations to unrelated membrane proteins
+      derive.
+    supporting_text: we present a human &#39;all-by-all&#39; reference interactome map of human
+      binary protein interactions, or &#39;HuRI&#39;
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Large-scale interactome screen; the PIGF hits are uninformative &#39;protein
+      binding&#39; partners unrelated to its GPI-biosynthesis function.
+- id: PMID:33386993
+  title: PIGF deficiency causes a phenotype overlapping with DOORS syndrome.
+  findings:
+  - statement: A homozygous PIGF missense variant (p.Pro172Arg) causes impaired GPI
+      biosynthesis (shown by flow cytometry) and a DOORS-syndrome-overlapping inherited
+      GPI-deficiency phenotype.
+    supporting_text: We demonstrate impaired glycosylphosphatidylinositol (GPI) biosynthesis
+      through flow cytometry analysis.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Human loss-of-function evidence linking PIGF to GPI-anchor biosynthesis
+      and to an inherited GPI-deficiency disorder (OORS/DOORS-overlap).
+- id: Reactome:R-HSA-162742
+  title: (ethanolamineP) mannose (a1-2) mannose (a1-6) (ethanolamineP) mannose (a1-4)
+    glucosaminyl-acyl-PI -&gt; (ethanolamineP) mannose (a1-2) (ethanolamineP) mannose
+    (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI
+  findings: []
+- id: file:human/PIGF/PIGF-uniprot.txt
+  title: UniProt entry Q07326 (PIGF_HUMAN)
+  findings:
+  - statement: UniProt describes PIGF as the stabilizing subunit of the EtNP transferase
+      2 and 3 complexes (with PIGG and PIGO), an ER membrane multi-pass protein, required
+      to stabilize PIGG and PIGO.
+    supporting_text: Stabilizing subunit of the ethanolamine phosphate transferase
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Curated UniProt record used for localization, subunit/complex, and
+      pathway statements.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGG/PIGG-ai-review.html
+++ b/genes/human/PIGG/PIGG-ai-review.html
@@ -1,0 +1,3279 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGG - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGG</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q5H8A4" target="_blank" class="term-link">
+                        Q5H8A4
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGG";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q5H8A4" data-a="DESCRIPTION: PIGG is the catalytic subunit of the glycosylphosp..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGG is the catalytic subunit of the glycosylphosphatidylinositol (GPI) ethanolamine phosphate transferase II complex (GPI-ET-II; also known as GPI7/hGPI7). During GPI-anchor biosynthesis in the endoplasmic reticulum, PIGG transfers an ethanolamine phosphate (EtNP), donated by phosphatidylethanolamine, onto the 6-OH of the second alpha-1,6-linked mannose of the GPI intermediate (the H7-to-H8 conversion). This second-mannose EtNP is a side-branch modification that is normally removed shortly after the anchor is transferred to protein. PIGG acts together with the accessory subunit PIGF, which stabilizes it, and competes with PIGO (which adds EtNP to the third mannose) for the shared PIGF stabilizer. PIGG is a multi-pass endoplasmic reticulum membrane protein with a large lumenal alkaline-phosphatase-like catalytic domain. Biallelic loss-of-function variants cause an inherited GPI-deficiency disorder characterized by intellectual disability/developmental delay, early-onset seizures, hypotonia, and cerebellar atrophy; genetic variation in PIGG also defines the Emm blood group system.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGG is a multi-pass endoplasmic reticulum membrane protein and carries out its EtNP-transferase reaction in the ER during GPI-anchor biosynthesis. The phylogenetic (IBA) location call is consistent with direct experimental localization and with the UniProt subcellular location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment for the site of PIGG action, corroborated by experimental localization (PMID:15632136) and UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGG/PIGG-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0051377" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the core molecular function of PIGG - transfer of ethanolamine phosphate from phosphatidylethanolamine to the second mannose of the GPI intermediate. The IBA call at this term is well supported by the human experimental data and the conserved yeast ortholog Gpi7p.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Represents the correct, specific catalytic activity of PIGG and is the core function; matches the current GOA term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGG (initially termed GPI7) [67], catalytic subunits of GPI-ETII and GPI-ETIII. Both PIGO and PIGG are stabilized by association with PIGF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGG catalyzes one step (transfer of EtNP to the second mannose) of the glycosylphosphatidylinositol-anchor biosynthetic pathway. The IBA process call is well supported.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process for this GPI-anchor biosynthetic enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34113002" target="_blank" class="term-link">
+                                        PMID:34113002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is an ethanolamine phosphate transferase that catalyzes the modification of the second mannose of glycosylphosphatidylinositol (GPI)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic mapping from the UniProt subcellular location vocabulary (SL-0097, ER membrane), consistent with experimental localization of PIGG.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location, agrees with experimental evidence and UniProt curation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGG/PIGG-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated inference (InterPro/UniPathway) that PIGG participates in GPI-anchor biosynthesis. This is correct and consistent with experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct process; the InterPro/UniPathway mapping is sound for this GPI-ET family enzyme.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGG/PIGG-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">PATHWAY: Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0051377" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro-based electronic assignment of the specific mannose-ethanolamine phosphotransferase activity, matching the experimentally established function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct specific molecular function; the InterPro2GO mapping is appropriate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link">
+                                        PMID:15632136
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">forms a protein complex with PIG-F and is involved in the H7-to-H8 conversion</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23864651" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23864651
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The identification of novel proteins that interact with the ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0005515" data-r="PMID:23864651" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> An IntAct-derived interaction annotation linking PIGG to the GLP-1 receptor (GLP1R, P43220), from a study screening for novel GLP1R interactors. Bare &#34;protein binding&#34; is uninformative and this interaction is not part of PIGG&#39;s characterized catalytic function in GPI-anchor biosynthesis; there is no evidence it reflects a physiological binding activity of PIGG.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative generic &#34;protein binding&#34; from a high-throughput interactome screen; per curation guidelines this term does not convey PIGG&#39;s actual molecular function and the GLP1R interaction is not an established functional partner.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGG/PIGG-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Q5H8A4; P43220: GLP1R; NbExp=2; IntAct=EBI-11724298, EBI-7466542</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162710
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0006506" data-r="Reactome:R-HSA-162710" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable assertion that PIGG participates in synthesis of GPI. Correct and consistent with the experimental and phylogenetic evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core process from an authoritative pathway resource.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGG (initially termed GPI7) [67], catalytic subunits of GPI-ETII and GPI-ETIII. Both PIGO and PIGG are stabilized by association with PIGF</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15632136
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    GPI7 is the second partner of PIG-F and involved in modifica...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0051377" data-r="PMID:15632136" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (Shishioh et al. 2005) that human GPI7/PIGG, in complex with PIG-F, mediates the transfer of ethanolamine phosphate to the second mannose (H7-to-H8 conversion). This is the defining catalytic activity of PIGG.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally demonstrated core molecular function; matches the current GOA term (GO:0051377; the older UniProt-DR term GO:0051267 is now obsolete).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link">
+                                        PMID:15632136
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an additional ethanolamine phosphate (EtNP) to the second mannose</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link">
+                                        PMID:15632136
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">forms a protein complex with PIG-F and is involved in the H7-to-H8 conversion</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15632136
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    GPI7 is the second partner of PIG-F and involved in modifica...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0005789" data-r="PMID:15632136" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental localization of PIGG/hGPI7 to the endoplasmic reticulum membrane, where GPI-anchor biosynthesis occurs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported correct location of action.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGG/PIGG-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32156170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Biosynthesis and biology of mammalian GPI-anchored proteins.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0005789" data-r="PMID:32156170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-statement (review) localization to the ER membrane, consistent with the described role of PIGG as a multi-pass ER-membrane GPI-ET enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location; consistent with experimental data and the ComplexPortal GPI-ETII complex annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Three GPI-ETs (PIGN, PIGO and PIGG) are also multiple transmembrane proteins bearing catalytic sites within the luminal regions</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016740" target="_blank" class="term-link">
+                                    GO:0016740
+                                </a>
+                            </span>
+                            <span class="term-label">transferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34113002" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34113002
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIGG variant pathogenicity assessment reveals characteristic...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0016740" data-r="PMID:34113002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The variant-pathogenicity study measured PIGG enzymatic (EtNP-transferase) activity via restoration of GPI-AP expression in PIGO/PIGG double-knockout cells, showing that pathogenic variants abolish or reduce this activity. The generic parent &#34;transferase activity&#34; understates the specific, experimentally assayed function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Too general; the assay specifically measures PIGG&#39;s ethanolamine-phosphate transferase (mannose-ethanolamine phosphotransferase) activity, so it should be replaced by the specific molecular function term.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    mannose-ethanolamine phosphotransferase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34113002" target="_blank" class="term-link">
+                                        PMID:34113002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">ten variants had a null enzymatic activity</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34113002" target="_blank" class="term-link">
+                                        PMID:34113002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">is an ethanolamine phosphate transferase that catalyzes the modification of the second mannose of glycosylphosphatidylinositol (GPI)</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016780" target="_blank" class="term-link">
+                                    GO:0016780
+                                </a>
+                            </span>
+                            <span class="term-label">phosphotransferase activity, for other substituted phosphate groups</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162742
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0016780" data-r="Reactome:R-HSA-162742" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable assertion capturing PIGG&#39;s phosphotransferase (EtNP-transfer) reaction at a broader level. This is a correct parent of the specific mannose-ethanolamine phosphotransferase activity but is less informative than GO:0051377.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but non-core generic parent term from Reactome; the specific EtNP-transferase activity (GO:0051377) is the core function captured elsewhere.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link">
+                                        PMID:15632136
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an additional ethanolamine phosphate (EtNP) to the second mannose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mass-spectrometry detection of PIGG in an NK-cell membrane proteome. &#34;Membrane&#34; is an uninformative parent term; the specific and correct location for PIGG is the endoplasmic reticulum membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Uninformative high-level compartment from a bulk membrane-proteome study; the specific ER membrane term is better supported and captured by other annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">approximately 40% of the identified proteins were predicted as plausible membrane proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162742
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0005789" data-r="Reactome:R-HSA-162742" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable assertion placing PIGG&#39;s reaction at the ER membrane, consistent with all other localization evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location from an authoritative pathway resource.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGG/PIGG-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15632136
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    GPI7 is the second partner of PIG-F and involved in modifica...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0005783" data-r="PMID:15632136" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental localization of PIGG/hGPI7 to the endoplasmic reticulum (broader compartment consistent with the ER membrane annotations).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct compartment, experimentally supported; a valid broader parent of endoplasmic reticulum membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGG/PIGG-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15632136
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    GPI7 is the second partner of PIG-F and involved in modifica...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q5H8A4" data-a="GO:0006506" data-r="PMID:15632136" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that knockdown of hGPI7/PIGG blocks the H7-to-H8 conversion, placing PIGG within the GPI-anchor biosynthetic process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally supported involvement in the core GPI-anchor biosynthetic process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link">
+                                        PMID:15632136
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">forms a protein complex with PIG-F and is involved in the H7-to-H8 conversion</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalytic subunit of the GPI ethanolamine phosphate transferase II complex that transfers ethanolamine phosphate (from phosphatidylethanolamine) onto the second mannose of the GPI intermediate during GPI-anchor biosynthesis in the ER, acting together with the stabilizing subunit PIGF.</h3>
+                <span class="vote-buttons" data-g="Q5H8A4" data-a="FUNCTION: Catalytic subunit of the GPI ethanolamine phosphat..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                            mannose-ethanolamine phosphotransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link">
+                                PMID:15632136
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">forms a protein complex with PIG-F and is involved in the H7-to-H8 conversion</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34113002" target="_blank" class="term-link">
+                                PMID:34113002
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">is an ethanolamine phosphate transferase that catalyzes the modification of the second mannose of glycosylphosphatidylinositol (GPI)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15632136" target="_blank" class="term-link">
+                            PMID:15632136
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">GPI7 is the second partner of PIG-F and involved in modification of glycosylphosphatidylinositol.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23864651" target="_blank" class="term-link">
+                            PMID:23864651
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The identification of novel proteins that interact with the GLP-1 receptor and restrain its activity.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                            PMID:32156170
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis and biology of mammalian GPI-anchored proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34113002" target="_blank" class="term-link">
+                            PMID:34113002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIGG variant pathogenicity assessment reveals characteristic features within 19 families.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162710
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Synthesis of glycosylphosphatidylinositol (GPI)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162742
+
+                    </span>
+                </div>
+
+                <div class="reference-title">(ethanolamineP) mannose (a1-2) mannose (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI -&gt; (ethanolamineP) mannose (a1-2) (ethanolamineP) mannose (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGG-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q5H8A4" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigg-q5h8a4-review-notes">PIGG (Q5H8A4) review notes</h1>
+<p>Human PIGG = GPI ethanolamine phosphate transferase 2, catalytic subunit (aka GPI7 homolog / hGPI7 / PIG-G).<br />
+Falcon deep research OUT OF CREDITS (HTTP 402) at time of review; grounded in UniProt, seeded GOA, and cached publications.</p>
+<h2 id="core-biology">Core biology</h2>
+<ul>
+<li>PIGG is the catalytic subunit of the GPI-ethanolamine-phosphate transferase II (GPI-ETII) complex.<br />
+  It transfers ethanolamine phosphate (EtNP), donated from phosphatidylethanolamine (PE), onto the<br />
+  6-OH of the <strong>second</strong> mannose of the GPI intermediate (H7 -&gt; H8 conversion). This is a side-branch<br />
+  EtNP that is normally shortly removed from the GPI-anchored protein after anchoring.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15632136" title="By attachment of an additional ethanolamine phosphate (EtNP) to the second mannose">PMID:15632136</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/34113002" title="PIGG is involved in transfer of EtNP to the second mannose before attachment of proteins">PMID:34113002</a></li>
+<li>Works with the accessory/regulatory subunit <strong>PIGF</strong>, which stabilizes it; PIGG competes with PIGO<br />
+  (GPI-ETIII, EtNP on 3rd mannose) for the shared stabilizer PIGF.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15632136" title="associated with and stabilized by PIG-F">PMID:15632136</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/32156170" title="Both PIGO and PIGG are stabilized by association with PIGF">PMID:32156170</a></li>
+<li>Multi-pass ER membrane protein (12 predicted TM helices; large N-terminal lumenal domain harboring<br />
+  the alkaline-phosphatase-like catalytic core); acts in the ER during GPI-anchor biosynthesis<br />
+  (step 11 of the pathway). [UniProt SUBCELLULAR LOCATION / PATHWAY]</li>
+</ul>
+<h2 id="disease">Disease</h2>
+<ul>
+<li>Biallelic LoF variants cause an inherited GPI-deficiency disorder: neurodevelopmental disorder with/without<br />
+  hypotonia, seizures, and cerebellar atrophy (NEDHSCA; MIM:616917) -&gt; DD/ID, hypotonia, early-onset (mostly<br />
+  febrile) seizures, cerebellar atrophy, ataxia. Unusually for IGDs, alkaline phosphatase and granulocyte<br />
+  GPI-AP surface levels are often normal (fibroblast CD73 is the sensitive readout).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/34113002">PMID:34113002</a> [PMID:26996948 - not cached; UniProt DISEASE]</li>
+<li>Genetic variation in PIGG also defines the Emm blood group system (Emm-null phenotype). [UniProt POLYMORPHISM; PMID:34535746]</li>
+</ul>
+<h2 id="goa-mf-term">GOA MF term</h2>
+<ul>
+<li>GOA carries <strong>GO:0051377 mannose-ethanolamine phosphotransferase activity</strong> for the IBA/IEA/IDA MF rows.</li>
+<li>The UniProt DR line lists GO:0051267 "CP2 mannose-ethanolamine phosphotransferase activity" for the IDA (MGI),<br />
+  but GO:0051267 is now <strong>OBSOLETE</strong> (QuickGO). The current/valid term to use is GO:0051377.</li>
+</ul>
+<h2 id="annotation-decisions-summary">Annotation decisions summary</h2>
+<ul>
+<li>MF GO:0051377 (IBA, IEA, IDA): ACCEPT - core enzymatic activity.</li>
+<li>BP GO:0006506 GPI anchor biosynthetic process (IBA, IEA, TAS, IDA/acts_upstream): ACCEPT - core process.</li>
+<li>CC GO:0005789 ER membrane (IBA is_active_in, IEA, EXP, NAS, TAS): ACCEPT - correct location of action.</li>
+<li>CC GO:0005783 ER (IDA): ACCEPT (broader parent of ER membrane; consistent).</li>
+<li>CC GO:0016020 membrane (HDA, NK-cell membrane proteome MS): MARK_AS_OVER_ANNOTATED - uninformative parent; ER membrane is the specific/correct term.</li>
+<li>MF GO:0016740 transferase activity (IMP, PMID:34113002): MODIFY -&gt; GO:0051377 (the IMP variant assay measures EtNP-transferase activity; the generic parent should be replaced by the specific MF).</li>
+<li>MF GO:0016780 phosphotransferase activity, for other substituted phosphate groups (TAS Reactome): ACCEPT (correct broader parent, TAS from Reactome; kept as-is, non-core-ish parent but sound).</li>
+<li>MF GO:0005515 protein binding (IPI, PMID:23864651, with GLP1R): MARK_AS_OVER_ANNOTATED - bare protein binding from a high-throughput GLP1R interactome screen; not the informative catalytic function.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q5H8A4
+gene_symbol: PIGG
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGG is the catalytic subunit of the glycosylphosphatidylinositol (GPI)
+  ethanolamine phosphate transferase II complex (GPI-ET-II; also known as GPI7/hGPI7).
+  During GPI-anchor biosynthesis in the endoplasmic reticulum, PIGG transfers an ethanolamine
+  phosphate (EtNP), donated by phosphatidylethanolamine, onto the 6-OH of the second
+  alpha-1,6-linked mannose of the GPI intermediate (the H7-to-H8 conversion). This
+  second-mannose EtNP is a side-branch modification that is normally removed shortly
+  after the anchor is transferred to protein. PIGG acts together with the accessory
+  subunit PIGF, which stabilizes it, and competes with PIGO (which adds EtNP to the
+  third mannose) for the shared PIGF stabilizer. PIGG is a multi-pass endoplasmic reticulum
+  membrane protein with a large lumenal alkaline-phosphatase-like catalytic domain.
+  Biallelic loss-of-function variants cause an inherited GPI-deficiency disorder characterized
+  by intellectual disability/developmental delay, early-onset seizures, hypotonia, and
+  cerebellar atrophy; genetic variation in PIGG also defines the Emm blood group system.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q5H8A4-1
+- name: &#39;2&#39;
+  id: Q5H8A4-2
+  sequence_note: VSP_019832
+- name: &#39;3&#39;
+  id: Q5H8A4-3
+  sequence_note: VSP_019828
+- name: &#39;4&#39;
+  id: Q5H8A4-4
+  sequence_note: VSP_019831, VSP_019833
+- name: &#39;5&#39;
+  id: Q5H8A4-5
+  sequence_note: VSP_019827, VSP_019829, VSP_019830
+- name: &#39;6&#39;
+  id: Q5H8A4-6
+  sequence_note: VSP_054387, VSP_054388, VSP_019833
+existing_annotations:
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: PIGG is a multi-pass endoplasmic reticulum membrane protein and carries
+      out its EtNP-transferase reaction in the ER during GPI-anchor biosynthesis.
+      The phylogenetic (IBA) location call is consistent with direct experimental
+      localization and with the UniProt subcellular location.
+    action: ACCEPT
+    reason: Correct compartment for the site of PIGG action, corroborated by experimental
+      localization (PMID:15632136) and UniProt.
+    supported_by:
+    - reference_id: file:human/PIGG/PIGG-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: This is the core molecular function of PIGG - transfer of ethanolamine
+      phosphate from phosphatidylethanolamine to the second mannose of the GPI intermediate.
+      The IBA call at this term is well supported by the human experimental data and
+      the conserved yeast ortholog Gpi7p.
+    action: ACCEPT
+    reason: Represents the correct, specific catalytic activity of PIGG and is the
+      core function; matches the current GOA term.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: PIGG (initially termed GPI7) [67], catalytic subunits of GPI-ETII
+        and GPI-ETIII. Both PIGO and PIGG are stabilized by association with PIGF
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: PIGG catalyzes one step (transfer of EtNP to the second mannose) of the
+      glycosylphosphatidylinositol-anchor biosynthetic pathway. The IBA process call
+      is well supported.
+    action: ACCEPT
+    reason: Correct core biological process for this GPI-anchor biosynthetic enzyme.
+    supported_by:
+    - reference_id: PMID:34113002
+      supporting_text: is an ethanolamine phosphate transferase that catalyzes the
+        modification of the second mannose of glycosylphosphatidylinositol (GPI)
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Electronic mapping from the UniProt subcellular location vocabulary (SL-0097,
+      ER membrane), consistent with experimental localization of PIGG.
+    action: ACCEPT
+    reason: Correct location, agrees with experimental evidence and UniProt curation.
+    supported_by:
+    - reference_id: file:human/PIGG/PIGG-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Automated inference (InterPro/UniPathway) that PIGG participates in GPI-anchor
+      biosynthesis. This is correct and consistent with experimental data.
+    action: ACCEPT
+    reason: Correct process; the InterPro/UniPathway mapping is sound for this GPI-ET
+      family enzyme.
+    supported_by:
+    - reference_id: file:human/PIGG/PIGG-uniprot.txt
+      supporting_text: &#39;PATHWAY: Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor&#39;
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro-based electronic assignment of the specific mannose-ethanolamine
+      phosphotransferase activity, matching the experimentally established function.
+    action: ACCEPT
+    reason: Correct specific molecular function; the InterPro2GO mapping is appropriate.
+    supported_by:
+    - reference_id: PMID:15632136
+      supporting_text: forms a protein complex with PIG-F and is involved in the H7-to-H8
+        conversion
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23864651
+  qualifier: enables
+  review:
+    summary: An IntAct-derived interaction annotation linking PIGG to the GLP-1 receptor
+      (GLP1R, P43220), from a study screening for novel GLP1R interactors. Bare &#34;protein
+      binding&#34; is uninformative and this interaction is not part of PIGG&#39;s characterized
+      catalytic function in GPI-anchor biosynthesis; there is no evidence it reflects
+      a physiological binding activity of PIGG.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative generic &#34;protein binding&#34; from a high-throughput interactome
+      screen; per curation guidelines this term does not convey PIGG&#39;s actual molecular
+      function and the GLP1R interaction is not an established functional partner.
+    supported_by:
+    - reference_id: file:human/PIGG/PIGG-uniprot.txt
+      supporting_text: &#39;Q5H8A4; P43220: GLP1R; NbExp=2; IntAct=EBI-11724298, EBI-7466542&#39;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162710
+  qualifier: involved_in
+  review:
+    summary: Reactome traceable assertion that PIGG participates in synthesis of GPI.
+      Correct and consistent with the experimental and phylogenetic evidence.
+    action: ACCEPT
+    reason: Correct core process from an authoritative pathway resource.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: PIGG (initially termed GPI7) [67], catalytic subunits of GPI-ETII
+        and GPI-ETIII. Both PIGO and PIGG are stabilized by association with PIGF
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: IDA
+  original_reference_id: PMID:15632136
+  qualifier: enables
+  review:
+    summary: Direct experimental evidence (Shishioh et al. 2005) that human GPI7/PIGG,
+      in complex with PIG-F, mediates the transfer of ethanolamine phosphate to the
+      second mannose (H7-to-H8 conversion). This is the defining catalytic activity
+      of PIGG.
+    action: ACCEPT
+    reason: Experimentally demonstrated core molecular function; matches the current
+      GOA term (GO:0051377; the older UniProt-DR term GO:0051267 is now obsolete).
+    supported_by:
+    - reference_id: PMID:15632136
+      supporting_text: an additional ethanolamine phosphate (EtNP) to the second mannose
+    - reference_id: PMID:15632136
+      supporting_text: forms a protein complex with PIG-F and is involved in the H7-to-H8
+        conversion
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: EXP
+  original_reference_id: PMID:15632136
+  qualifier: located_in
+  review:
+    summary: Experimental localization of PIGG/hGPI7 to the endoplasmic reticulum
+      membrane, where GPI-anchor biosynthesis occurs.
+    action: ACCEPT
+    reason: Experimentally supported correct location of action.
+    supported_by:
+    - reference_id: file:human/PIGG/PIGG-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32156170
+  qualifier: located_in
+  review:
+    summary: Author-statement (review) localization to the ER membrane, consistent
+      with the described role of PIGG as a multi-pass ER-membrane GPI-ET enzyme.
+    action: ACCEPT
+    reason: Correct location; consistent with experimental data and the ComplexPortal
+      GPI-ETII complex annotation.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: Three GPI-ETs (PIGN, PIGO and PIGG) are also multiple transmembrane
+        proteins bearing catalytic sites within the luminal regions
+- term:
+    id: GO:0016740
+    label: transferase activity
+  evidence_type: IMP
+  original_reference_id: PMID:34113002
+  qualifier: enables
+  review:
+    summary: The variant-pathogenicity study measured PIGG enzymatic (EtNP-transferase)
+      activity via restoration of GPI-AP expression in PIGO/PIGG double-knockout cells,
+      showing that pathogenic variants abolish or reduce this activity. The generic
+      parent &#34;transferase activity&#34; understates the specific, experimentally assayed
+      function.
+    action: MODIFY
+    reason: Too general; the assay specifically measures PIGG&#39;s ethanolamine-phosphate
+      transferase (mannose-ethanolamine phosphotransferase) activity, so it should
+      be replaced by the specific molecular function term.
+    proposed_replacement_terms:
+    - id: GO:0051377
+      label: mannose-ethanolamine phosphotransferase activity
+    supported_by:
+    - reference_id: PMID:34113002
+      supporting_text: ten variants had a null enzymatic activity
+    - reference_id: PMID:34113002
+      supporting_text: is an ethanolamine phosphate transferase that catalyzes the
+        modification of the second mannose of glycosylphosphatidylinositol (GPI)
+- term:
+    id: GO:0016780
+    label: phosphotransferase activity, for other substituted phosphate groups
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162742
+  qualifier: enables
+  review:
+    summary: Reactome traceable assertion capturing PIGG&#39;s phosphotransferase (EtNP-transfer)
+      reaction at a broader level. This is a correct parent of the specific mannose-ethanolamine
+      phosphotransferase activity but is less informative than GO:0051377.
+    action: KEEP_AS_NON_CORE
+    reason: Correct but non-core generic parent term from Reactome; the specific EtNP-transferase
+      activity (GO:0051377) is the core function captured elsewhere.
+    supported_by:
+    - reference_id: PMID:15632136
+      supporting_text: an additional ethanolamine phosphate (EtNP) to the second mannose
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: High-throughput mass-spectrometry detection of PIGG in an NK-cell membrane
+      proteome. &#34;Membrane&#34; is an uninformative parent term; the specific and correct
+      location for PIGG is the endoplasmic reticulum membrane.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Uninformative high-level compartment from a bulk membrane-proteome study;
+      the specific ER membrane term is better supported and captured by other annotations.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: approximately 40% of the identified proteins were predicted
+        as plausible membrane proteins
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162742
+  qualifier: located_in
+  review:
+    summary: Reactome traceable assertion placing PIGG&#39;s reaction at the ER membrane,
+      consistent with all other localization evidence.
+    action: ACCEPT
+    reason: Correct location from an authoritative pathway resource.
+    supported_by:
+    - reference_id: file:human/PIGG/PIGG-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IDA
+  original_reference_id: PMID:15632136
+  qualifier: located_in
+  review:
+    summary: Direct experimental localization of PIGG/hGPI7 to the endoplasmic reticulum
+      (broader compartment consistent with the ER membrane annotations).
+    action: ACCEPT
+    reason: Correct compartment, experimentally supported; a valid broader parent
+      of endoplasmic reticulum membrane.
+    supported_by:
+    - reference_id: file:human/PIGG/PIGG-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum membrane&#39;
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IDA
+  original_reference_id: PMID:15632136
+  qualifier: acts_upstream_of_or_within
+  review:
+    summary: Direct experimental evidence that knockdown of hGPI7/PIGG blocks the
+      H7-to-H8 conversion, placing PIGG within the GPI-anchor biosynthetic process.
+    action: ACCEPT
+    reason: Experimentally supported involvement in the core GPI-anchor biosynthetic
+      process.
+    supported_by:
+    - reference_id: PMID:15632136
+      supporting_text: forms a protein complex with PIG-F and is involved in the H7-to-H8
+        conversion
+core_functions:
+- description: Catalytic subunit of the GPI ethanolamine phosphate transferase II
+    complex that transfers ethanolamine phosphate (from phosphatidylethanolamine)
+    onto the second mannose of the GPI intermediate during GPI-anchor biosynthesis
+    in the ER, acting together with the stabilizing subunit PIGF.
+  molecular_function:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:15632136
+    supporting_text: forms a protein complex with PIG-F and is involved in the H7-to-H8
+      conversion
+  - reference_id: PMID:34113002
+    supporting_text: is an ethanolamine phosphate transferase that catalyzes the modification
+      of the second mannose of glycosylphosphatidylinositol (GPI)
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:15632136
+  title: GPI7 is the second partner of PIG-F and involved in modification of glycosylphosphatidylinositol.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Primary paper establishing that human GPI7/PIGG forms a complex with
+      PIG-F and mediates EtNP transfer to the second mannose (H7-to-H8 conversion);
+      abstract cached (full text not available). Supports the core MF, BP, and ER
+      location.
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: High-throughput NK-cell membrane proteome MS study; only supports
+      a generic &#34;membrane&#34; localization for PIGG, not an informative function.
+- id: PMID:23864651
+  title: The identification of novel proteins that interact with the GLP-1 receptor
+    and restrain its activity.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Source of the IntAct PIGG-GLP1R interaction (bare protein binding).
+      The paper is a GLP1R interactome screen and does not establish a physiological
+      binding function for PIGG; annotation marked as over-annotated.
+- id: PMID:32156170
+  title: Biosynthesis and biology of mammalian GPI-anchored proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Authoritative review placing PIGG (GPI7) as the catalytic subunit
+      of GPI-ETII adding EtNP to the second mannose, stabilized by PIGF; supports
+      function, complex, ER localization, and disease (IGD).
+- id: PMID:34113002
+  title: PIGG variant pathogenicity assessment reveals characteristic features within
+    19 families.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Full-text (PMC9900493) study of 19 families with biallelic PIGG
+      variants; functional assay of EtNP-transferase activity in PIGO/PIGG DKO cells
+      and detailed neurodevelopmental phenotype (DD/ID, seizures, hypotonia, cerebellar
+      atrophy). Supports the IMP MF, BP, and disease.
+- id: Reactome:R-HSA-162710
+  title: Synthesis of glycosylphosphatidylinositol (GPI)
+  findings: []
+- id: Reactome:R-HSA-162742
+  title: (ethanolamineP) mannose (a1-2) mannose (a1-6) (ethanolamineP) mannose (a1-4)
+    glucosaminyl-acyl-PI -&gt; (ethanolamineP) mannose (a1-2) (ethanolamineP) mannose
+    (a1-6) (ethanolamineP) mannose (a1-4) glucosaminyl-acyl-PI
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGN/PIGN-ai-review.html
+++ b/genes/human/PIGN/PIGN-ai-review.html
@@ -1,0 +1,3212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGN - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGN</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O95427" target="_blank" class="term-link">
+                        O95427
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGN";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O95427" data-a="DESCRIPTION: PIGN (GPI ethanolamine phosphate transferase 1; GP..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGN (GPI ethanolamine phosphate transferase 1; GPI-ET-I) is a multi-pass endoplasmic reticulum membrane protein that acts in glycosylphosphatidylinositol (GPI) anchor biosynthesis. It transfers ethanolamine phosphate from phosphatidylethanolamine onto the 2-OH of the first alpha-1,4-linked mannose of the GPI intermediate, one of three ethanolamine phosphate additions to the trimannosyl core (PIGN acts on mannose 1; the paralogs PIGO and PIGG act on mannoses 3 and 2). PIGN belongs to the PIGG/PIGN/PIGO family and localizes to the ER membrane, where the later steps of GPI assembly occur. Biallelic loss-of-function variants cause multiple congenital anomalies-hypotonia-seizures syndrome 1 (MCAHS1), an autosomal recessive disorder of GPI-anchor biosynthesis characterized by neonatal hypotonia, seizures, dysmorphic features, and congenital anomalies.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGN is a multi-pass ER membrane protein that carries out the ethanolamine phosphate transfer step of GPI-anchor biosynthesis in the ER; this phylogenetic (IBA) location annotation reflects the correct site of action and is a core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records the subcellular location as ER membrane (multi-pass membrane protein), consistent with the whole GPI-biosynthetic machinery residing in the ER, and the topology has 13 predicted transmembrane helices. This IBA is well supported and represents where PIGN functions.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGN participates in GPI-anchor biosynthesis, transferring ethanolamine phosphate onto the first mannose of the GPI intermediate. This phylogenetic annotation captures the core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The UniProt PATHWAY line assigns PIGN to glycosylphosphatidylinositol-anchor biosynthesis, and its FUNCTION describes participation in a defined step of GPI biosynthesis. The IBA is consistent across orthologs (yeast MCD4, mouse Pign) and represents a core process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the eighth step of the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0051377" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is PIGN&#39;s core molecular function: transfer of ethanolamine phosphate from phosphatidylethanolamine onto a mannose of the GPI intermediate. The phylogenetic annotation is the correct, appropriately specific catalytic term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt describes PIGN as an ethanolamine phosphate transferase that transfers EtNP from PE to the 2-OH of the first alpha-1,4-linked mannose of the GPI intermediate. GO:0051377 (mannose-ethanolamine phosphotransferase activity) is the exact catalytic term and is well conserved across the PIGN orthologs used for the IBA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Ethanolamine phosphate transferase that catalyzes an</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ethanolamine phosphate (EtNP) transfer from phosphatidylethanolamine</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">the first alpha-1,4-linked mannose</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0005789" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro/SubCell) annotation placing PIGN in the ER membrane; agrees with the curated UniProt location and the IBA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The InterPro signatures (IPR007070 GPI EtNP transferase 1, IPR017852) and UniProtKB-SubCell SL-0097 map to ER membrane, matching PIGN&#39;s curated location as a multi-pass ER membrane protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic annotation assigning PIGN to GPI-anchor biosynthesis via InterPro and UniPathway; consistent with the curated pathway and the IBA/TAS.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> InterPro GPI EtNP-transferase signatures and UniPathway UPA00196 (glycosylphosphatidylinositol-anchor biosynthesis) correctly place PIGN in this core process.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic InterPro-derived membrane localization. True but uninformative given the more specific ER membrane annotation that pinpoints where PIGN acts.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PIGN is a multi-pass membrane protein, so a bare &#39;membrane&#39; term is not wrong, but it is subsumed by the more specific and functionally correct GO:0005789 ER membrane annotation. The specific term should carry the localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Multi-pass membrane protein</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016740" target="_blank" class="term-link">
+                                    GO:0016740
+                                </a>
+                            </span>
+                            <span class="term-label">transferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0016740" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic InterPro parent term for PIGN&#39;s transferase activity. Correct but far less informative than the specific mannose-ethanolamine phosphotransferase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0016740 is a high-level ancestor of PIGN&#39;s actual catalytic term GO:0051377. It is not wrong, but the specific EtNP-transferase term should represent the molecular function; the parent adds no additional information.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Ethanolamine phosphate transferase that catalyzes an</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0051377" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (InterPro) assignment of PIGN&#39;s specific catalytic activity, matching the IBA/ISS/TAS and the curated UniProt function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> InterPro GPI EtNP-transferase 1 signatures (IPR007070, IPR037671) correctly predict the mannose-ethanolamine phosphotransferase activity that is PIGN&#39;s core molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ethanolamine phosphate (EtNP) transfer from phosphatidylethanolamine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162710
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0006506" data-r="Reactome:R-HSA-162710" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author annotation placing PIGN in the human GPI synthesis pathway. Consistent with the core biological process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome pathway R-HSA-162710 (Synthesis of glycosylphosphatidylinositol) includes the EtNP-transfer reaction catalyzed by PIGN as one step of GPI-anchor biosynthesis; this is a well-established core process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162710
+
+                                </span>
+
+                                <div class="support-text">GPI is synthesized in the endoplasmic reticulum</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HPA immunofluorescence-based cytosolic localization. PIGN is a multi-pass ER membrane protein that functions on the lumenal/ER-membrane face during GPI assembly; a cytosolic pool is not its site of function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a high-throughput HPA IF annotation. PIGN&#39;s curated location is the ER membrane, and its 13-TM topology and role in GPI-anchor synthesis place its activity in the ER, not the bulk cytosol. A cytosolic signal most likely reflects antibody background or over-expression and is not the functional site. Retained (not removed) per policy, but flagged as over-annotated relative to the ER localization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0005886" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HPA immunofluorescence-based plasma membrane localization. PIGN acts in the ER membrane during GPI-anchor biosynthesis; the plasma membrane is where mature GPI-anchored proteins end up, not where PIGN itself functions.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A plasma-membrane signal for an ER-resident biosynthetic enzyme is not its functional location. This HPA IF annotation likely reflects staining of the broader secretory/membrane compartment or antibody cross-reactivity; PIGN&#39;s curated and functional location is the ER membrane. Retained (not removed) per policy, but marked over-annotated.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0005789" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer of the ER membrane location from the mouse ortholog (Q9R1S3). Matches the curated location and other evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ISS from mouse Pign (UniProtKB:Q9R1S3) correctly assigns the ER membrane location; this is PIGN&#39;s core site of action and is corroborated by IBA, IEA, and TAS evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0006506" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer of the GPI-anchor biosynthetic process from mouse Pign. Consistent with PIGN&#39;s core role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ISS from mouse Pign (UniProtKB:Q9R1S3) assigns the GPI-anchor biosynthetic process, matching the curated pathway and PIGN&#39;s function as the EtNP transferase for the first mannose.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the eighth step of the</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0051377" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer of the EtNP-transferase activity from mouse Pign; this is PIGN&#39;s core molecular function and the UniProt EC/catalytic-activity block is itself inferred by similarity to the mouse enzyme.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ISS from mouse Pign (UniProtKB:Q9R1S3) assigns mannose-ethanolamine phosphotransferase activity, matching PIGN&#39;s curated catalytic activity (EtNP transfer from PE to the first mannose of the GPI intermediate).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGN/PIGN-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Ethanolamine phosphate transferase that catalyzes an</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162798
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0051377" data-r="Reactome:R-HSA-162798" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author annotation of the specific EtNP-transfer reaction catalyzed by PIGN (phosphoethanolamine from PE onto the first mannose of the GPI precursor). Directly supports the core molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome reaction R-HSA-162798 describes the transfer of a phosphoethanolamine group from phosphatidylethanolamine onto the first mannose of the GPI precursor, the reaction PIGN catalyzes, mapping to GO:0051377.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162798
+
+                                </span>
+
+                                <div class="support-text">a phosphoethanolamine group is transferred from phosphatidylethanolamine onto the first mannose of the GPI precursor</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mass-spectrometry detection of PIGN in an NK-cell membrane proteome. Confirms PIGN is a membrane protein but gives only a generic membrane location, not its functional ER-membrane site.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited study is a bulk membrane-proteome MS survey of the YTS NK-like cell line that identified ~1843 proteins; detection in a crude membrane fraction supports only a generic &#39;membrane&#39; term and is subsumed by the specific ER membrane annotation that reflects where PIGN acts.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Mass spectrometric analysis identified 1843 proteins with high confidence scores.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-162798
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O95427" data-a="GO:0005789" data-r="Reactome:R-HSA-162798" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome traceable-author annotation placing the PIGN-catalyzed EtNP-transfer reaction in the ER. Consistent with the core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome annotates GPI synthesis, including the PIGN reaction R-HSA-162798, as occurring in the endoplasmic reticulum, matching PIGN&#39;s curated ER membrane location.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-162710
+
+                                </span>
+
+                                <div class="support-text">GPI is synthesized in the endoplasmic reticulum</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PIGN transfers ethanolamine phosphate from phosphatidylethanolamine onto the 2-OH of the first alpha-1,4-linked mannose of the GPI intermediate in the ER membrane, an essential step of glycosylphosphatidylinositol-anchor biosynthesis.</h3>
+                <span class="vote-buttons" data-g="O95427" data-a="FUNCTION: PIGN transfers ethanolamine phosphate from phospha..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                            mannose-ethanolamine phosphotransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGN/PIGN-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Ethanolamine phosphate transferase that catalyzes an ethanolamine phosphate (EtNP) transfer from phosphatidylethanolamine</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGN/PIGN-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            Reactome:R-HSA-162798
+
+                        </span>
+
+                        <div class="finding-text">a phosphoethanolamine group is transferred from phosphatidylethanolamine onto the first mannose of the GPI precursor</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162710
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Synthesis of glycosylphosphatidylinositol (GPI)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-162798
+
+                    </span>
+                </div>
+
+                <div class="reference-title">mannose(a1-4)glucosaminyl-acyl-PI + phosphatidylethanolamine -&gt; (ethanolamineP) mannose(al1-4)glucosaminyl-acyl-PI + diacylglycerol</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGN/PIGN-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt entry O95427 (PIGN_HUMAN), GPI ethanolamine phosphate transferase 1</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGN-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O95427" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pign-review-notes">PIGN review notes</h1>
+<p>Gene: PIGN (HGNC:8967), UniProt O95427, human (NCBITaxon:9606)<br />
+Product name: GPI ethanolamine phosphate transferase 1 (GPI-ET-I / GPI-ethanolamine transferase I / PIG-N / MCD4 homolog)</p>
+<h2 id="verified-biology-grounded-in-pign-uniprottxt-goa-cached-reactomepmid">Verified biology (grounded in PIGN-uniprot.txt, GOA, cached Reactome/PMID)</h2>
+<p>PIGN is an <strong>ethanolamine phosphate (EtNP) transferase</strong> of the ER that acts in<br />
+glycosylphosphatidylinositol (GPI) anchor biosynthesis. It transfers ethanolamine<br />
+phosphate from phosphatidylethanolamine (PE) onto the <strong>2-OH of the first<br />
+(alpha-1,4-linked) mannose</strong> of the GPI intermediate.</p>
+<p>UniProt FUNCTION [file:human/PIGN/PIGN-uniprot.txt]:<br />
+"Ethanolamine phosphate transferase that catalyzes an ethanolamine phosphate (EtNP)<br />
+transfer from phosphatidylethanolamine (PE) to the 2-OH position of the first<br />
+alpha-1,4-linked mannose ... participates in the eighth step of the<br />
+glycosylphosphatidylinositol-anchor biosynthesis (By similarity)."</p>
+<ul>
+<li>Family: "Belongs to the PIGG/PIGN/PIGO family. PIGN subfamily." — the three human<br />
+  paralogs each add EtNP to a different mannose (PIGN → Man1; PIGO → Man3, the bridging<br />
+  EtNP that links the anchor to protein; PIGG → Man2).</li>
+<li>PATHWAY: "Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor biosynthesis."<br />
+  (UniPathway UPA00196).</li>
+<li>Localization: "Endoplasmic reticulum membrane ... Multi-pass membrane protein"; the<br />
+  UniProt topology has 13 TM helices (multi-pass ER membrane protein), consistent with<br />
+  ER membrane (GO:0005789).</li>
+<li>MCAHS1: "Multiple congenital anomalies-hypotonia-seizures syndrome 1 (MCAHS1)<br />
+  [MIM:614080]" — autosomal recessive; neonatal hypotonia, seizures, dysmorphism,<br />
+  congenital anomalies (PubMed:21493957, variant R709Q).</li>
+<li>A secondary/moonlighting claim: "May act as suppressor of replication stress and<br />
+  chromosome missegregation (PubMed:23446422)." This is a screen-derived observation,<br />
+  not the core evolved GPI-biosynthesis function.</li>
+</ul>
+<h2 id="goa-mf-term-exact-current-term-to-use">GOA MF term (exact current term to use)</h2>
+<p>GOA (genes/human/PIGN/PIGN-goa.tsv) carries the MF as:<br />
+- <strong>GO:0051377 "mannose-ethanolamine phosphotransferase activity"</strong> (verified current,<br />
+  MF aspect, not obsolete via QuickGO). This is the exact term used in core_functions.</p>
+<p>Core BP: GO:0006506 "GPI anchor biosynthetic process" (verified current, BP aspect).<br />
+Core CC: GO:0005789 "endoplasmic reticulum membrane" (verified current, CC aspect).</p>
+<h2 id="reactome">Reactome</h2>
+<ul>
+<li>R-HSA-162710 "Synthesis of glycosylphosphatidylinositol (GPI)" — pathway; TAS<br />
+  support for GO:0006506.</li>
+<li>R-HSA-162798 "mannose(a1-4)glucosaminyl-acyl-PI + phosphatidylethanolamine -&gt;<br />
+  (ethanolamineP) mannose(al1-4)glucosaminyl-acyl-PI + diacylglycerol" — the specific<br />
+  EtNP-transfer reaction (sixth step of GPI synthesis per Reactome; UniProt calls it the<br />
+  eighth step under a finer-grained numbering). Supports the EtNP-transferase MF and ER<br />
+  membrane CC. Reactome summary: "a phosphoethanolamine group is transferred from<br />
+  phosphatidylethanolamine onto the first mannose of the GPI precursor."</li>
+</ul>
+<h2 id="annotation-by-annotation-decisions">Annotation-by-annotation decisions</h2>
+<p>Total GOA lines: 16 (rows 2-18 of TSV).</p>
+<p>MF GO:0051377 (IBA, IEA-InterPro, ISS, TAS-Reactome) — core catalytic activity; ACCEPT all.<br />
+MF GO:0016740 transferase activity (IEA InterPro) — correct parent, less informative;<br />
+  MARK_AS_OVER_ANNOTATED (redundant with the specific GO:0051377).<br />
+BP GO:0006506 (IBA, IEA, TAS, ISS) — core biological process; ACCEPT all.<br />
+CC GO:0005789 ER membrane (IBA is_active_in, IEA, ISS, TAS) — correct core location; ACCEPT all.<br />
+CC GO:0016020 membrane (IEA InterPro; HDA proteomics PMID:19946888) — true but generic;<br />
+  MARK_AS_OVER_ANNOTATED (subsumed by ER membrane; HDA is a bulk membrane-proteome MS study).<br />
+CC GO:0005829 cytosol (IDA HPA) — PIGN is a multi-pass ER membrane protein; a soluble<br />
+  cytosolic pool is not its site of function. HPA IF can pick up antibody background /<br />
+  over-expression signal. MARK_AS_OVER_ANNOTATED (do not REMOVE an IDA per policy).<br />
+CC GO:0005886 plasma membrane (IDA HPA) — likewise not PIGN's functional site; PIGN acts<br />
+  in the ER lumen/membrane, not the PM. MARK_AS_OVER_ANNOTATED.</p>
+<h2 id="references">References</h2>
+<ul>
+<li>file:human/PIGN/PIGN-uniprot.txt — UniProt O95427 (FUNCTION, PATHWAY, SUBCELLULAR<br />
+  LOCATION, DISEASE, SIMILARITY). Grounds MF/BP/CC and MCAHS1.</li>
+<li>Reactome R-HSA-162710, R-HSA-162798 (titles left exactly as fetched).</li>
+<li>PMID:19946888 — NK-cell membrane proteome MS; abstract-only; supports generic membrane<br />
+  detection (HDA), not ER-specific localization.</li>
+<li>GO_REF:0000002/0000024/0000033/0000052/0000120 — standard pipeline references.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O95427
+gene_symbol: PIGN
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PIGN (GPI ethanolamine phosphate transferase 1; GPI-ET-I) is a multi-pass
+  endoplasmic reticulum membrane protein that acts in glycosylphosphatidylinositol
+  (GPI) anchor biosynthesis. It transfers ethanolamine phosphate from
+  phosphatidylethanolamine onto the 2-OH of the first alpha-1,4-linked mannose of
+  the GPI intermediate, one of three ethanolamine phosphate additions to the trimannosyl
+  core (PIGN acts on mannose 1; the paralogs PIGO and PIGG act on mannoses 3 and 2).
+  PIGN belongs to the PIGG/PIGN/PIGO family and localizes to the ER membrane, where the
+  later steps of GPI assembly occur. Biallelic loss-of-function variants cause multiple
+  congenital anomalies-hypotonia-seizures syndrome 1 (MCAHS1), an autosomal recessive
+  disorder of GPI-anchor biosynthesis characterized by neonatal hypotonia, seizures,
+  dysmorphic features, and congenital anomalies.
+existing_annotations:
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      PIGN is a multi-pass ER membrane protein that carries out the ethanolamine
+      phosphate transfer step of GPI-anchor biosynthesis in the ER; this phylogenetic
+      (IBA) location annotation reflects the correct site of action and is a core
+      localization.
+    action: ACCEPT
+    reason: &gt;-
+      UniProt records the subcellular location as ER membrane (multi-pass membrane
+      protein), consistent with the whole GPI-biosynthetic machinery residing in the
+      ER, and the topology has 13 predicted transmembrane helices. This IBA is well
+      supported and represents where PIGN functions.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Endoplasmic reticulum membrane
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Multi-pass membrane protein
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      PIGN participates in GPI-anchor biosynthesis, transferring ethanolamine phosphate
+      onto the first mannose of the GPI intermediate. This phylogenetic annotation
+      captures the core biological process.
+    action: ACCEPT
+    reason: &gt;-
+      The UniProt PATHWAY line assigns PIGN to glycosylphosphatidylinositol-anchor
+      biosynthesis, and its FUNCTION describes participation in a defined step of GPI
+      biosynthesis. The IBA is consistent across orthologs (yeast MCD4, mouse Pign) and
+      represents a core process.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        participates in the eighth step of the
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      This is PIGN&#39;s core molecular function: transfer of ethanolamine phosphate from
+      phosphatidylethanolamine onto a mannose of the GPI intermediate. The phylogenetic
+      annotation is the correct, appropriately specific catalytic term.
+    action: ACCEPT
+    reason: &gt;-
+      UniProt describes PIGN as an ethanolamine phosphate transferase that transfers
+      EtNP from PE to the 2-OH of the first alpha-1,4-linked mannose of the GPI
+      intermediate. GO:0051377 (mannose-ethanolamine phosphotransferase activity) is the
+      exact catalytic term and is well conserved across the PIGN orthologs used for the
+      IBA.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Ethanolamine phosphate transferase that catalyzes an
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        ethanolamine phosphate (EtNP) transfer from phosphatidylethanolamine
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        the first alpha-1,4-linked mannose
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (InterPro/SubCell) annotation placing PIGN in the ER membrane; agrees
+      with the curated UniProt location and the IBA.
+    action: ACCEPT
+    reason: &gt;-
+      The InterPro signatures (IPR007070 GPI EtNP transferase 1, IPR017852) and
+      UniProtKB-SubCell SL-0097 map to ER membrane, matching PIGN&#39;s curated location as
+      a multi-pass ER membrane protein.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Endoplasmic reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic annotation assigning PIGN to GPI-anchor biosynthesis via InterPro and
+      UniPathway; consistent with the curated pathway and the IBA/TAS.
+    action: ACCEPT
+    reason: &gt;-
+      InterPro GPI EtNP-transferase signatures and UniPathway UPA00196
+      (glycosylphosphatidylinositol-anchor biosynthesis) correctly place PIGN in this
+      core process.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Generic InterPro-derived membrane localization. True but uninformative given the
+      more specific ER membrane annotation that pinpoints where PIGN acts.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      PIGN is a multi-pass membrane protein, so a bare &#39;membrane&#39; term is not wrong, but
+      it is subsumed by the more specific and functionally correct GO:0005789 ER
+      membrane annotation. The specific term should carry the localization.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Multi-pass membrane protein
+- term:
+    id: GO:0016740
+    label: transferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Generic InterPro parent term for PIGN&#39;s transferase activity. Correct but far less
+      informative than the specific mannose-ethanolamine phosphotransferase activity.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      GO:0016740 is a high-level ancestor of PIGN&#39;s actual catalytic term GO:0051377.
+      It is not wrong, but the specific EtNP-transferase term should represent the
+      molecular function; the parent adds no additional information.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Ethanolamine phosphate transferase that catalyzes an
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic (InterPro) assignment of PIGN&#39;s specific catalytic activity, matching
+      the IBA/ISS/TAS and the curated UniProt function.
+    action: ACCEPT
+    reason: &gt;-
+      InterPro GPI EtNP-transferase 1 signatures (IPR007070, IPR037671) correctly
+      predict the mannose-ethanolamine phosphotransferase activity that is PIGN&#39;s core
+      molecular function.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        ethanolamine phosphate (EtNP) transfer from phosphatidylethanolamine
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162710
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author annotation placing PIGN in the human GPI synthesis
+      pathway. Consistent with the core biological process.
+    action: ACCEPT
+    reason: &gt;-
+      Reactome pathway R-HSA-162710 (Synthesis of glycosylphosphatidylinositol) includes
+      the EtNP-transfer reaction catalyzed by PIGN as one step of GPI-anchor biosynthesis;
+      this is a well-established core process annotation.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162710
+      supporting_text: &gt;-
+        GPI is synthesized in the endoplasmic reticulum
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      HPA immunofluorescence-based cytosolic localization. PIGN is a multi-pass ER
+      membrane protein that functions on the lumenal/ER-membrane face during GPI
+      assembly; a cytosolic pool is not its site of function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      This is a high-throughput HPA IF annotation. PIGN&#39;s curated location is the ER
+      membrane, and its 13-TM topology and role in GPI-anchor synthesis place its
+      activity in the ER, not the bulk cytosol. A cytosolic signal most likely reflects
+      antibody background or over-expression and is not the functional site. Retained
+      (not removed) per policy, but flagged as over-annotated relative to the ER
+      localization.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Endoplasmic reticulum membrane
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      HPA immunofluorescence-based plasma membrane localization. PIGN acts in the ER
+      membrane during GPI-anchor biosynthesis; the plasma membrane is where mature
+      GPI-anchored proteins end up, not where PIGN itself functions.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      A plasma-membrane signal for an ER-resident biosynthetic enzyme is not its
+      functional location. This HPA IF annotation likely reflects staining of the
+      broader secretory/membrane compartment or antibody cross-reactivity; PIGN&#39;s
+      curated and functional location is the ER membrane. Retained (not removed) per
+      policy, but marked over-annotated.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Endoplasmic reticulum membrane
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Sequence-similarity transfer of the ER membrane location from the mouse ortholog
+      (Q9R1S3). Matches the curated location and other evidence.
+    action: ACCEPT
+    reason: &gt;-
+      ISS from mouse Pign (UniProtKB:Q9R1S3) correctly assigns the ER membrane location;
+      this is PIGN&#39;s core site of action and is corroborated by IBA, IEA, and TAS
+      evidence.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Endoplasmic reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Sequence-similarity transfer of the GPI-anchor biosynthetic process from mouse
+      Pign. Consistent with PIGN&#39;s core role.
+    action: ACCEPT
+    reason: &gt;-
+      ISS from mouse Pign (UniProtKB:Q9R1S3) assigns the GPI-anchor biosynthetic process,
+      matching the curated pathway and PIGN&#39;s function as the EtNP transferase for the
+      first mannose.
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        participates in the eighth step of the
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-similarity transfer of the EtNP-transferase activity from mouse Pign;
+      this is PIGN&#39;s core molecular function and the UniProt EC/catalytic-activity block
+      is itself inferred by similarity to the mouse enzyme.
+    action: ACCEPT
+    reason: &gt;-
+      ISS from mouse Pign (UniProtKB:Q9R1S3) assigns mannose-ethanolamine
+      phosphotransferase activity, matching PIGN&#39;s curated catalytic activity (EtNP
+      transfer from PE to the first mannose of the GPI intermediate).
+    supported_by:
+    - reference_id: file:human/PIGN/PIGN-uniprot.txt
+      supporting_text: &gt;-
+        Ethanolamine phosphate transferase that catalyzes an
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162798
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reactome traceable-author annotation of the specific EtNP-transfer reaction
+      catalyzed by PIGN (phosphoethanolamine from PE onto the first mannose of the GPI
+      precursor). Directly supports the core molecular function.
+    action: ACCEPT
+    reason: &gt;-
+      Reactome reaction R-HSA-162798 describes the transfer of a phosphoethanolamine
+      group from phosphatidylethanolamine onto the first mannose of the GPI precursor,
+      the reaction PIGN catalyzes, mapping to GO:0051377.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162798
+      supporting_text: &gt;-
+        a phosphoethanolamine group is transferred from phosphatidylethanolamine onto
+        the first mannose of the GPI precursor
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput mass-spectrometry detection of PIGN in an NK-cell membrane
+      proteome. Confirms PIGN is a membrane protein but gives only a generic membrane
+      location, not its functional ER-membrane site.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The cited study is a bulk membrane-proteome MS survey of the YTS NK-like cell line
+      that identified ~1843 proteins; detection in a crude membrane fraction supports
+      only a generic &#39;membrane&#39; term and is subsumed by the specific ER membrane
+      annotation that reflects where PIGN acts.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: &gt;-
+        Mass spectrometric analysis identified 1843 proteins with high confidence scores.
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-162798
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Reactome traceable-author annotation placing the PIGN-catalyzed EtNP-transfer
+      reaction in the ER. Consistent with the core localization.
+    action: ACCEPT
+    reason: &gt;-
+      Reactome annotates GPI synthesis, including the PIGN reaction R-HSA-162798, as
+      occurring in the endoplasmic reticulum, matching PIGN&#39;s curated ER membrane
+      location.
+    supported_by:
+    - reference_id: Reactome:R-HSA-162710
+      supporting_text: &gt;-
+        GPI is synthesized in the endoplasmic reticulum
+core_functions:
+- description: &gt;-
+    PIGN transfers ethanolamine phosphate from phosphatidylethanolamine onto the 2-OH of
+    the first alpha-1,4-linked mannose of the GPI intermediate in the ER membrane, an
+    essential step of glycosylphosphatidylinositol-anchor biosynthesis.
+  molecular_function:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: file:human/PIGN/PIGN-uniprot.txt
+    supporting_text: &gt;-
+      Ethanolamine phosphate transferase that catalyzes an ethanolamine phosphate (EtNP)
+      transfer from phosphatidylethanolamine
+  - reference_id: file:human/PIGN/PIGN-uniprot.txt
+    supporting_text: &gt;-
+      Glycolipid biosynthesis; glycosylphosphatidylinositol-anchor
+  - reference_id: Reactome:R-HSA-162798
+    supporting_text: &gt;-
+      a phosphoethanolamine group is transferred from phosphatidylethanolamine onto the
+      first mannose of the GPI precursor
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Bulk NK-cell membrane-proteome MS study; supports only generic membrane detection
+      of PIGN (HDA), not its functional ER-membrane localization.
+- id: Reactome:R-HSA-162710
+  title: Synthesis of glycosylphosphatidylinositol (GPI)
+  findings: []
+- id: Reactome:R-HSA-162798
+  title: mannose(a1-4)glucosaminyl-acyl-PI + phosphatidylethanolamine -&gt; (ethanolamineP)
+    mannose(al1-4)glucosaminyl-acyl-PI + diacylglycerol
+  findings: []
+- id: file:human/PIGN/PIGN-uniprot.txt
+  title: UniProt entry O95427 (PIGN_HUMAN), GPI ethanolamine phosphate transferase 1
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PIGO/PIGO-ai-review.html
+++ b/genes/human/PIGO/PIGO-ai-review.html
@@ -1,0 +1,3368 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIGO - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PIGO</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q8TEQ8" target="_blank" class="term-link">
+                        Q8TEQ8
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PIGO";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q8TEQ8" data-a="DESCRIPTION: PIGO is the catalytic subunit of the GPI ethanolam..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PIGO is the catalytic subunit of the GPI ethanolamine phosphate transferase 3 complex (GPI-ET-III), an endoplasmic reticulum membrane multi-pass enzyme in the glycosylphosphatidylinositol (GPI) anchor biosynthetic pathway. It transfers a bridging ethanolamine phosphate (EtNP), derived from phosphatidylethanolamine, onto the 6-OH of the third mannose of the GPI intermediate; this is the EtNP through which the mature protein&#39;s C-terminus is ultimately joined to the anchor by the GPI transamidase. PIGO functions together with the accessory subunit PIGF, which is required to stabilise it, and it catalyses the tenth step of the eleven-step core GPI assembly on the ER membrane. Biallelic loss-of-function of PIGO causes hyperphosphatasia with impaired intellectual development syndrome 2 (HPMRS2 / Mabry syndrome), characterised by developmental delay, seizures, brachytelephalangy, and elevated serum alkaline phosphatase.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGO acts as a multi-pass ER membrane enzyme; the core GPI is assembled on the ER membrane. IBA localization is consistent with UniProt (ISS from mouse ortholog) and the pathway literature.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The phylogenetically inferred ER membrane localization matches the experimental and homology-based evidence and the known site of GPI biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The core GPI is assembled on the endoplasmic reticulum (ER) membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0006506" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PIGO catalyses step 10 of the eleven core reactions of GPI-anchor biosynthesis, transferring the bridging ethanolamine phosphate to the third mannose. Core biological process for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by the biosynthetic role established in the literature and UniProt pathway annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Two EtNPs are sequentially transferred to the 6-positions of Man3 and then Man2 by PIGO</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the tenth step of the glycosylphosphatidylinositol-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0051377" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the precise molecular function of PIGO (GPI-ET-III) - transfer of ethanolamine phosphate to a mannose residue of the GPI lipid precursor (the third mannose). Represents the core catalytic activity of the gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0051377 is defined as catalysis of transfer of ethanolamine phosphate to a mannose residue in the GPI lipid precursor, exactly matching PIGO&#39;s characterized reaction; the IBA is concordant with UniProt (IMP) and the pathway literature.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Two EtNPs are sequentially transferred to the 6-positions of Man3 and then Man2 by PIGO</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">transfers an ethanolamine phosphate (EtNP) from a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCellular Location mapping to ER membrane; consistent with the multi-pass ER membrane topology and the ER site of GPI assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization; concordant with the IBA, ISS and NAS ER membrane annotations.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0006506" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (ARBA/InterPro/UniPathway) assignment to GPI-anchor biosynthesis, matching PIGO&#39;s role in the core GPI assembly pathway.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core process; agrees with experimental (IMP) and phylogenetic (IBA) annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the tenth step of the glycosylphosphatidylinositol-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016772" target="_blank" class="term-link">
+                                    GO:0016772
+                                </a>
+                            </span>
+                            <span class="term-label">transferase activity, transferring phosphorus-containing groups</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0016772" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro2GO mapping to a very high-level transferase parent term. Not wrong (PIGO does transfer a phosphorus-containing EtNP group), but far less informative than the specific GO:0051377 that is already annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0016772 is a broad ancestor of the specific molecular function GO:0051377 (mannose-ethanolamine phosphotransferase activity) already captured; the specific term should represent the molecular function, so the generic parent is redundant/over-general.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">transfers an ethanolamine phosphate (EtNP) from a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0051377" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automated (ARBA/InterPro) assignment of the correct specific molecular function of PIGO.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matches PIGO&#39;s characterized catalytic activity and the IBA/IMP annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">transfers an ethanolamine phosphate (EtNP) from a</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0005789" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ER membrane localization transferred by sequence similarity from the mouse ortholog (UniProtKB:Q9JJI6). Consistent with all other localization evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct localization supported by ortholog data and the ER site of GPI biosynthesis.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24417746" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24417746
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIGO mutations in intractable epilepsy and severe developmen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0006506" data-r="PMID:24417746" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Patient PIGO mutations (compound heterozygous, including T130N) cause GPI deficiency with reduced cell-surface GPI-anchored proteins, demonstrating PIGO&#39;s involvement in GPI-anchor biosynthesis. The T130N variant decreases mannose-ethanolamine phosphotransferase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Loss-of-function variants impairing GPI-AP expression establish PIGO&#39;s role in the GPI-anchor biosynthetic process; corroborated by UniProt variant/functional annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24417746" target="_blank" class="term-link">
+                                        PMID:24417746
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Our findings therefore expand the clinical spectrum of</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">decrease in mannose-ethanolamine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28337824" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28337824
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phenotype-genotype correlations of PIGO deficiency with vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0006506" data-r="PMID:28337824" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genotype-phenotype study of PIGO deficiency using a PIGO-deficient cell line and functional assays; multiple patient variants reduce activity and GPI-AP surface expression, confirming PIGO&#39;s role in GPI-anchor biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Functional analyses in a PIGO-deficient cell line link PIGO loss to defective GPI biosynthesis; concordant with UniProt catalytic/variant annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28337824" target="_blank" class="term-link">
+                                        PMID:28337824
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIGO deficiency shows characteristic features, such as Hirschsprung disease,</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">decrease in mannose-ethanolamine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24417746" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24417746
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PIGO mutations in intractable epilepsy and severe developmen...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0051377" data-r="PMID:24417746" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The PIGO T130N patient variant decreases mannose-ethanolamine phosphotransferase activity, providing experimental (mutation) support that PIGO enables this molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Variant-based functional evidence for PIGO&#39;s characterized catalytic activity (transfer of EtNP to the GPI mannose); the enzyme is the source (ECO:0000305) of the UniProt catalytic-activity annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">decrease in mannose-ethanolamine</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24417746" target="_blank" class="term-link">
+                                        PMID:24417746
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Our findings therefore expand the clinical spectrum of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28337824" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28337824
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phenotype-genotype correlations of PIGO deficiency with vari...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0051377" data-r="PMID:28337824" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Functional analysis of multiple HPMRS2 PIGO variants (e.g. R119W, M344K, N370S, K1047E) in a PIGO-deficient cell line shows decreased mannose-ethanolamine phosphotransferase activity, supporting PIGO&#39;s catalytic function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directed mutagenesis / patient-variant activity assays demonstrate PIGO enables the specific EtNP-transferase activity; concordant with UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">decrease in mannose-ethanolamine</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28337824" target="_blank" class="term-link">
+                                        PMID:28337824
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">functional analysis</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24049131" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24049131
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Vitamin B6-responsive epilepsy due to inherited GPI deficien...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0006506" data-r="PMID:24049131" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Inherited GPI deficiency due to PIGO mutation (R119W), presenting as vitamin B6-responsive epilepsy; loss of PIGO function impairs GPI-anchor biosynthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Patient loss-of-function evidence establishes PIGO&#39;s involvement in the GPI-anchor biosynthetic process; the R119W variant decreases EtNP-transferase activity per UniProt.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24049131" target="_blank" class="term-link">
+                                        PMID:24049131
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vitamin B6-responsive epilepsy due to inherited GPI deficiency</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">decrease in mannose-ethanolamine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32156170
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Biosynthesis and biology of mammalian GPI-anchored proteins.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0005789" data-r="PMID:32156170" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The GPI biosynthesis review (basis for ComplexPortal CPX-2679) places core GPI assembly, including the PIGO/PIGF EtNP-transferase III complex, on the ER membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Author statement consistent with all other ER membrane evidence and the known site of GPI assembly.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                        PMID:32156170
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The core GPI is assembled on the endoplasmic reticulum (ER) membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                                    GO:0051377
+                                </a>
+                            </span>
+                            <span class="term-label">mannose-ethanolamine phosphotransferase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24049131" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24049131
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Vitamin B6-responsive epilepsy due to inherited GPI deficien...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0051377" data-r="PMID:24049131" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The PIGO R119W patient variant decreases mannose-ethanolamine phosphotransferase activity, supporting that PIGO enables this molecular function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Variant functional evidence for PIGO&#39;s specific catalytic activity; concordant with UniProt catalytic-activity annotation (ECO:0000305 from this paper).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">decrease in mannose-ethanolamine</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24049131" target="_blank" class="term-link">
+                                        PMID:24049131
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vitamin B6-responsive epilepsy due to inherited GPI deficiency</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput MS identification of PIGO in the NK-cell (YTS) membrane proteome. Correct that PIGO is a membrane protein, but &#34;membrane&#34; is an uninformative generic parent of the specific ER membrane localization already annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0016020 is a high-level ancestor of GO:0005789 (endoplasmic reticulum membrane); the specific ER membrane term better represents PIGO&#39;s localization, and the proteomics hit does not distinguish sub-membrane compartment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                                        PMID:19946888
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">approximately 40% of the identified proteins were predicted as plausible membrane proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                    GO:0006506
+                                </a>
+                            </span>
+                            <span class="term-label">GPI anchor biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8TEQ8" data-a="GO:0006506" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GPI-anchor biosynthesis role transferred by sequence similarity from the mouse ortholog (UniProtKB:Q9JJI6). Core process for PIGO.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct core biological process; concordant with experimental (IMP), automated (IEA) and phylogenetic (IBA) annotations to the same term.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIGO/PIGO-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">participates in the tenth step of the glycosylphosphatidylinositol-</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Catalytic subunit of GPI ethanolamine phosphate transferase III (GPI-ET-III); transfers the bridging ethanolamine phosphate from phosphatidylethanolamine onto the third mannose of the GPI intermediate (the protein-attachment EtNP), acting with the accessory subunit PIGF.</h3>
+                <span class="vote-buttons" data-g="Q8TEQ8" data-a="FUNCTION: Catalytic subunit of GPI ethanolamine phosphate tr..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051377" target="_blank" class="term-link">
+                            mannose-ethanolamine phosphotransferase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006506" target="_blank" class="term-link">
+                                GPI anchor biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                                PMID:32156170
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Two EtNPs are sequentially transferred to the 6-positions of Man3 and then Man2 by PIGO</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIGO/PIGO-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">transfers an ethanolamine phosphate (EtNP) from a</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24049131" target="_blank" class="term-link">
+                            PMID:24049131
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Vitamin B6-responsive epilepsy due to inherited GPI deficiency.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24417746" target="_blank" class="term-link">
+                            PMID:24417746
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PIGO mutations in intractable epilepsy and severe developmental delay with mild elevation of alkaline phosphatase levels.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28337824" target="_blank" class="term-link">
+                            PMID:28337824
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phenotype-genotype correlations of PIGO deficiency with variable phenotypes from infantile lethality to mild learning difficulties.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32156170" target="_blank" class="term-link">
+                            PMID:32156170
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Biosynthesis and biology of mammalian GPI-anchored proteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIGO/PIGO-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB entry Q8TEQ8 (PIGO_HUMAN), GPI ethanolamine phosphate transferase 3, catalytic subunit</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIGO-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8TEQ8" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pigo-q8teq8-curation-notes">PIGO (Q8TEQ8) — curation notes</h1>
+<p>Human PIGO, HGNC:23215, UniProtKB Q8TEQ8. GPI ethanolamine phosphate transferase 3,<br />
+catalytic subunit ("PIG-O", GPI-ET-III). NCBITaxon:9606.</p>
+<p>No deep-research file: falcon provider is out of credits (HTTP 402). Review grounded in<br />
+the UniProt record, the seeded GOA, and cached publications.</p>
+<h2 id="verified-biology">Verified biology</h2>
+<ul>
+<li><strong>Function / MF.</strong> PIGO is the catalytic subunit of the GPI ethanolamine phosphate<br />
+  transferase 3 complex. It transfers a <strong>bridging ethanolamine phosphate (EtNP) from<br />
+  phosphatidylethanolamine (PE) onto the 6-OH of the third mannose (Man3)</strong> of the GPI<br />
+  intermediate. This is the EtNP to which the mature protein's C-terminus is ultimately<br />
+  attached by the GPI transamidase (the "protein-attachment" EtNP).</li>
+<li>UniProt FUNCTION: "transfers an ethanolamine phosphate (EtNP) from a<br />
+    phosphatidylethanolamine (PE) to the 6-OH position of the third alpha-1,2-linked<br />
+    mannose ... participates in the tenth step of the glycosylphosphatidylinositol-anchor<br />
+    biosynthesis" [file:human/PIGO/PIGO-uniprot.txt].</li>
+<li>Kinoshita review: "Two EtNPs are sequentially transferred to the 6-positions of Man3<br />
+    and then Man2 by PIGO [46] and PIGG (initially termed GPI7) [67]"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/32156170">PMID:32156170</a>. Table 2 lists PIGO at step 10 as "GPI-ETIII, catalytic".</li>
+<li>
+<p>GO:0051377 "mannose-ethanolamine phosphotransferase activity" def = "Catalysis of the<br />
+    transfer of ethanolamine phosphate to a mannose residue in the GPI lipid precursor" —<br />
+    exact match. This is the GOA MF term (IBA + IEA + 3 IMP).</p>
+</li>
+<li>
+<p><strong>Complex / accessory subunit.</strong> PIGO acts with PIGF, which stabilises it. UniProt<br />
+  SUBUNIT: "Part of the ethanolamine phosphate transferase 3 complex composed by PIGO and<br />
+  PIGF ... PIGF is required to stabilize PIGO" [file:human/PIGO/PIGO-uniprot.txt].<br />
+  Kinoshita: "Both PIGO and PIGG are stabilized by association with PIGF" <a href="https://pubmed.ncbi.nlm.nih.gov/32156170">PMID:32156170</a>.<br />
+  ComplexPortal CPX-2679 = "Glycosylphosphatidylinsitol ethanolamine-phosphate transferase<br />
+  III complex".</p>
+</li>
+<li>
+<p><strong>Localization.</strong> ER membrane, multi-pass. "The core GPI is assembled on the<br />
+  endoplasmic reticulum (ER) membrane" <a href="https://pubmed.ncbi.nlm.nih.gov/32156170">PMID:32156170</a>. UniProt SUBCELLULAR LOCATION:<br />
+  "Endoplasmic reticulum membrane ... Multi-pass membrane protein". 14 predicted TM<br />
+  helices. ISS from mouse ortholog Q9JJI6.</p>
+</li>
+<li>
+<p><strong>Disease.</strong> Biallelic loss-of-function causes Hyperphosphatasia with impaired<br />
+  intellectual development syndrome 2 (HPMRS2 / Mabry syndrome; MIM 614749); phenotype<br />
+  spans infantile lethality → mild learning difficulties, with seizures, developmental<br />
+  delay, brachytelephalangy, elevated serum ALP. Patient variants (R119W, T130N, M344K,<br />
+  N370S, K1047E) reduce mannose-ethanolamine phosphotransferase activity in functional<br />
+  assays [file:human/PIGO/PIGO-uniprot.txt VARIANT notes; PMID:24417746, PMID:28337824,<br />
+  PMID:24049131].</p>
+</li>
+</ul>
+<h2 id="goa-annotation-summary-19-lines">GOA annotation summary (19 lines)</h2>
+<ul>
+<li>MF GO:0051377 mannose-ethanolamine phosphotransferase activity: IBA + IEA + 3×IMP → all<br />
+  ACCEPT (exact function; IMPs backed by variant activity assays + UniProt EC/305 sourcing).</li>
+<li>MF GO:0016772 transferase activity, transferring phosphorus-containing groups (IEA,<br />
+  InterPro): correct but a very high-level parent of GO:0051377 → MARK_AS_OVER_ANNOTATED.</li>
+<li>BP GO:0006506 GPI anchor biosynthetic process: IBA + IEA + 2×IMP + ISS → all ACCEPT<br />
+  (core process). One extra IMP (PMID:24049131) also ACCEPT.</li>
+<li>CC GO:0005789 endoplasmic reticulum membrane: IBA + IEA + 2×ISS + NAS → all ACCEPT.</li>
+<li>CC GO:0016020 membrane (HDA, PMID:19946888, NK-cell membrane proteome MS): true but<br />
+  uninformative parent of ER membrane → MARK_AS_OVER_ANNOTATED.</li>
+</ul>
+<h2 id="core-functions">Core functions</h2>
+<ol>
+<li>MF GO:0051377 mannose-ethanolamine phosphotransferase activity (GPI-ET-III; adds<br />
+   bridging EtNP to Man3).</li>
+<li>directly involved in BP GO:0006506 GPI anchor biosynthetic process (step 10 of 11).</li>
+<li>located in CC GO:0005789 endoplasmic reticulum membrane.</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q8TEQ8
+gene_symbol: PIGO
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: PIGO is the catalytic subunit of the GPI ethanolamine phosphate transferase
+  3 complex (GPI-ET-III), an endoplasmic reticulum membrane multi-pass enzyme in the
+  glycosylphosphatidylinositol (GPI) anchor biosynthetic pathway. It transfers a bridging
+  ethanolamine phosphate (EtNP), derived from phosphatidylethanolamine, onto the 6-OH
+  of the third mannose of the GPI intermediate; this is the EtNP through which the
+  mature protein&#39;s C-terminus is ultimately joined to the anchor by the GPI transamidase.
+  PIGO functions together with the accessory subunit PIGF, which is required to stabilise
+  it, and it catalyses the tenth step of the eleven-step core GPI assembly on the ER
+  membrane. Biallelic loss-of-function of PIGO causes hyperphosphatasia with impaired
+  intellectual development syndrome 2 (HPMRS2 / Mabry syndrome), characterised by
+  developmental delay, seizures, brachytelephalangy, and elevated serum alkaline
+  phosphatase.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q8TEQ8-1
+- name: &#39;2&#39;
+  id: Q8TEQ8-2
+  sequence_note: VSP_003944
+existing_annotations:
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: PIGO acts as a multi-pass ER membrane enzyme; the core GPI is assembled
+      on the ER membrane. IBA localization is consistent with UniProt (ISS from mouse
+      ortholog) and the pathway literature.
+    action: ACCEPT
+    reason: The phylogenetically inferred ER membrane localization matches the experimental
+      and homology-based evidence and the known site of GPI biosynthesis.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: The core GPI is assembled on the endoplasmic reticulum (ER)
+        membrane
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: PIGO catalyses step 10 of the eleven core reactions of GPI-anchor biosynthesis,
+      transferring the bridging ethanolamine phosphate to the third mannose. Core biological
+      process for this gene.
+    action: ACCEPT
+    reason: Directly supported by the biosynthetic role established in the literature
+      and UniProt pathway annotation.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: Two EtNPs are sequentially transferred to the 6-positions of
+        Man3 and then Man2 by PIGO
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: participates in the tenth step of the glycosylphosphatidylinositol-
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: This is the precise molecular function of PIGO (GPI-ET-III) - transfer
+      of ethanolamine phosphate to a mannose residue of the GPI lipid precursor (the
+      third mannose). Represents the core catalytic activity of the gene.
+    action: ACCEPT
+    reason: GO:0051377 is defined as catalysis of transfer of ethanolamine phosphate
+      to a mannose residue in the GPI lipid precursor, exactly matching PIGO&#39;s characterized
+      reaction; the IBA is concordant with UniProt (IMP) and the pathway literature.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: Two EtNPs are sequentially transferred to the 6-positions of
+        Man3 and then Man2 by PIGO
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: transfers an ethanolamine phosphate (EtNP) from a
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: UniProt SubCellular Location mapping to ER membrane; consistent with the
+      multi-pass ER membrane topology and the ER site of GPI assembly.
+    action: ACCEPT
+    reason: Correct localization; concordant with the IBA, ISS and NAS ER membrane
+      annotations.
+    supported_by:
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: involved_in
+  review:
+    summary: Automated (ARBA/InterPro/UniPathway) assignment to GPI-anchor biosynthesis,
+      matching PIGO&#39;s role in the core GPI assembly pathway.
+    action: ACCEPT
+    reason: Correct core process; agrees with experimental (IMP) and phylogenetic (IBA)
+      annotations to the same term.
+    supported_by:
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: participates in the tenth step of the glycosylphosphatidylinositol-
+- term:
+    id: GO:0016772
+    label: transferase activity, transferring phosphorus-containing groups
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: InterPro2GO mapping to a very high-level transferase parent term. Not wrong
+      (PIGO does transfer a phosphorus-containing EtNP group), but far less informative
+      than the specific GO:0051377 that is already annotated.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: GO:0016772 is a broad ancestor of the specific molecular function GO:0051377
+      (mannose-ethanolamine phosphotransferase activity) already captured; the specific
+      term should represent the molecular function, so the generic parent is redundant/over-general.
+    supported_by:
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: transfers an ethanolamine phosphate (EtNP) from a
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: enables
+  review:
+    summary: Automated (ARBA/InterPro) assignment of the correct specific molecular
+      function of PIGO.
+    action: ACCEPT
+    reason: Matches PIGO&#39;s characterized catalytic activity and the IBA/IMP annotations
+      to the same term.
+    supported_by:
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: transfers an ethanolamine phosphate (EtNP) from a
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: ER membrane localization transferred by sequence similarity from the mouse
+      ortholog (UniProtKB:Q9JJI6). Consistent with all other localization evidence.
+    action: ACCEPT
+    reason: Correct localization supported by ortholog data and the ER site of GPI
+      biosynthesis.
+    supported_by:
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: Endoplasmic reticulum membrane
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:24417746
+  qualifier: involved_in
+  review:
+    summary: Patient PIGO mutations (compound heterozygous, including T130N) cause GPI
+      deficiency with reduced cell-surface GPI-anchored proteins, demonstrating PIGO&#39;s
+      involvement in GPI-anchor biosynthesis. The T130N variant decreases mannose-ethanolamine
+      phosphotransferase activity.
+    action: ACCEPT
+    reason: Loss-of-function variants impairing GPI-AP expression establish PIGO&#39;s role
+      in the GPI-anchor biosynthetic process; corroborated by UniProt variant/functional
+      annotation.
+    supported_by:
+    - reference_id: PMID:24417746
+      supporting_text: Our findings therefore expand the clinical spectrum of
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: decrease in mannose-ethanolamine
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:28337824
+  qualifier: involved_in
+  review:
+    summary: Genotype-phenotype study of PIGO deficiency using a PIGO-deficient cell
+      line and functional assays; multiple patient variants reduce activity and GPI-AP
+      surface expression, confirming PIGO&#39;s role in GPI-anchor biosynthesis.
+    action: ACCEPT
+    reason: Functional analyses in a PIGO-deficient cell line link PIGO loss to defective
+      GPI biosynthesis; concordant with UniProt catalytic/variant annotation.
+    supported_by:
+    - reference_id: PMID:28337824
+      supporting_text: PIGO deficiency shows characteristic features, such as Hirschsprung
+        disease,
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: decrease in mannose-ethanolamine
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: IMP
+  original_reference_id: PMID:24417746
+  qualifier: enables
+  review:
+    summary: The PIGO T130N patient variant decreases mannose-ethanolamine phosphotransferase
+      activity, providing experimental (mutation) support that PIGO enables this molecular
+      function.
+    action: ACCEPT
+    reason: Variant-based functional evidence for PIGO&#39;s characterized catalytic activity
+      (transfer of EtNP to the GPI mannose); the enzyme is the source (ECO:0000305) of
+      the UniProt catalytic-activity annotation.
+    supported_by:
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: decrease in mannose-ethanolamine
+    - reference_id: PMID:24417746
+      supporting_text: Our findings therefore expand the clinical spectrum of
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: IMP
+  original_reference_id: PMID:28337824
+  qualifier: enables
+  review:
+    summary: Functional analysis of multiple HPMRS2 PIGO variants (e.g. R119W, M344K,
+      N370S, K1047E) in a PIGO-deficient cell line shows decreased mannose-ethanolamine
+      phosphotransferase activity, supporting PIGO&#39;s catalytic function.
+    action: ACCEPT
+    reason: Directed mutagenesis / patient-variant activity assays demonstrate PIGO
+      enables the specific EtNP-transferase activity; concordant with UniProt.
+    supported_by:
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: decrease in mannose-ethanolamine
+    - reference_id: PMID:28337824
+      supporting_text: functional analysis
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:24049131
+  qualifier: involved_in
+  review:
+    summary: Inherited GPI deficiency due to PIGO mutation (R119W), presenting as vitamin
+      B6-responsive epilepsy; loss of PIGO function impairs GPI-anchor biosynthesis.
+    action: ACCEPT
+    reason: Patient loss-of-function evidence establishes PIGO&#39;s involvement in the
+      GPI-anchor biosynthetic process; the R119W variant decreases EtNP-transferase
+      activity per UniProt.
+    supported_by:
+    - reference_id: PMID:24049131
+      supporting_text: Vitamin B6-responsive epilepsy due to inherited GPI deficiency
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: decrease in mannose-ethanolamine
+- term:
+    id: GO:0005789
+    label: endoplasmic reticulum membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32156170
+  qualifier: located_in
+  review:
+    summary: The GPI biosynthesis review (basis for ComplexPortal CPX-2679) places core
+      GPI assembly, including the PIGO/PIGF EtNP-transferase III complex, on the ER
+      membrane.
+    action: ACCEPT
+    reason: Author statement consistent with all other ER membrane evidence and the
+      known site of GPI assembly.
+    supported_by:
+    - reference_id: PMID:32156170
+      supporting_text: The core GPI is assembled on the endoplasmic reticulum (ER)
+        membrane
+- term:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  evidence_type: IMP
+  original_reference_id: PMID:24049131
+  qualifier: enables
+  review:
+    summary: The PIGO R119W patient variant decreases mannose-ethanolamine phosphotransferase
+      activity, supporting that PIGO enables this molecular function.
+    action: ACCEPT
+    reason: Variant functional evidence for PIGO&#39;s specific catalytic activity; concordant
+      with UniProt catalytic-activity annotation (ECO:0000305 from this paper).
+    supported_by:
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: decrease in mannose-ethanolamine
+    - reference_id: PMID:24049131
+      supporting_text: Vitamin B6-responsive epilepsy due to inherited GPI deficiency
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  qualifier: located_in
+  review:
+    summary: High-throughput MS identification of PIGO in the NK-cell (YTS) membrane
+      proteome. Correct that PIGO is a membrane protein, but &#34;membrane&#34; is an uninformative
+      generic parent of the specific ER membrane localization already annotated.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: GO:0016020 is a high-level ancestor of GO:0005789 (endoplasmic reticulum
+      membrane); the specific ER membrane term better represents PIGO&#39;s localization,
+      and the proteomics hit does not distinguish sub-membrane compartment.
+    supported_by:
+    - reference_id: PMID:19946888
+      supporting_text: approximately 40% of the identified proteins were predicted as
+        plausible membrane proteins
+- term:
+    id: GO:0006506
+    label: GPI anchor biosynthetic process
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: GPI-anchor biosynthesis role transferred by sequence similarity from the
+      mouse ortholog (UniProtKB:Q9JJI6). Core process for PIGO.
+    action: ACCEPT
+    reason: Correct core biological process; concordant with experimental (IMP), automated
+      (IEA) and phylogenetic (IBA) annotations to the same term.
+    supported_by:
+    - reference_id: file:human/PIGO/PIGO-uniprot.txt
+      supporting_text: participates in the tenth step of the glycosylphosphatidylinositol-
+core_functions:
+- description: Catalytic subunit of GPI ethanolamine phosphate transferase III (GPI-ET-III);
+    transfers the bridging ethanolamine phosphate from phosphatidylethanolamine onto
+    the third mannose of the GPI intermediate (the protein-attachment EtNP), acting
+    with the accessory subunit PIGF.
+  molecular_function:
+    id: GO:0051377
+    label: mannose-ethanolamine phosphotransferase activity
+  directly_involved_in:
+  - id: GO:0006506
+    label: GPI anchor biosynthetic process
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: PMID:32156170
+    supporting_text: Two EtNPs are sequentially transferred to the 6-positions of Man3
+      and then Man2 by PIGO
+  - reference_id: file:human/PIGO/PIGO-uniprot.txt
+    supporting_text: transfers an ethanolamine phosphate (EtNP) from a
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Proteomics MS identification of PIGO in an NK-cell membrane fraction;
+      supports only generic membrane localization, not a specific function.
+- id: PMID:24049131
+  title: Vitamin B6-responsive epilepsy due to inherited GPI deficiency.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Reports a PIGO (R119W) patient with inherited GPI deficiency and
+      characterizes decreased EtNP-transferase activity; abstract-only in cache but
+      UniProt cites it for FUNCTION/CATALYTIC ACTIVITY and the R119W variant effect.
+- id: PMID:24417746
+  title: PIGO mutations in intractable epilepsy and severe developmental delay with
+    mild elevation of alkaline phosphatase levels.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Compound-heterozygous PIGO patients (T130N/Q430*) with decreased
+      GPI-AP surface expression; UniProt attributes the T130N activity decrease to
+      this paper.
+- id: PMID:28337824
+  title: Phenotype-genotype correlations of PIGO deficiency with variable phenotypes
+    from infantile lethality to mild learning difficulties.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Functional analysis of multiple PIGO variants in a PIGO-deficient
+      cell line; establishes decreased EtNP-transferase activity and links to GPI-AP
+      deficiency.
+- id: PMID:32156170
+  title: Biosynthesis and biology of mammalian GPI-anchored proteins.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Authoritative review; Table 2 lists PIGO at step 10 as GPI-ETIII
+      catalytic, PIGF as regulatory; describes EtNP transfer to Man3 and ER assembly
+      site.
+- id: file:human/PIGO/PIGO-uniprot.txt
+  title: UniProtKB entry Q8TEQ8 (PIGO_HUMAN), GPI ethanolamine phosphate transferase
+    3, catalytic subunit
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Source of function, catalytic activity, pathway, subunit (PIGF),
+      subcellular location, and variant functional data used throughout this review.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/modules/gpi_anchor_ethanolamine_phosphate.html
+++ b/pages/modules/gpi_anchor_ethanolamine_phosphate.html
@@ -1,0 +1,899 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GPI anchor biosynthesis III — ethanolamine-phosphate additions; PIGN/PIGG/PIGF/PIGO - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.scope {
+            background: #eef2f7;
+            border-color: #cbd5e1;
+            color: #334155;
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / GPI anchor biosynthesis III — ethanolamine-phosphate additions; PIGN/PIGG/PIGF/PIGO
+    </nav>
+
+    <header class="header">
+        <h1>GPI anchor biosynthesis III — ethanolamine-phosphate additions; PIGN/PIGG/PIGF/PIGO</h1>            <p class="description">As the trimannosyl core of the glycosylphosphatidylinositol (GPI) anchor is built, three ethanolamine-phosphate (EtNP) groups are transferred from phosphatidylethanolamine onto the mannoses by three ER-membrane EtNP transferases. PIGN (GPI-ET-I) adds EtNP to the first mannose; PIGG (GPI-ET-II), together with its accessory subunit PIGF, adds EtNP to the second mannose (a side-branch EtNP removed after the anchor is attached to protein); and PIGO (GPI-ET-III), also partnered by PIGF, adds the bridging EtNP to the third mannose — the ethanolamine-phosphate whose amino group forms the amide bond to the protein C-terminus at the transamidation step. PIGF is a non-catalytic accessory subunit shared by PIGO and PIGG, required to stabilise both. Defects cause GPI-deficiency disease: PIGN (multiple congenital anomalies-hypotonia-seizures syndrome 1, MCAHS1), PIGO (hyperphosphatasia with mental retardation syndrome 2, HPMRS2), PIGG (an intellectual-disability/seizure GPIBD) and PIGF (inherited GPI deficiency).</p>        <div class="meta-row"><span class="pill">MODULE:gpi_anchor_ethanolamine_phosphate</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/gpi_anchor_ethanolamine_phosphate.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a><div><strong>GPI anchor biosynthetic process</strong></div><div>The module is grounded in GPI anchor biosynthetic process (GO:0006506); it covers the three ethanolamine-phosphate transfers onto the GPI mannoses.</div></div>                <div class="evidence-card small"><span class="source-id">Reactome:R-HSA-162710</span><div><strong>Synthesis of glycosylphosphatidylinositol (GPI)</strong></div><div>Step order and intermediates follow the human Reactome &#34;Synthesis of glycosylphosphatidylinositol (GPI)&#34; sub-pathway (reactions R-HSA-162798 PIGN, R-HSA-162742 PIGG).</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGN/PIGN-ai-review.yaml</span><div><strong>PIGN gene review (human)</strong></div><div>The first-mannose EtNP transfer (UniProtKB:O95427, GO:0051377) matches the completed human PIGN review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGG/PIGG-ai-review.yaml</span><div><strong>PIGG gene review (human)</strong></div><div>The second-mannose EtNP transfer (UniProtKB:Q5H8A4, GO:0051377) matches the completed human PIGG review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGF/PIGF-ai-review.yaml</span><div><strong>PIGF gene review (human)</strong></div><div>The non-catalytic PIGO/PIGG accessory-subunit role (UniProtKB:Q07326) matches the completed human PIGF review.</div></div>                <div class="evidence-card small"><span class="source-id">file:human/PIGO/PIGO-ai-review.yaml</span><div><strong>PIGO gene review (human)</strong></div><div>The bridging third-mannose EtNP transfer (UniProtKB:Q8TEQ8, GO:0051377) matches the completed human PIGO review.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">4</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">5</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Connections</span></div>
+    </section>    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>                    <div><span class="qc-headline">100.0%</span>
+                        <span class="muted small">recommended fields populated</span></div>                        <p class="muted small">All recommended fields populated.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>MODULE:gpi_anchor_ethanolamine_phosphate</code> deep-research report alongside the module YAML.</p>            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>            </div>
+
+            <div class="qc-card">
+                <h3>Template conformance</h3>                    <p><span class="ok">&#10003;</span> <span class="small">every declared <code>conforms_to</code> bundle matches its template motif.</span></p>            </div>
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">(4/4 grounded genes reviewed)</span>
+                </h3>                    <p class="small muted">
+                        4 complete review(s) &middot;
+                        0 with deep research &middot;
+                        0 missing review &middot;
+                        4 reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>                                <tr>
+                                    <td>PIGF
+                                        <span class="muted term-id">Q07326</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGG
+                                        <span class="muted term-id">Q5H8A4</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGN
+                                        <span class="muted term-id">O95427</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                                <tr>
+                                    <td>PIGO
+                                        <span class="muted term-id">Q8TEQ8</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="ok">&#10003;</span></td>
+                                    <td class="center"><span class="warn">&#10007;</span></td>
+                                </tr>                        </tbody>
+                    </table>            </div>
+        </div>
+    </section>
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-gpi_anchor_ethanolamine_phosphate">GPI anchor ethanolamine-phosphate additions</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">gpi_anchor_ethanolamine_phosphate</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. EtNP on the first mannose</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pign_step">ethanolamine-phosphate added to mannose-I</a><span class="pill type">Reaction</span><span class="tree-id">pign_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pign_activity">PIGN: GPI ethanolamine phosphate transferase 1</a>
+                                <span class="tree-id">Family: GPI ethanolamine-phosphate transferase family (PIGN)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. EtNP on the second mannose (side-branch)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pigg_step">ethanolamine-phosphate added to mannose-II</a><span class="pill type">Protein Complex</span><span class="tree-id">pigg_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigg_activity">PIGG: GPI ethanolamine phosphate transferase 2 (catalytic)</a>
+                                <span class="tree-id">Family: GPI ethanolamine-phosphate transferase family (PIGG)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigf_activity_g">PIGF: accessory subunit (with PIGG)</a>
+                                <span class="tree-id">Family: GPI biosynthesis protein Pig-F family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. bridging EtNP on the third mannose (protein-attachment site)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pigo_step">bridging ethanolamine-phosphate added to mannose-III</a><span class="pill type">Protein Complex</span><span class="tree-id">pigo_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigo_activity">PIGO: GPI ethanolamine phosphate transferase 3 (catalytic)</a>
+                                <span class="tree-id">Family: GPI ethanolamine-phosphate transferase family (PIGO)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pigf_activity_o">PIGF: accessory subunit (with PIGO)</a>
+                                <span class="tree-id">Family: GPI biosynthesis protein Pig-F family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-gpi_anchor_ethanolamine_phosphate">
+        <div class="node-heading">
+            <span class="node-title">GPI anchor ethanolamine-phosphate additions</span><span class="pill type">Metabolic Pathway</span><span class="pill">gpi_anchor_ethanolamine_phosphate</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>
+
+            </div>
+        <p class="muted small">GPI ethanolamine-phosphate-addition segment, grounded to the human enzymes PIGN (UniProtKB:O95427, GO:0051377), PIGG (Q5H8A4, GO:0051377) and PIGO (Q8TEQ8, GO:0051377), all mannose-ethanolamine phosphotransferases, plus the shared non-catalytic accessory subunit PIGF (Q07326; no PANTHER family — the InterPro family IPR009580 GPI-biosynthesis-protein Pig-F is used as its family selector). GO molecular-function/BP/location terms were taken from the completed human gene reviews and verified against the local go.db; Reactome reaction ids/titles (R-HSA-162798 PIGN, R-HSA-162742 PIGG; PIGO has no cached WT reaction so its node is grounded on its review and the umbrella pathway R-HSA-162710) were verified against the local reactome cache. Each step uses a family selector (PANTHER for PIGN/PIGG/PIGO, InterPro for PIGF); the PIGG and PIGO steps are PROTEIN_COMPLEX nodes pairing each catalytic transferase with the shared PIGF accessory subunit (modelled by its BP role, as it has no catalytic MF). All three transferases use phosphatidylethanolamine as the EtNP donor. This segment interleaves with the mannosylation module: PIGN acts on mannose-I (between PIGM and PIGV), PIGG on mannose-II (after PIGV), and PIGO adds the bridging EtNP on mannose-III (after PIGB) — the last modification before the completed GPI is transferred to protein by the GPI transamidase (PIGK/PIGS/PIGT/PIGU/GPAA1; separate module). Disorders: MCAHS1 (PIGN), HPMRS2 (PIGO), and GPIBD intellectual disability/seizures (PIGG, PIGF).</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pign_step">pign_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pigg_step">pigg_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">The GPI intermediate EtNP-modified on mannose-I is further EtNP-modified on mannose-II by PIGG/PIGF.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-pigg_step">pigg_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-pigo_step">pigo_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">The GPI intermediate is completed by the bridging EtNP on mannose-III added by PIGO/PIGF.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: EtNP on the first mannose</div>
+                <section class="node-detail depth-1" id="node-pign_step">
+        <div class="node-heading">
+            <span class="node-title">ethanolamine-phosphate added to mannose-I</span><span class="pill type">Reaction</span><span class="pill">pign_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pign_activity">
+        <div class="annoton-title">PIGN: GPI ethanolamine phosphate transferase 1</div>
+        <div class="small muted">pign_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI ethanolamine-phosphate transferase family (PIGN)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI ethanolamine-phosphate transferase family (PIGN)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR12250" target="_blank" rel="noopener">PANTHER:PTHR12250</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGN (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/O95427/entry" target="_blank" rel="noopener">UniProtKB:O95427</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>mannose-ethanolamine phosphotransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0051377" target="_blank" rel="noopener">GO:0051377</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>Man1-GlcN-(acyl)PI GPI intermediate</span></span>                            <span class="descriptor">
+            <span>phosphatidylethanolamine</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>EtNP-Man1 GPI intermediate</span></span>                            <span class="descriptor">
+            <span>diacylglycerol</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Adds EtNP to mannose-I; deficiency = MCAHS1.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: EtNP on the second mannose (side-branch)</div>
+                <section class="node-detail depth-1" id="node-pigg_step">
+        <div class="node-heading">
+            <span class="node-title">ethanolamine-phosphate added to mannose-II</span><span class="pill type">Protein Complex</span><span class="pill">pigg_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pigg_activity">
+        <div class="annoton-title">PIGG: GPI ethanolamine phosphate transferase 2 (catalytic)</div>
+        <div class="small muted">pigg_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI ethanolamine-phosphate transferase family (PIGG)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI ethanolamine-phosphate transferase family (PIGG)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR23072" target="_blank" rel="noopener">PANTHER:PTHR23072</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGG (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q5H8A4/entry" target="_blank" rel="noopener">UniProtKB:Q5H8A4</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>mannose-ethanolamine phosphotransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0051377" target="_blank" rel="noopener">GO:0051377</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>Man2 GPI intermediate</span></span>                            <span class="descriptor">
+            <span>phosphatidylethanolamine</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>EtNP-Man2 GPI intermediate</span></span>                            <span class="descriptor">
+            <span>diacylglycerol</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Catalytic EtNP transferase for mannose-II.</p></article>                    <article class="annoton-card" id="annoton-pigf_activity_g">
+        <div class="annoton-title">PIGF: accessory subunit (with PIGG)</div>
+        <div class="small muted">pigf_activity_g</div>            <div class="small"><strong>Participant:</strong> Family: GPI biosynthesis protein Pig-F family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI biosynthesis protein Pig-F family</strong></span><span class="term-id">InterPro:IPR009580</span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGF (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q07326/entry" target="_blank" rel="noopener">UniProtKB:Q07326</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Non-catalytic accessory subunit that stabilises PIGG.</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:human/PIGF/PIGF-ai-review.yaml</span><div>non-catalytic accessory subunit required to stabilise the EtNP transferases PIGG and PIGO</div></div>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: bridging EtNP on the third mannose (protein-attachment site)</div>
+                <section class="node-detail depth-1" id="node-pigo_step">
+        <div class="node-heading">
+            <span class="node-title">bridging ethanolamine-phosphate added to mannose-III</span><span class="pill type">Protein Complex</span><span class="pill">pigo_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pigo_activity">
+        <div class="annoton-title">PIGO: GPI ethanolamine phosphate transferase 3 (catalytic)</div>
+        <div class="small muted">pigo_activity</div>            <div class="small"><strong>Participant:</strong> Family: GPI ethanolamine-phosphate transferase family (PIGO)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI ethanolamine-phosphate transferase family (PIGO)</strong></span><a class="term-id" href="https://www.pantherdb.org/panther/family.do?clsAccession=PTHR23071" target="_blank" rel="noopener">PANTHER:PTHR23071</a>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGO (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8TEQ8/entry" target="_blank" rel="noopener">UniProtKB:Q8TEQ8</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>mannose-ethanolamine phosphotransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0051377" target="_blank" rel="noopener">GO:0051377</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>Man3 GPI intermediate</span></span>                            <span class="descriptor">
+            <span>phosphatidylethanolamine</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>EtNP-Man3 (bridging EtNP) GPI intermediate</span></span>                            <span class="descriptor">
+            <span>diacylglycerol</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Catalytic EtNP transferase for the third mannose; supplies the bridging EtNP for protein attachment. Deficiency = HPMRS2.</p></article>                    <article class="annoton-card" id="annoton-pigf_activity_o">
+        <div class="annoton-title">PIGF: accessory subunit (with PIGO)</div>
+        <div class="small muted">pigf_activity_o</div>            <div class="small"><strong>Participant:</strong> Family: GPI biosynthesis protein Pig-F family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>GPI biosynthesis protein Pig-F family</strong></span><span class="term-id">InterPro:IPR009580</span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>PIGF (human)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q07326/entry" target="_blank" rel="noopener">UniProtKB:Q07326</a></span>                    </div></div>
+                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>GPI anchor biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0006506" target="_blank" rel="noopener">GO:0006506</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>endoplasmic reticulum membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005789" target="_blank" rel="noopener">GO:0005789</a></span>        </div>            <p class="role-description">Non-catalytic accessory subunit that stabilises PIGO.</p><div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:human/PIGF/PIGF-ai-review.yaml</span><div>non-catalytic accessory subunit required to stabilise the EtNP transferases PIGO and PIGG</div></div>        </div></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -285,7 +285,7 @@
 
     <section class="toolbar">
         <input class="search" type="search" placeholder="Filter modules" data-module-search>
-        <div class="count"><span data-visible-count>142</span> / 142 modules</div>
+        <div class="count"><span data-visible-count>143</span> / 143 modules</div>
     </section>
 
     <div class="table-wrap">
@@ -1508,6 +1508,29 @@ Design intent: the module is organized as a driver layer (PUFA-phospholipid supp
                         0
                     </td>
                     <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/gpi_anchor_core_glycan_assembly.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td class="module-cell" data-sort-value="GPI anchor biosynthesis III — ethanolamine-phosphate additions; PIGN/PIGG/PIGF/PIGO">
+                        <a class="module-name" href="gpi_anchor_ethanolamine_phosphate.html">GPI anchor biosynthesis III — ethanolamine-phosphate additions; PIGN/PIGG/PIGF/PIGO</a><span class="module-id">MODULE:gpi_anchor_ethanolamine_phosphate</span>                        <span class="module-desc">As the trimannosyl core of the glycosylphosphatidylinositol (GPI) anchor is built, three ethanolamine-phosphate (EtNP) groups are transferred from...</span>                        <details class="module-desc-more">
+                            <summary><span class="more-label">[more...]</span><span class="less-label">[less]</span></summary>
+                            <span class="module-desc-full">As the trimannosyl core of the glycosylphosphatidylinositol (GPI) anchor is built, three ethanolamine-phosphate (EtNP) groups are transferred from phosphatidylethanolamine onto the mannoses by three ER-membrane EtNP transferases. PIGN (GPI-ET-I) adds EtNP to the first mannose; PIGG (GPI-ET-II), together with its accessory subunit PIGF, adds EtNP to the second mannose (a side-branch EtNP removed after the anchor is attached to protein); and PIGO (GPI-ET-III), also partnered by PIGF, adds the bridging EtNP to the third mannose — the ethanolamine-phosphate whose amino group forms the amide bond to the protein C-terminus at the transamidation step. PIGF is a non-catalytic accessory subunit shared by PIGO and PIGG, required to stabilise both. Defects cause GPI-deficiency disease: PIGN (multiple congenital anomalies-hypotonia-seizures syndrome 1, MCAHS1), PIGO (hyperphosphatasia with mental retardation syndrome 2, HPMRS2), PIGG (an intellectual-disability/seizure GPIBD) and PIGF (inherited GPI deficiency).</span>
+                        </details>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="">                    </td>
+                    <td class="num" data-sort-value="0">0</td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">GPI anchor biosynthetic process</span>                        </div>                    </td>
+                    <td class="num">4</td>
+                    <td class="num">5</td>
+                    <td class="num">3</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">2</td>                    <td class="num" data-sort-value="4">
+                        4/4
+                    </td>
+                    <td class="num" data-sort-value="0">
+                        0
+                    </td>
+                    <td data-sort-value="no">&#10007;                    </td>                    <td><span class="source">modules/gpi_anchor_ethanolamine_phosphate.yaml</span></td>
                 </tr>                <tr data-module-row>
                     <td class="module-cell" data-sort-value="Galactose catabolism (Leloir pathway)">
                         <a class="module-name" href="galactose_leloir_pathway.html">Galactose catabolism (Leloir pathway)</a><span class="module-id">MODULE:galactose_leloir_pathway</span>                        <span class="module-desc">The Leloir pathway, the main route by which dietary D-galactose (chiefly from the milk sugar lactose) is converted to glucose-1-phosphate and...</span>                        <details class="module-desc-more">


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 3242 |
| Gene review HTML pages | 3242 |
| Project pages | 1111 |
| Module pages | 144 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
